### PR TITLE
Address sainitizer fix

### DIFF
--- a/mParticle-Apple-SDK/Data Model/MPConsumerInfo.mm
+++ b/mParticle-Apple-SDK/Data Model/MPConsumerInfo.mm
@@ -196,11 +196,8 @@ NSString *const kMPCKExpiration = @"e";
 }
 
 - (id)init {
-    // Serial since read/write lock not appropriate given how mpId is created.
-    dispatch_queue_t newQueue = dispatch_queue_create("com.mParticle.MPCookie.queue", DISPATCH_QUEUE_SERIAL);
-    
     self = [super init];
-    if (self && newQueue) {
+    if (self) {
         _consumerInfoId = 0;
     } else {
         self = nil;
@@ -227,8 +224,6 @@ NSString *const kMPCKExpiration = @"e";
 }
 
 - (id)initWithCoder:(NSCoder *)coder {
-    // Serial since read/write lock not appropriate given how mpId is created.
-    dispatch_queue_t newQueue = dispatch_queue_create("com.mParticle.MPCookie.queue", DISPATCH_QUEUE_SERIAL);
     self = [super init];
     if (self) {
         _cookies = [coder decodeObjectForKey:@"cookies"];


### PR DESCRIPTION
This fixes a simultaneous read and write of the _mpId variable by different threads detected by Xcode 8's AddressSanitizer.  It protects the data by using a serial queue.