### PR TITLE
Add continueUserActivity call to mParticle sharedInstance

### DIFF
--- a/mParticle-Apple-SDK/mParticle.h
+++ b/mParticle-Apple-SDK/mParticle.h
@@ -307,6 +307,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)openURL:(NSURL *)url options:(nullable NSDictionary<NSString *, id> *)options;
 
+/**
+ Informs the mParticle SDK the app has been asked to open to continue an NSUserActivity.
+ This method should be called only if proxiedAppDelegate is disabled. This method is only available for iOS 9 and above.
+ @param userActivity The NSUserActivity that caused the app to be opened
+ @param restorationHandler A block to execute if your app creates objects to perform the task.
+ @see proxiedAppDelegate
+ */
+- (BOOL)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler;
+
 #pragma mark - Basic Tracking
 /**
  Contains a collection with all active timed events (timed events that had begun, but not yet ended). You should not keep a 

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -536,6 +536,14 @@ NSString *const kMPStateKey = @"state";
     [[MPAppNotificationHandler sharedInstance] openURL:url options:options];
 }
 
+- (BOOL)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler {
+    if (self.proxiedAppDelegate) {
+        return NO;
+    }
+
+    return [[MPAppNotificationHandler sharedInstance] continueUserActivity:userActivity restorationHandler:restorationHandler];
+}
+
 #pragma mark Basic tracking
 - (nullable NSSet *)activeTimedEvents {
     NSAssert(self.backendController.initializationStatus != MPInitializationStatusNotStarted, @"\n****\n  Cannot fetch timed events prior to starting the mParticle SDK.\n****\n");


### PR DESCRIPTION
We're integrating the Branch SDK with a non-proxied app delegate so need to be able to call continueUserActivity:

```
[[MParticle sharedInstance] continueUserActivity:userActivity restorationHandler:restorationHandler];
```