### PR TITLE
fix: custom mapping to transaction attributes not to be null-ed for e…

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1340,10 +1340,9 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     };
     
     // Block to project a product according to attribute projections
-    NSDictionary * (^projectProductWithAttributes)(MPProduct *, NSArray *) = ^(MPProduct *product, NSArray<MPAttributeProjection *> *attributeProjections) {
+    NSDictionary * (^projectProductWithAttributes)(MPProduct *, NSArray *, NSDictionary *) = ^(MPProduct *product, NSArray<MPAttributeProjection *> *attributeProjections, NSDictionary *projectedDictionary) {
         NSMutableDictionary *projectedProductDictionary = [[NSMutableDictionary alloc] init];
         NSDictionary *sourceDictionary;
-        NSDictionary *projectedDictionary;
         NSPredicate *predicate;
         NSArray<MPAttributeProjection *> *filteredAttributeProjections;
         
@@ -1377,7 +1376,7 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         }
         
         if (projectedProductDictionary.count == 0) {
-            return (NSDictionary *)nil;
+            return projectedDictionary;
         }
         
         return (NSDictionary *)projectedProductDictionary;
@@ -1454,7 +1453,7 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
                         
                         for (auto idx : productIndexes) {
                             MPProduct *product = products[idx];
-                            projectedDictionary = projectProductWithAttributes(product, attributeProjections);
+                            projectedDictionary = projectProductWithAttributes(product, attributeProjections, projectedDictionary);
                             
                             if (projectedDictionary) {
                                 if ((NSNull *)projectedDictionary != [NSNull null]) {


### PR DESCRIPTION
…com events

## Summary
M&S noticed that when they custom map the purchase to another eCom event (Checkout in their case) in their AppsFlyer connection config. The revenue that is mapped to the total amount is not being forwarded. After a thorough investigation, I was able to find the issue within our Apple SDK and not the AppsFlyer kit. When testing locally, I noticed that when a transaction attribute is mapped but no product attribute is mapped, it overrides the existing mapping to the transaction attribute (Revenue/Total Amount in this case) and replace it with a nil projectedDictionary and thus never be forwarded to AppsFlyer (or any integration kit that use the same settings with custom mapping). The fix provided here is instead of overriding the projectedDictionary to a nil one, it just returns it to itself with existing correctly mapped transaction attributes.

## Testing Plan
Tested with different scenarios locally and they all worked as expected:
  - Scenario 1: eCom event mapped with transaction attributes only and no product attributes mapped (client issue).
  - Scenario 2: eCom event mapped with both transaction and product attributes.
  - Scenario 3: eCom event mapped with product attributes only and no transaction attributes mapped.
