### PR TITLE
Remove NSDictionary generic specifications for checkForDeferredDeepLinkWithCompletionHandler callback

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Kits/MPKitProtocol.h
@@ -60,7 +60,7 @@
 - (void)deinit;
 
 #pragma mark Application
-- (nonnull MPKitExecStatus *)checkForDeferredDeepLinkWithCompletionHandler:(void(^ _Nonnull)(NSDictionary<NSString *, NSString *> * _Nullable linkInfo, NSError * _Nullable error))completionHandler;
+- (nonnull MPKitExecStatus *)checkForDeferredDeepLinkWithCompletionHandler:(void(^ _Nonnull)(NSDictionary * _Nullable linkInfo, NSError * _Nullable error))completionHandler;
 - (nonnull MPKitExecStatus *)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler;
 - (nonnull MPKitExecStatus *)didUpdateUserActivity:(nonnull NSUserActivity *)userActivity;
 - (nonnull MPKitExecStatus *)didBecomeActive;

--- a/mParticle-Apple-SDK/mParticle.h
+++ b/mParticle-Apple-SDK/mParticle.h
@@ -409,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
  Checks for deferred deep link information.
  @param completionHandler A block to be called when deep link checking is finished.
  */
-- (void)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary<NSString *, NSString *> * _Nullable linkInfo, NSError * _Nullable error))completionHandler;
+- (void)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary * _Nullable linkInfo, NSError * _Nullable error))completionHandler;
 
 #pragma mark - Error, Exception, and Crash Handling
 /**

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -716,7 +716,7 @@ NSString *const kMPStateKey = @"state";
 }
 
 #pragma mark Deep linking
-- (void)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary<NSString *, NSString *> * linkInfo, NSError *error))completionHandler {
+- (void)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary * linkInfo, NSError *error))completionHandler {
     [[MPKitContainer sharedInstance] forwardSDKCall:@selector(checkForDeferredDeepLinkWithCompletionHandler:) kitHandler:^(id<MPKitProtocol> _Nonnull kit, MPKitExecStatus * __autoreleasing  _Nonnull * _Nonnull execStatus) {
         [kit checkForDeferredDeepLinkWithCompletionHandler:completionHandler];
     }];


### PR DESCRIPTION
(See http://useyourloaf.com/blog/using-objective-c-lightweight-generics/ on Objective-C generics)

Because the callback for `checkForDeferredDeepLinkWithCompletionHandler` traces its NSDictionary all the way back to `[Branch getLatestReferringParams]`, which doesn’t specify generics for NSDictionary, there is no guarantee that the keys and values will be of type `<NSString *, NSString *>`. This proves to be an issue when bridging to Swift, as there are times when `[Branch getLatestreferringParams]` _can_ return a dictionary of type `[NSObject : AnyObject]`, which causes a crash at runtime because Swift is expecting `[String : String]`, but is getting `[String : NSNumber]`.

Therefore, the callback can only be as specific as its upstream dependencies, which is to say, not at all. Thus, removing the <NSString *, NSString *> generic specification on the callback.

Removing the specification results in bridging to `[NSObject : AnyObject]` when consumed in Swift, which requires the consumer to cast from `AnyObject` to the expected type (`String` in this case) when pulling values out of the dictionary.

**This PR has implications for the mparticle-integrations/mparticle-apple-integration-branchmetrics repo implementation, for which there is a PR already created [here](https://github.com/mparticle-integrations/mparticle-apple-integration-branchmetrics/pull/4).**

Here is how I’ve implemented the contract change in our code:
```
MParticle.sharedInstance().checkForDeferredDeepLinkWithCompletionHandler { linkInfo, error in
    if let canonicalURL = linkInfo?["$canonical_url"] as? String, let url = NSURL(string: canonicalURL) {
        navigateToLink(url)
    }
}
```