### PR TITLE
fix: Expose Session Start Time

### DIFF
--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -57,6 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) NSString *UUID;
 
+/**
+ The session start time.
+ */
+@property (nonatomic, readonly) NSNumber *startTime;
+
 @end
 
 /**

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -52,7 +52,10 @@ static NSArray *execStatusDescriptions;
 static BOOL appBackgrounded = NO;
  
 @interface MParticleSession ()
+
+@property (nonatomic, readwrite) NSNumber *startTime;
 - (instancetype)initWithUUID:(NSString *)uuid;
+
 @end
 
 @interface MParticle ()
@@ -1138,6 +1141,8 @@ static BOOL skipNextUpload = NO;
     
     MPSession *mpSession = [[MPSession alloc] init];
     mpSession.uuid = tempSession.UUID;
+    
+    tempSession.startTime = MPMilliseconds(mpSession.startTime);
     
     [self broadcastSessionDidBegin:mpSession];
     

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -104,6 +104,7 @@ NSString *const kMPStateKey = @"state";
 - (instancetype)initWithUUID:(NSString *)uuid;
 @property (nonatomic, readwrite) NSNumber *sessionID;
 @property (nonatomic, readwrite) NSString *UUID;
+@property (nonatomic, readwrite) NSNumber *startTime;
 
 @end
 
@@ -645,6 +646,7 @@ NSString *const kMPStateKey = @"state";
     
     if (sessionInternal) {
         session = [[MParticleSession alloc] initWithUUID:sessionInternal.uuid];
+        session.startTime = MPMilliseconds(sessionInternal.startTime);
     }
     
     return session;


### PR DESCRIPTION
On mParticle's Web and Android SDK's it's possible to retrieve the current sessions start time:

MParticle.getInstance()?.currentSession?.sessionStartTime
Web - mParticle.Store.sessionStartDate.getTime()

Currently on the iOS SDK MPSession is internal only while MParticleSession is what is provided to users (which doesn't expose the session start time property). 
