### PR TITLE
Allow user attributes with empty string values to be set

### DIFF
--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -279,7 +279,7 @@
 - (void)setUserAttribute:(nonnull NSString *)key value:(nonnull id)value {
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:key parameter2:value];
     
-    if ([value isKindOfClass:[NSString class]] && (((NSString *)value).length <= 0)) {
+    if ([value isKindOfClass:[NSString class]] && (((NSString *)value).length < 0)) {
         MPILogDebug(@"User attribute not updated. Please use removeUserAttribute.");
         
         return;

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -2037,7 +2037,7 @@ static BOOL skipNextUpload = NO;
         return;
     }
     
-    if (!(([value isKindOfClass:[NSString class]] && ((NSString *)value).length > 0) || [value isKindOfClass:[NSNumber class]]) && value != nil) {
+    if (!(([value isKindOfClass:[NSString class]] && ((NSString *)value).length >= 0) || [value isKindOfClass:[NSNumber class]]) && value != nil) {
         if (completionHandler) {
             completionHandler(keyCopy, value, MPExecStatusInvalidDataType);
         }


### PR DESCRIPTION
## Summary
The Signature Hospitality Group noticed in their iOS React Native app that user attributes with empty string are not being set. We confirmed that custom feeds, Web SDK and Android SDK (in both original SDK and React Native) are forwarding the attribute as expected when the string is empty. We were able to identify that this issue is on the iOS SDK and not React Native SDK itself when testing. The code here adds the necessary fixes to allow empty string attributes to not be considered an invalid data type and would forward as the same other SDKs.

## Testing Plan
Changed the files locally on my sample app in the mParticle iOS SDK and tested with my sample app.
