### PR TITLE
copy currency property in MPCommerceEvent

### DIFF
--- a/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
@@ -356,6 +356,7 @@ static NSArray *actionNames;
         copyObject->type = type;
         copyObject->commerceEventKind = commerceEventKind;
         copyObject->_timestamp = [_timestamp copy];
+        copyObject->_currency = [_currency copy];
     }
     
     return copyObject;


### PR DESCRIPTION
Please, find more details in the issue.
https://github.com/mParticle/mparticle-apple-sdk/issues/56

MPCommerce event losing a currency property after being copied.