### PR TITLE
Forward userAttribute registration instead of removing it.

### DIFF
--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -169,11 +169,11 @@
                                                                                     [kit setUserAttribute:key value:value];
                                                                                 }];
                                        } else {
-                                           [[MPKitContainer sharedInstance] forwardSDKCall:@selector(removeUserAttribute:)
+                                           [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserAttribute:value:)
                                                                           userAttributeKey:key
                                                                                      value:value
                                                                                 kitHandler:^(id<MPKitProtocol> kit) {
-                                                                                    [kit removeUserAttribute:key];
+                                                                                    [kit setUserAttribute:key value:value];
                                                                                 }];
                                        }
                                    } else {


### PR DESCRIPTION
## Summary
When registering user attributes without a value, the attribute is not forwarded to any kits. Instead `removeUserAttribute` is called. I've updated to call `setUserAttribute:value:`
