### PR TITLE
ci: fix building of *.framework artifacts for iOS

### DIFF
--- a/Scripts/carthage.sh
+++ b/Scripts/carthage.sh
@@ -6,13 +6,19 @@ set -euo pipefail
 xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
 trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
-# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# For Xcode 12/13 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
 
 CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
-echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+EXCLUDED_ARCHS_SIMULATOR="arm64 arm64e armv7 armv7s armv6 armv8"
 
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+# Xcode 12
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $EXCLUDED_ARCHS_SIMULATOR" >> $xcconfig
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = $EXCLUDED_ARCHS_SIMULATOR" >> $xcconfig
+# Xcode 13
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1300 = $EXCLUDED_ARCHS_SIMULATOR" >> $xcconfig
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1300__BUILD_$CURRENT_XCODE_VERSION = $EXCLUDED_ARCHS_SIMULATOR" >> $xcconfig
+
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"


### PR DESCRIPTION
## Summary
Since the Github runners switched to defaulting to Xcode 13, the *.framework builds for iOS stopped working (*.xcframework builds still worked).

Turns out it was a pretty simple change to our build script to work for Xcode 13 (previously was Xcode 12 only).

Merging this directly to main since it's CI that needs to run on next release.

## Testing Plan
Tested the build locally on my machine and it works correctly (also updated the latest release to include the iOS framework artifacts)

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3550
