### PR TITLE
Change imports to modular

### DIFF
--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -14,7 +14,7 @@
 #import "mParticle.h"
 #import "MPUploadBuilder.h"
 #import "MPDatabaseMigrationController.h"
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import "MPIUserDefaults.h"
 #import "MPBaseTestCase.h"
 #import "MPStateMachine.h"

--- a/mParticle-Apple-SDK/Persistence/MPDatabaseMigrationController.m
+++ b/mParticle-Apple-SDK/Persistence/MPDatabaseMigrationController.m
@@ -1,5 +1,5 @@
 #import "MPDatabaseMigrationController.h"
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import "MPSession.h"
 #import "MPIUserDefaults.h"
 #import "mParticle.h"

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -20,7 +20,7 @@
 #import "mParticle.h"
 #import "MPIConstants.h"
 #import "MPConsentSerialization.h"
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import "MPListenerProtocol.h"
 
 using namespace std;


### PR DESCRIPTION
## Summary
Using the the quotations for imports conflicts with other sqlite pods that may be included from other dependencies causing a 

sqlite.h file not found

## Testing Plan
Build and run and observe a successful build result

## Master Issue
