### PR TITLE
feat: add support for client side rules

### DIFF
--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -18,6 +18,7 @@
 @property (nonatomic, strong) MPStateMachine *stateMachine;
 @property (nonatomic, strong, nullable) NSString *dataPlanId;
 @property (nonatomic, strong, nullable) NSNumber *dataPlanVersion;
+@property (nonatomic, strong) MParticleOptions *options;
 
 @end
 
@@ -669,5 +670,140 @@
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
+
+- (MPUploadBuilder *)createTestUploadBuilder {
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    
+    NSDictionary *messageInfo = @{@"key1":@"value1",
+                                  @"key2":@"value2",
+                                  @"key3":@"value3"};
+    
+    [self configureCustomModules];
+    
+    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
+                                                                           session:session
+                                                                       messageInfo:messageInfo];
+    
+    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    MPMessage *message = [messageBuilder build];
+    
+    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
+                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                   messages:@[message]
+                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                             uploadInterval:DEFAULT_DEBUG_UPLOAD_INTERVAL
+                                                                 dataPlanId:message.dataPlanId
+                                                            dataPlanVersion:message.dataPlanVersion
+    ];
+    
+    XCTAssertNotNil(uploadBuilder);
+    
+    NSDictionary *userAttributes = @{@"Dinosaur":@"T-Rex",
+                                     @"Arm length":@"Short",
+                                     @"Height":@20,
+                                     @"Keywords":@[@"Omnivore", @"Loud", @"Pre-historic"]};
+    
+    NSSet *deletedUserAttributes = [NSSet setWithObjects:@"Push ups", nil];
+    
+    [uploadBuilder withUserAttributes:userAttributes deletedUserAttributes:deletedUserAttributes];
+    
+    NSArray *userIdentities = @[
+        @{
+            @"n":@7,
+            @"i":@"trex@shortarmsdinosaurs.com",
+            @"dfs":MPCurrentEpochInMilliseconds,
+            @"f":@NO
+        },
+        @{
+            @"n":@22,
+            @"i":@"C56A4180-65AA-42EC-A945-5FD21DEC0538"
+        }
+    ];
+    
+    [uploadBuilder withUserIdentities:userIdentities];
+    
+    NSString *description = [uploadBuilder description];
+    XCTAssertNotNil(description);
+    return uploadBuilder;
+}
+
+- (void)testBatchMutation {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Upload builder instance (session)"];
+    MParticleOptions *options = [[MParticleOptions alloc] init];
+    options.onCreateBatch = ^NSDictionary * _Nullable(NSDictionary * _Nonnull batch) {
+        NSMutableDictionary *mutableBatch = [batch mutableCopy];
+        mutableBatch[@"Test key"] = @"Test value";
+        return mutableBatch;
+    };
+    MParticle.sharedInstance.options = options;
+    
+    MPUploadBuilder *uploadBuilder = [self createTestUploadBuilder];
+    
+    [uploadBuilder build:^(MPUpload * _Nullable upload) {
+        XCTAssertNotNil(upload);
+        Class uploadClass = [MPUpload class];
+        XCTAssertEqualObjects([upload class], uploadClass);
+        
+        NSDictionary *uploadDictionary = [(MPUpload *)upload dictionaryRepresentation];
+        XCTAssertNotNil(uploadDictionary);
+        
+        XCTAssertEqualObjects(uploadDictionary[@"Test key"], @"Test value");
+        XCTAssertEqual(uploadDictionary[@"mb"], @YES);
+        
+        NSDictionary *deviceInfoDictionary = uploadDictionary[kMPDeviceInformationKey];
+        XCTAssertNotNil(deviceInfoDictionary);
+        XCTAssertNil(deviceInfoDictionary[kMPDeviceAdvertiserIdKey]);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testNoBatchMutation {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Upload builder instance (session)"];
+    MParticleOptions *options = [[MParticleOptions alloc] init];
+    options.onCreateBatch = ^NSDictionary * _Nullable(NSDictionary * _Nonnull batch) {
+        return [NSDictionary dictionaryWithDictionary:batch];
+    };
+    MParticle.sharedInstance.options = options;
+    
+    MPUploadBuilder *uploadBuilder = [self createTestUploadBuilder];
+    
+    [uploadBuilder build:^(MPUpload * _Nullable upload) {
+        XCTAssertNotNil(upload);
+        Class uploadClass = [MPUpload class];
+        XCTAssertEqualObjects([upload class], uploadClass);
+        
+        NSDictionary *uploadDictionary = [(MPUpload *)upload dictionaryRepresentation];
+        XCTAssertNotNil(uploadDictionary);
+        
+        XCTAssertNil(uploadDictionary[@"Test key"]);
+        XCTAssertNil(uploadDictionary[@"mb"]);
+        
+        NSDictionary *deviceInfoDictionary = uploadDictionary[kMPDeviceInformationKey];
+        XCTAssertNotNil(deviceInfoDictionary);
+        XCTAssertNil(deviceInfoDictionary[kMPDeviceAdvertiserIdKey]);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testBatchBlocking {
+    MParticleOptions *options = [[MParticleOptions alloc] init];
+    options.onCreateBatch = ^NSDictionary * _Nullable(NSDictionary * _Nonnull batch) {
+        return nil;
+    };
+    MParticle.sharedInstance.options = options;
+    
+    MPUploadBuilder *uploadBuilder = [self createTestUploadBuilder];
+    
+    [uploadBuilder build:^(MPUpload * _Nullable upload) {
+        XCTAssert(NO, @"Builder completion should not have been called since batch was blocked by customer");
+    }];
+}
+
 
 @end

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -394,6 +394,19 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  */
 @property (nonatomic, copy) void (^onAttributionComplete)(MPAttributionResult *_Nullable attributionResult, NSError *_Nullable error);
 
+/**
+ Custom handler to modify or block batch data before upload.
+
+ If set, this will be called when a new batch of data is created. By returning a different value, you can change the batch contents, or by returning 'nil' you can block the batch from being uploaded.
+
+ Use with care. This feature was initially added to allow the value of existing fields to be modified. If you add new data in a format that the platform is not expecting, it may be dropped or not parsed correctly.
+
+ Note: Use of this handler will also cause the field 'mb' (modified batch) to appear in the batch so we can distinguish for troubleshooting purposes whether data was changed.
+ 
+ Also note: Unlike other callbacks, this block will be called on the SDK queue to prevent batches from being processed out of order. Please avoid excessively blocking in this handler as this will prevent the SDK from doing other tasks.
+ */
+@property (nonatomic, copy) NSDictionary *_Nullable (^onCreateBatch)(NSDictionary * batch);
+
 @end
 
 /**

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -1975,33 +1975,33 @@ static BOOL skipNextUpload = NO;
 - (MPExecStatus)checkForKitsAndUploadWithCompletionHandler:(void (^ _Nullable)(BOOL didShortCircuit))completionHandler {
     __weak MPBackendController *weakSelf = self;
 
-            [self requestConfig:^(BOOL uploadBatch) {
-                if (!uploadBatch) {
-                    if (completionHandler) {
-                        completionHandler(NO);
-                    }
-                    
-                    return;
-                }
-                __strong MPBackendController *strongSelf = weakSelf;
-                MPKitContainer *kitContainer = [MParticle sharedInstance].kitContainer;
-                BOOL shouldDelayUploadForKits = kitContainer && [kitContainer shouldDelayUpload:kMPMaximumKitWaitTimeSeconds];
-                BOOL shouldDelayUpload = shouldDelayUploadForKits || [MParticle.sharedInstance.webView shouldDelayUpload:kMPMaximumAgentWaitTimeSeconds];
-                if (shouldDelayUpload) {
-                    if (completionHandler) {
-                        completionHandler(YES);
-                    }
-                    
-                    return;
-                }
-                
-                [strongSelf uploadBatchesWithCompletionHandler:^(BOOL success) {
-                    if (completionHandler) {
-                        completionHandler(NO);
-                    }
-                }];
-                
-            }];
+    [self requestConfig:^(BOOL uploadBatch) {
+        if (!uploadBatch) {
+            if (completionHandler) {
+                completionHandler(NO);
+            }
+            
+            return;
+        }
+        __strong MPBackendController *strongSelf = weakSelf;
+        MPKitContainer *kitContainer = [MParticle sharedInstance].kitContainer;
+        BOOL shouldDelayUploadForKits = kitContainer && [kitContainer shouldDelayUpload:kMPMaximumKitWaitTimeSeconds];
+        BOOL shouldDelayUpload = shouldDelayUploadForKits || [MParticle.sharedInstance.webView shouldDelayUpload:kMPMaximumAgentWaitTimeSeconds];
+        if (shouldDelayUpload) {
+            if (completionHandler) {
+                completionHandler(YES);
+            }
+            
+            return;
+        }
+        
+        [strongSelf uploadBatchesWithCompletionHandler:^(BOOL success) {
+            if (completionHandler) {
+                completionHandler(NO);
+            }
+        }];
+        
+    }];
     
     return MPExecStatusSuccess;
 }


### PR DESCRIPTION
## Summary
This PR implements support for allowing SDK batches of data to be passed through a customer callback where they can be modified or dropped.

## Testing Plan
- Unit testing
- Manual testing

## Master Issue
Closes https://go.mparticle.com/work/3733
