### PR TITLE
feat: match android type support for custom attributes

### DIFF
--- a/Example/mParticleExample/ViewController.m
+++ b/Example/mParticleExample/ViewController.m
@@ -111,10 +111,11 @@
     MPEvent *event = [[MPEvent alloc] initWithName:@"Event Name" type:MPEventTypeTransaction];
     
     // Add attributes to an event
+    NSDate *currentDate = [NSDate dateWithTimeIntervalSinceNow:0];
     event.customAttributes = @{@"A_String_Key":@"A String Value",
                                       @"A Number Key":@(42),
                                       @"A Date Key":[NSDate date],
-                                      @"test Dictionary": @{}};
+                               @"test Dictionary": @{@"test1": @"test", @"test2": @2, @"test3": currentDate}};
     
     // Custom flags are attributes sent to mParticle, but not forwarded to other providers
     [event addCustomFlag:@"Top Secret" withKey:@"Not_forwarded_to_providers"];

--- a/Example/mParticleExample/ViewController.m
+++ b/Example/mParticleExample/ViewController.m
@@ -112,8 +112,9 @@
     
     // Add attributes to an event
     event.customAttributes = @{@"A_String_Key":@"A String Value",
-                   @"A Number Key":@(42),
-                   @"A Date Key":[NSDate date]};
+                                      @"A Number Key":@(42),
+                                      @"A Date Key":[NSDate date],
+                                      @"test Dictionary": @{}};
     
     // Custom flags are attributes sent to mParticle, but not forwarded to other providers
     [event addCustomFlag:@"Top Secret" withKey:@"Not_forwarded_to_providers"];

--- a/UnitTests/MPEventTests.mm
+++ b/UnitTests/MPEventTests.mm
@@ -47,7 +47,8 @@
     }
     
     NSDictionary *eventInfo = @{@"speed":@25,
-                                @"modality":@"sprinting"};
+                                @"modality":@"sprinting",
+                                @"stats":@{}};
     
     event.customAttributes = eventInfo;
     event.category = @"Olympic Games";
@@ -86,8 +87,8 @@
     XCTAssertNotNil(event.customAttributes, @"Should not have been nil.");
     XCTAssertNotNil(event.info, @"Should not have been nil.");
 
-    XCTAssertEqual(event.customAttributes.count, 2, @"Should have been two values in the customAttributes dictionary.");
-    XCTAssertEqual(event.info.count, 2, @"Should have been two values in the info dictionary.");
+    XCTAssertEqual(event.customAttributes.count, 3, @"Should have been three values in the customAttributes dictionary.");
+    XCTAssertEqual(event.info.count, 3, @"Should have been three values in the info dictionary.");
 
     NSDictionary *copyEventInfo = [eventInfo copy];
     event.customAttributes = copyEventInfo;
@@ -163,7 +164,8 @@
     MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeOther];
     event.duration = eventDuration;
     event.customAttributes = @{@"speed":@25,
-                   @"modality":@"sprinting"};
+                               @"modality":@"sprinting",
+                               @"stats":@{}};
     event.category = @"Olympic Games";
     
     [session incrementCounter];
@@ -180,6 +182,7 @@
     
     NSDictionary *attributes = @{@"speed":@25,
                                  @"modality":@"sprinting",
+                                 @"stats":@{},
                                  @"$Category":@"Olympic Games",
                                  @"EventLength":eventDuration};
     XCTAssertEqualObjects(dictionaryRepresentation[kMPAttributesKey], attributes, @"Attributes are not being set correctly.");

--- a/UnitTests/MPEventTests.mm
+++ b/UnitTests/MPEventTests.mm
@@ -188,6 +188,76 @@
     XCTAssertEqualObjects(dictionaryRepresentation[kMPAttributesKey], attributes, @"Attributes are not being set correctly.");
 }
 
