### PR TITLE
Adds conformsToProtocol forwarding to MPAppDelegateProxy

### DIFF
--- a/mParticle-Apple-SDK/AppNotifications/MPAppDelegateProxy.m
+++ b/mParticle-Apple-SDK/AppNotifications/MPAppDelegateProxy.m
@@ -13,9 +13,18 @@
 
 @implementation MPAppDelegateProxy
 
+static MPAppDelegateProxy* _defaultProxy = nil;
++ (MPAppDelegateProxy *)defaultProxy {
+    return _defaultProxy;
+}
+
 - (instancetype)initWithOriginalAppDelegate:(id)originalAppDelegate {
     _originalAppDelegate = originalAppDelegate;
     originalAppDelegateSelector = @selector(originalAppDelegate);
+    static dispatch_once_t pred = 0;
+    dispatch_once(&pred, ^{
+        _defaultProxy = self;
+    });
     return self;
 }
 
@@ -87,8 +96,10 @@
     return respondsToSelector;
 }
 
-- (BOOL)conformsToProtocol:(Protocol *)aProtocol {
-    return [_originalAppDelegate conformsToProtocol:aProtocol] || [self.surrogateAppDelegate conformsToProtocol:aProtocol];
++ (BOOL)conformsToProtocol:(Protocol *)aProtocol {
+    id original = [[MPAppDelegateProxy defaultProxy] originalAppDelegate];
+    id surrogate = [[MPAppDelegateProxy defaultProxy] surrogateAppDelegate];
+    return [original conformsToProtocol:aProtocol] || [surrogate conformsToProtocol:aProtocol];
 }
 
 #pragma mark Public accessors

--- a/mParticle-Apple-SDK/AppNotifications/MPAppDelegateProxy.m
+++ b/mParticle-Apple-SDK/AppNotifications/MPAppDelegateProxy.m
@@ -87,6 +87,10 @@
     return respondsToSelector;
 }
 
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol {
+    return [_originalAppDelegate conformsToProtocol:aProtocol] || [self.surrogateAppDelegate conformsToProtocol:aProtocol];
+}
+
 #pragma mark Public accessors
 - (MPSurrogateAppDelegate *)surrogateAppDelegate {
     if (_surrogateAppDelegate) {


### PR DESCRIPTION
## Summary
Adds an implementation of `conformsToProtocol:` to `MPAppDelegateProxy` that bubbles up protocol implementations from the base AppDelegate. Issue is described in #143.

Had to add an extra singleton in order to get the original app delegate types. If anyone can think of a better way, input is extremely welcome. 

## Testing Plan
Manually smoke tested in our setup, and unit tested. Should be low-to-no impact for other integrations, but unknown.

## Master Issue
Implementation as described in [#143](https://github.com/mParticle/mparticle-apple-sdk/issues/143)
