### PR TITLE
Fix: Correct IDFA Enrichment when Changed during Session

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.mm
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.mm
@@ -175,6 +175,23 @@ using namespace std;
         uploadDictionary[kMPDeviceInformationKey] = [device dictionaryRepresentationWithMpid:mpid];
     }
     
+    // Update the IDFA if it changed after the session was created/saved (the IDFA changed or the ATTStatus has been set to authorized)
+    NSNumber *authStatus = [MParticle sharedInstance].stateMachine.attAuthorizationStatus;
+    NSMutableArray *userIdentities = uploadDictionary[kMPUserIdentityArrayKey];
+    NSString *advertiserId;
+    for (NSMutableDictionary *userIdentityDictionary in userIdentities) {
+        NSNumber *identityTypeKey = userIdentityDictionary[kMPUserIdentityTypeKey];
+        if ([identityTypeKey isEqualToNumber:@(MPIdentityIOSAdvertiserId)]) {
+            advertiserId = userIdentityDictionary[kMPUserIdentityIdKey];
+        }
+    }
+
+    if (authStatus && advertiserId && authStatus.intValue == MPATTAuthorizationStatusAuthorized) {
+        NSMutableDictionary *deviceInfoDictCopy = [uploadDictionary[kMPDeviceInformationKey] mutableCopy];
+        deviceInfoDictCopy[kMPDeviceAdvertiserIdKey] = advertiserId;
+        uploadDictionary[kMPDeviceInformationKey] = [deviceInfoDictCopy copy];
+    }
+    
     MPConsumerInfo *consumerInfo = stateMachine.consumerInfo;
     
     NSDictionary *cookies = [consumerInfo cookiesDictionaryRepresentation];


### PR DESCRIPTION
## Summary
Basically the device Info that's used for the event batch comes from the MPSession saved to the local database. So that saved version of the deviceInfo wasn't getting updated until a new session is created (restart). ATT and IDFA were implemented before we began [caching app and device info](https://github.com/mParticle/mparticle-apple-sdk-internal/pull/17/files#diff-4166039127eb7c02c467286fe092e331049fc718b8770abc7ffcf78fe061b8d5R159) so it been broken in this way since that change.

## Testing Plan
Tested using sample App

## Master Issue
Closes https://go.mparticle.com/work/76333
