### PR TITLE
Add fix for xcode 12 and swift 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,9 +2,15 @@
 
 import PackageDescription
 
+#if swift(>=5.3)
+let ios = SupportedPlatform.iOS(.v9)
+#else
+let ios = SupportedPlatform.iOS(.v8)
+#endif
+
 let package = Package(
     name: "mParticle-Apple-SDK",
-    platforms: [ .iOS(.v8), .tvOS(.v9) ],
+    platforms: [ ios, .tvOS(.v9) ],
     products: [
         .library(
             name: "mParticle-Apple-SDK",


### PR DESCRIPTION
## Summary
Swift 5.3 does not support iOS 8 anymore and therefore Xcode 12 (using Swift 5.3) will print a 'IPHONEOS_DEPLOYMENT_TARGET' warning. This change correctly targets the right iOS version for Swift 5.3.

## Testing Plan
Package correctly parses and targets the right iOS version.
