### PR TITLE
Annotate `MParticleOptions` and `MPIdentityApiRequest` factory initializers with `instancetype`

### DIFF
--- a/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
+++ b/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
@@ -14,8 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MPIdentityApiRequest : NSObject
 
-+ (MPIdentityApiRequest *)requestWithEmptyUser;
-+ (MPIdentityApiRequest *)requestWithUser:(MParticleUser *) user;
++ (instancetype)requestWithEmptyUser;
++ (instancetype)requestWithUser:(MParticleUser *) user;
 
 - (void)setIdentity:(nullable NSString *)identityString identityType:(MPIdentity)identityType;
 

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -166,7 +166,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  
  These values can be retrieved from your App's dashboard within the mParticle platform.
  */
-+ (MParticleOptions*)optionsWithKey:(NSString *)apiKey secret:(NSString *)secret;
++ (instancetype)optionsWithKey:(NSString *)apiKey secret:(NSString *)secret;
 
 /*
  App key. mParticle uses this to attribute incoming data to your app's acccount/workspace/platform.


### PR DESCRIPTION
## Summary
When mparticle-apple-sdk is pulled in via Cocoapods as a static library w/ `use_modular_headers!` set, the factory initializers for `MParticleOptions` and `MPIdentityApiRequest` (and likely others, though these are the two that affect us) don't get bridged as expected, resulting in the following error:

<img width="1002" alt="Screen Shot 2021-05-07 at 9 34 14 PM" src="https://user-images.githubusercontent.com/11869755/117527400-af7fe000-af80-11eb-9d11-722c52d5075c.png">

This change replaces the return types of these two initializers with `instancetype`, which corrects the bridging behavior.

## Testing Plan
Tested via compiling with our app.  This is generally a compile-time enhancement, and shouldn't have any run-time differences.