### PR TITLE
Fix environment bug

### DIFF
--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -419,7 +419,9 @@ NSString *const kMPStateKey = @"state";
             registerForSilentNotifications = [configRegisterForSilentNotifications boolValue];
         }
     }
-    
+
+    [MPStateMachine setEnvironment:environment];
+
     [self.backendController startWithKey:apiKey
                                   secret:secret
                                 firstRun:firstRun
@@ -437,9 +439,7 @@ NSString *const kMPStateKey = @"state";
                                userDefaults[kMParticleFirstRun] = @NO;
                                [userDefaults synchronize];
                            }
-                           
-                           [MPStateMachine setEnvironment:environment];
-                           
+
                            strongSelf->_optOut = [MPStateMachine sharedInstance].optOut;
                            strongSelf->privateOptOut = @(strongSelf->_optOut);
                            


### PR DESCRIPTION
Set `MPStateMachine` environment before using `MPBackendController` because `MPBackendController` reads environment and adds it to config request header.

I ran into an issue when testing Branch deferred deep link. I was explicitly specifying production environment when starting mParticle but mParticle was sometimes using the Branch development key and sometimes using the Branch production key. Digging deeper I found that when mParticle retrieved the config at startup the config that was returned sometimes had Branch development key and other times Branch production key. This was caused by the environment specified in the request header. The request builder gets the environment from `MPStateMachine` but the environment is not set according to mParticle start parameters until after the config request completes. So it seems `MPStateMachine` environment must be set prior to using `MPBackendController` which makes the config request.

To test deferred deep link I delete my app, go to Safari and tap a deep link which would take me to the App Store, and then load my app from Xcode. The Branch development key was always used the first time the app was loaded from Xcode. And then the second or third time I would load the app it would use the Branch production key and then I would get the deferred deep link. Not exactly sure what caused the inconsistency. After making the changes in this PR I always got the deferred deep link the first time I loaded the app.