### PR TITLE
Add imports for category definitions

### DIFF
--- a/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent+Dictionary.h
+++ b/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent+Dictionary.h
@@ -1,4 +1,5 @@
 #import "MPEnums.h"
+#import "MPCommerceEvent.h"
 #import "MPCommerceEventInstruction.h"
 
 typedef NS_ENUM(NSInteger, MPCommerceEventKind) {

--- a/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes+Dictionary.h
+++ b/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes+Dictionary.h
@@ -1,3 +1,5 @@
+#import "MPTransactionAttributes+Dictionary.h"
+
 @interface MPTransactionAttributes(Dictionary)
 
 - (NSDictionary *)dictionaryRepresentation;

--- a/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes+Dictionary.h
+++ b/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes+Dictionary.h
@@ -1,4 +1,4 @@
-#import "MPTransactionAttributes+Dictionary.h"
+#import "MPTransactionAttributes.h"
 
 @interface MPTransactionAttributes(Dictionary)
 


### PR DESCRIPTION
## Summary
There are two files that are missing the direct import for the category definitions that they create. This allows those files to be built if the top-level header is not directly added.

## Testing Plan
Built into the Airbnb Alpha app.

## Master Issue
No formal issue created. Discussion on mParticle Slack channel only.
