### PR TITLE
Update Markdown Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ You can leave the version settings as default and click Next one more time to co
 
 Several integrations require additional client-side add-on libraries called "kits." Some kits embed other SDKs, others just contain a bit of additional functionality. Kits are designed to feel just like server-side integrations; you enable, disable, filter, sample, and otherwise tweak kits completely from the mParticle platform UI. The Core SDK will detect kits at runtime, but you need to add them as dependencies to your app.
 
-Kit | CocoaPods | Carthage | Swift Package Manager
-----|:---------:|:-------:
+Kit | CocoaPods | Carthage | Swift Package Manager |
+----|:---------:|:-------:|:-------:|
 [Adjust](https://github.com/mparticle-integrations/mparticle-apple-integration-adjust)                                            | ✓  | ✓  | ✓  
 [Appboy](https://github.com/mparticle-integrations/mparticle-apple-integration-appboy)                                            | ✓  | ✓  | ✓  
 [Adobe](https://github.com/mparticle-integrations/mparticle-apple-integration-adobe)                                              | ✓  | ✓  |    


### PR DESCRIPTION
Markdown table format is now OK

## Summary
The table was broken, because it has some markdown mistakes.

## Before
![image](https://user-images.githubusercontent.com/5422102/124898922-ea81ac80-dfdf-11eb-8847-409e5bda5598.png)

## After
![image](https://user-images.githubusercontent.com/5422102/124899289-41878180-dfe0-11eb-8a1a-2075faac6c13.png)

