### PR TITLE
fix: update active kits header

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -560,6 +560,9 @@
     activeKits = [kitContainer activeKitsRegistry];
     
     XCTAssertEqual(activeKits.count, 0);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 1);
+    XCTAssertTrue([configuredKits containsObject:@42]);
 }
 
 - (void)testForwardLoggedOutUserWithMultipleKits {
@@ -614,9 +617,88 @@
     [kitContainer configureKits:configurations];
     
     activeKits = [kitContainer activeKitsRegistry];
-    
     XCTAssertEqual(activeKits.count, 1);
     XCTAssertEqual(activeKits[0].code, @314);
+    
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+}
+
+- (void)testConfiguredKits {
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            }
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+    
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    [[kitContainer startKit:@314 configuration:kitConfiguration] start];
+
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+    
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    
+    XCTAssertEqual(activeKits.count, 2);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+    
+    configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@true
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@92,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+    
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+    
+    activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 1);
+    XCTAssertEqual(activeKits[0].code, @314);
+    
+    configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 3);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@92]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+
 }
 
 - (void)testForwardLoggedInUserWithMultipleKits {
@@ -653,6 +735,11 @@
     XCTAssertTrue([activeKits[0].code integerValue] == 42 || [activeKits[0].code integerValue] == 314);
     XCTAssertTrue([activeKits[1].code integerValue] == 42 || [activeKits[1].code integerValue] == 314);
     
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+    
     configurations = @[
                        @{
                            @"id":@(42),
@@ -680,6 +767,10 @@
     XCTAssertEqual(activeKits.count, 2);
     XCTAssertTrue([activeKits[0].code integerValue] == 42 || [activeKits[0].code integerValue] == 314);
     XCTAssertTrue([activeKits[1].code integerValue] == 42 || [activeKits[1].code integerValue] == 314);
+    configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
 }
 
 - (void)testFilterMessageType {

--- a/UnitTests/MPURLRequestBuilderTests.m
+++ b/UnitTests/MPURLRequestBuilderTests.m
@@ -375,9 +375,8 @@
     [[[mockWebView stub] andReturn:agent] userAgent];
     
     id mockKitContainer = OCMClassMock([MPKitContainer class]);
-    id mockKit = OCMProtocolMock(@protocol(MPExtensionKitProtocol));
-    [(id<MPExtensionKitProtocol>)[[mockKit stub] andReturn:@42] code];
-    [[[mockKitContainer stub] andReturn:@[mockKit]] activeKitsRegistry];
+    NSNumber *mockKitId = @42;
+    [[[mockKitContainer stub] andReturn:@[mockKitId]] configuredKitsRegistry];
     
     id mockMParticle = OCMPartialMock(sharedInstance);
     [[[mockMParticle stub] andReturn:mockWebView] webView];
@@ -432,7 +431,6 @@
     }
     [mockMParticle stopMocking];
     [mockKitContainer stopMocking];
-    [mockKit stopMocking];
     [mockWebView stopMocking];
 }
 

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -20,7 +20,7 @@
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;
 
 - (nullable NSArray<id<MPExtensionKitProtocol>> *)activeKitsRegistry;
-- (nonnull NSArray<NSNumber *> *)configuredKitsRegistry;
+- (nullable NSArray<NSNumber *> *)configuredKitsRegistry;
 - (void)configureKits:(nullable NSArray<NSDictionary *> *)kitsConfiguration;
 - (nullable NSArray<NSNumber *> *)supportedKits;
 - (void)initializeKits;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -20,6 +20,7 @@
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;
 
 - (nullable NSArray<id<MPExtensionKitProtocol>> *)activeKitsRegistry;
+- (nonnull NSArray<NSNumber *> *)configuredKitsRegistry;
 - (void)configureKits:(nullable NSArray<NSDictionary *> *)kitsConfiguration;
 - (nullable NSArray<NSNumber *> *)supportedKits;
 - (void)initializeKits;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1893,7 +1893,7 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 }
 
 - (nullable NSArray<NSNumber *> *)configuredKitsRegistry {
-    BOOL anyKitsIncluded = self.supportedKits != nil && self.supportedKits.count > 0;
+    BOOL anyKitsIncluded = self.supportedKits.count > 0;
     BOOL anyKitsConfigured = self.kitConfigurations != nil && self.kitConfigurations.count > 0;
     if (!anyKitsIncluded || !anyKitsConfigured) {
         return nil;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1894,7 +1894,7 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 
 - (nullable NSArray<NSNumber *> *)configuredKitsRegistry {
     BOOL anyKitsIncluded = self.supportedKits.count > 0;
-    BOOL anyKitsConfigured = self.kitConfigurations != nil && self.kitConfigurations.count > 0;
+    BOOL anyKitsConfigured = self.kitConfigurations.count > 0;
     if (!anyKitsIncluded || !anyKitsConfigured) {
         return nil;
     }

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1892,6 +1892,16 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     completionHandler(projectedEvents, appliedProjections);
 }
 
+- (nonnull NSArray<NSNumber *> *)configuredKitsRegistry {
+    NSMutableArray<NSNumber *> *configuredKits = [[NSMutableArray alloc] initWithCapacity:self.kitConfigurations.count];
+    for (NSNumber *kitId in self.kitConfigurations.allKeys) {
+        if ([self.supportedKits containsObject:kitId]) {
+            [configuredKits addObject:kitId];
+        }
+    }
+    return configuredKits;
+}
+
 #pragma mark Public methods
 - (nullable NSArray<id<MPExtensionKitProtocol>> *)activeKitsRegistry {
     if (kitsRegistry.count == 0) {

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1892,7 +1892,12 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     completionHandler(projectedEvents, appliedProjections);
 }
 
-- (nonnull NSArray<NSNumber *> *)configuredKitsRegistry {
+- (nullable NSArray<NSNumber *> *)configuredKitsRegistry {
+    BOOL anyKitsIncluded = self.supportedKits != nil && self.supportedKits.count > 0;
+    BOOL anyKitsConfigured = self.kitConfigurations != nil && self.kitConfigurations.count > 0;
+    if (!anyKitsIncluded || !anyKitsConfigured) {
+        return nil;
+    }
     NSMutableArray<NSNumber *> *configuredKits = [[NSMutableArray alloc] initWithCapacity:self.kitConfigurations.count];
     for (NSNumber *kitId in self.kitConfigurations.allKeys) {
         if ([self.supportedKits containsObject:kitId]) {

--- a/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
+++ b/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
@@ -170,7 +170,7 @@ static NSDateFormatter *RFC1123DateFormatter;
                 kits = nil;
             }
             
-            NSMutableArray<NSNumber *> *configuredKitIds = [[NSMutableArray alloc] initWithArray:[[MParticle sharedInstance].kitContainer configuredKitsRegistry]];
+            NSArray<NSNumber *> *configuredKitIds = MParticle.sharedInstance.kitContainer.configuredKitsRegistry.copy;
             
             kits = [configuredKitIds componentsJoinedByString:@","];
             

--- a/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
+++ b/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
@@ -170,16 +170,9 @@ static NSDateFormatter *RFC1123DateFormatter;
                 kits = nil;
             }
             
-            NSArray<id<MPExtensionKitProtocol>> *activeKitsRegistry = [[MParticle sharedInstance].kitContainer activeKitsRegistry];
-            if (activeKitsRegistry.count > 0) {
-                NSMutableArray<NSNumber *> *activeKitIds = [[NSMutableArray alloc] initWithCapacity:activeKitsRegistry.count];
-                
-                for (id<MPExtensionKitProtocol> kitRegister in activeKitsRegistry) {
-                    [activeKitIds addObject:kitRegister.code];
-                }
-                
-                kits = [activeKitIds componentsJoinedByString:@","];
-            }
+            NSMutableArray<NSNumber *> *configuredKitIds = [[NSMutableArray alloc] initWithArray:[[MParticle sharedInstance].kitContainer configuredKitsRegistry]];
+            
+            kits = [configuredKitIds componentsJoinedByString:@","];
             
             range = [_message rangeOfString:kMPMessageTypeNetworkPerformance];
             if (range.location != NSNotFound) {

--- a/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
+++ b/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
@@ -170,9 +170,7 @@ static NSDateFormatter *RFC1123DateFormatter;
                 kits = nil;
             }
             
-            NSArray<NSNumber *> *configuredKitIds = MParticle.sharedInstance.kitContainer.configuredKitsRegistry.copy;
-            
-            kits = [configuredKitIds componentsJoinedByString:@","];
+            kits = [MParticle.sharedInstance.kitContainer.configuredKitsRegistry componentsJoinedByString:@","];
             
             range = [_message rangeOfString:kMPMessageTypeNetworkPerformance];
             if (range.location != NSNotFound) {


### PR DESCRIPTION
## Summary
The "x-mp-kits" header field was previously sending a list of kits that were actively receiving events. Now it will send a list of kits that have been configured, even if they are not actively receiving events due to the SDK state. For Example, a kit that was shut down due to the current user's logged-in status not matching its configurations directive previous would not have been included in this list but now will be included

## Testing Plan
Modified a few existing tests to include checks for the new `[kjitContainer configuredKits]` method where the results would differ from `[kitContainer activeKits]`. Also included a new unit test with a more focused scenario. Updated a networking tests to make sure the `configuredKits` method was properly being applied to `x-mp-kits`

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3738

### Related (Android) PR
https://github.com/mParticle/mparticle-android-sdk/pull/126

