### PR TITLE
Add missing DEFINE_MODULE

### DIFF
--- a/mParticle-Apple-SDK.podspec
+++ b/mParticle-Apple-SDK.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
     s.requires_arc      = true
     s.default_subspec   = 'mParticle'
     s.module_name       = "mParticle_Apple_SDK"
+    s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
     pch_mParticle       = <<-EOS
                           #ifndef TARGET_OS_IOS


### PR DESCRIPTION
## Summary
For this SDK to be specified as a dependency in another podspec, `s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }` must be added the podspec so integrating applications do not have to respecify the dependency using `modular_header`

## Testing Plan
Tested using a private podspec in our internal setup