+- (void)testDictionaryRepresentationWithDictionaryValues {
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
+    stateMachine.currentSession = session;
+    
+    NSNumber *eventDuration = @2;
+    
+    MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeOther];
+    event.duration = eventDuration;
+    NSDate *currentDate = [NSDate dateWithTimeIntervalSinceNow:0];
+    event.customAttributes = @{@"speed":@25,
+                               @"modality":@"sprinting",
+                               @"stats":@{@"test1": @"test", @"test2": @2, @"test3": currentDate}};
+    event.category = @"Olympic Games";
+    
+    [session incrementCounter];
+    [session incrementCounter];
+    [session incrementCounter];
+    
+    NSDictionary *dictionaryRepresentation = [event dictionaryRepresentation];
+    XCTAssertNotNil(dictionaryRepresentation, @"Dictionary representation should not have been nil.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventNameKey], @"Dinosaur Run", @"Name is not correct.");
+    XCTAssertNotNil(dictionaryRepresentation[kMPEventStartTimestamp], @"Start timestamp should not have been nil.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventTypeKey], @"Other", @"Type should have been 'Other.'");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventLength], @2, @"Length should have been 2.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventCounterKey], @3, @"Event counter should have been 3.");
+    
+    NSDictionary *attributes = @{@"speed":@25,
+                                 @"modality":@"sprinting",
+                                 @"stats":@{@"test1": @"test", @"test2": @2, @"test3": currentDate},
+                                 @"$Category":@"Olympic Games",
+                                 @"EventLength":eventDuration};
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPAttributesKey], attributes, @"Attributes are not being set correctly.");
+}
+
+- (void)testDictionaryRepresentationWithDictionaryValuesContainingDictionary {
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
+    stateMachine.currentSession = session;
+    
+    NSNumber *eventDuration = @2;
+    
+    MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeOther];
+    event.duration = eventDuration;
+    NSDate *currentDate = [NSDate dateWithTimeIntervalSinceNow:0];
+    event.customAttributes = @{@"speed":@25,
+                               @"modality":@"sprinting",
+                               @"stats":@{@"test1": @"test", @"test2": @2, @"test3": currentDate}, @"test3": @{@"test1": @"test", @"test2": @2}};
+    event.category = @"Olympic Games";
+    
+    [session incrementCounter];
+    [session incrementCounter];
+    [session incrementCounter];
+    
+    NSDictionary *dictionaryRepresentation = [event dictionaryRepresentation];
+    XCTAssertNotNil(dictionaryRepresentation, @"Dictionary representation should not have been nil.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventNameKey], @"Dinosaur Run", @"Name is not correct.");
+    XCTAssertNotNil(dictionaryRepresentation[kMPEventStartTimestamp], @"Start timestamp should not have been nil.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventTypeKey], @"Other", @"Type should have been 'Other.'");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventLength], @2, @"Length should have been 2.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventCounterKey], @3, @"Event counter should have been 3.");
+    
+    NSDictionary *attributes = @{@"speed":@25,
+                                 @"modality":@"sprinting",
+                                 @"stats":@{@"test1": @"test", @"test2": @2, @"test3": currentDate}, @"test3": @{@"test1": @"test", @"test2": @2},
+                                 @"$Category":@"Olympic Games",
+                                 @"EventLength":eventDuration};
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPAttributesKey], attributes, @"Attributes are not being set correctly.");
+}
+
 - (void)testBreadcrumbDictionaryRepresentation {
     MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeNavigation];
     event.customAttributes = @{@"speed":@25,

--- a/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
+++ b/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
@@ -70,9 +70,18 @@
             transformedDictionary[key] = [MPDateFormatter stringFromDateRFC3339:obj];
         } else if ([obj isKindOfClass:[NSData class]] && [(NSData *)obj length] > 0) {
             transformedDictionary[key] = [[NSString alloc] initWithData:obj encoding:NSUTF8StringEncoding];
+        } else if ([obj isKindOfClass:[NSDictionary class]]) {
+            transformedDictionary[key] = [obj description];
+        } else if ([obj isKindOfClass:[NSMutableDictionary class]]) {
+            transformedDictionary[key] = [obj description];
+        } else if ([obj isKindOfClass:[NSArray class]]) {
+            transformedDictionary[key] = [obj description];
+        } else if ([obj isKindOfClass:[NSMutableArray class]]) {
+            transformedDictionary[key] = [obj description];
         } else {
             MPILogError(@"Data type is not supported as an attribute value: %@ - %@", obj, [[obj class] description]);
-            transformedDictionary[key] = [obj description];
+            NSAssert([obj isKindOfClass:[NSString class]], @"Data type is not supported as an attribute value");
+            return;
         }
     }];
     

--- a/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
+++ b/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
@@ -72,8 +72,7 @@
             transformedDictionary[key] = [[NSString alloc] initWithData:obj encoding:NSUTF8StringEncoding];
         } else {
             MPILogError(@"Data type is not supported as an attribute value: %@ - %@", obj, [[obj class] description]);
-            NSAssert([obj isKindOfClass:[NSString class]], @"Data type is not supported as an attribute value");
-            return;
+            transformedDictionary[key] = [obj description];
         }
     }];
     


### PR DESCRIPTION
## Summary
We discussed this in stand up and determined it makes sense to have iOS match Android behavior in terms of serializing dictionaries when sending to the server but leave the objects as-is when passing to kits. 

## Testing Plan
Updated unit test to include cases with dictionaries

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4087
