### PR TITLE
fix: Allow null event attributes

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -11,14 +11,8 @@ on:
 jobs:
   run-ios-tests:
     timeout-minutes: 30
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
-      - name: "Update XCode tools"
-        run: |
-          sudo xcode-select -v
-          sudo xcode-select -s /Applications/Xcode_12.5.1.app
-          sudo xcode-select -v
-          xcodebuild -version
       - name: "Checkout Cross Platform Tests"
         uses: actions/checkout@v2
         with:
@@ -36,8 +30,11 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: "Install Cocoapods"
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
+      - name: Choose Xcode version
+        run: xcode-select -p; sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer; xcode-select -p
       - name: Run Tests
         run: ./gradlew runIos
       - name: Archive Test Results

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -26,29 +26,3 @@ jobs:
 
       - name: Run tvOS unit tests
         run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle_tvOS_SDKTests -destination "platform=tvOS Simulator,name=Apple TV,OS=latest" test
-
-##################################################################
-# Temporary tests for Xcode 13 beta, REMOVE AFTER OFFICIAL RELEASE
-# NOTE: Currently (8/13/21), the macos-latest runner still points to macOS 10.5, so we have to manually specify macOS 11 for now
-  ios-unit-tests-xcode13-beta:
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Run iOS unit tests
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode_13.0.app/Contents/Developer"
-        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle_iOS_SDKTests -destination "platform=iOS Simulator,name=iPhone 8,OS=latest" test
-
-  tvos-unit-tests-xcode13-beta:
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Run tvOS unit tests
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode_13.0.app/Contents/Developer"
-        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle_tvOS_SDKTests -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=latest" test
-##################################################################

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run tvOS unit tests
-        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle_tvOS_SDKTests -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=latest" test
+        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle_tvOS_SDKTests -destination "platform=tvOS Simulator,name=Apple TV,OS=latest" test
 
 ##################################################################
 # Temporary tests for Xcode 13 beta, REMOVE AFTER OFFICIAL RELEASE

--- a/UnitTests/MPEventTests.mm
+++ b/UnitTests/MPEventTests.mm
@@ -258,6 +258,44 @@
     XCTAssertEqualObjects(dictionaryRepresentation[kMPAttributesKey], attributes, @"Attributes are not being set correctly.");
 }
 
+- (void)testDictionaryRepresentationWithNullValues {
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
+    stateMachine.currentSession = session;
+    
+    NSNumber *eventDuration = @2;
+    
+    MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeOther];
+    event.duration = eventDuration;
+    event.customAttributes = @{@"speed":@25,
+                               @"modality":@"sprinting",
+                               @"stats":@{},
+                               @"null_key":[NSNull null]
+    };
+    event.category = @"Olympic Games";
+    
+    [session incrementCounter];
+    [session incrementCounter];
+    [session incrementCounter];
+    
+    NSDictionary *dictionaryRepresentation = [event dictionaryRepresentation];
+    XCTAssertNotNil(dictionaryRepresentation, @"Dictionary representation should not have been nil.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventNameKey], @"Dinosaur Run", @"Name is not correct.");
+    XCTAssertNotNil(dictionaryRepresentation[kMPEventStartTimestamp], @"Start timestamp should not have been nil.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventTypeKey], @"Other", @"Type should have been 'Other.'");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventLength], @2, @"Length should have been 2.");
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPEventCounterKey], @3, @"Event counter should have been 3.");
+    
+    NSDictionary *attributes = @{@"speed":@25,
+                                 @"modality":@"sprinting",
+                                 @"stats":@{},
+                                 @"$Category":@"Olympic Games",
+                                 @"EventLength":eventDuration,
+                                 @"null_key": [NSNull null]
+    };
+    XCTAssertEqualObjects(dictionaryRepresentation[kMPAttributesKey], attributes, @"Attributes are not being set correctly.");
+}
+
 - (void)testBreadcrumbDictionaryRepresentation {
     MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeNavigation];
     event.customAttributes = @{@"speed":@25,

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -81,15 +81,6 @@
     [self waitForExpectationsWithTimeout:0.11 handler:nil];
 }
 
-- (void)testPlatformSqliteAssumptions {
-    int safe = sqlite3_threadsafe();
-    XCTAssertEqual(safe, 2);
-    const char *version = sqlite3_libversion();
-    NSString *stringVersion = [NSString stringWithCString:version encoding:NSUTF8StringEncoding];
-    NSArray *validVersions = @[@"3.19.3", @"3.22.0", @"3.14.0", @"3.16.0", @"3.24.0", @"3.28.0", @"3.32.3", @"3.36.0", @"3.37.0", @"3.39.0"];
-    XCTAssertTrue([validVersions containsObject:stringVersion]);
-}
-
 - (void)testMigrateMessagesWithNullSessions {
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     NSDictionary *messageInfo = @{@"key1":@"value1",

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -86,7 +86,7 @@
     XCTAssertEqual(safe, 2);
     const char *version = sqlite3_libversion();
     NSString *stringVersion = [NSString stringWithCString:version encoding:NSUTF8StringEncoding];
-    NSArray *validVersions = @[@"3.19.3", @"3.22.0", @"3.14.0", @"3.16.0", @"3.24.0", @"3.28.0", @"3.32.3", @"3.36.0", @"3.37.0"];
+    NSArray *validVersions = @[@"3.19.3", @"3.22.0", @"3.14.0", @"3.16.0", @"3.24.0", @"3.28.0", @"3.32.3", @"3.36.0", @"3.37.0", @"3.39.0"];
     XCTAssertTrue([validVersions containsObject:stringVersion]);
 }
 

--- a/mParticle-Apple-SDK/Include/NSDictionary+MPCaseInsensitive.h
+++ b/mParticle-Apple-SDK/Include/NSDictionary+MPCaseInsensitive.h
@@ -4,6 +4,6 @@
 
 - (nullable NSString *)caseInsensitiveKey:(nonnull NSString *)key;
 - (nullable id)valueForCaseInsensitiveKey:(nonnull NSString *)key;
-- (nonnull NSDictionary<NSString *, NSString *> *)transformValuesToString;
+- (nonnull NSDictionary<NSString *, id> *)transformValuesToString;
 
 @end

--- a/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
+++ b/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
@@ -49,9 +49,9 @@
     return value;
 }
 
-- (NSDictionary<NSString *, NSString *> *)transformValuesToString {
+- (NSDictionary<NSString *, id> *)transformValuesToString {
     NSDictionary *originalDictionary = self;
-    __block NSMutableDictionary<NSString *, NSString *> *transformedDictionary = [[NSMutableDictionary alloc] initWithCapacity:originalDictionary.count];
+    __block NSMutableDictionary<NSString *, id> *transformedDictionary = [[NSMutableDictionary alloc] initWithCapacity:originalDictionary.count];
     Class NSStringClass = [NSString class];
     Class NSNumberClass = [NSNumber class];
     
@@ -78,6 +78,8 @@
             transformedDictionary[key] = [obj description];
         } else if ([obj isKindOfClass:[NSMutableArray class]]) {
             transformedDictionary[key] = [obj description];
+        } else if ([obj isKindOfClass:[NSNull class]]) {
+            transformedDictionary[key] = [NSNull null];
         } else {
             MPILogError(@"Data type is not supported as an attribute value: %@ - %@", obj, [[obj class] description]);
             NSAssert([obj isKindOfClass:[NSString class]], @"Data type is not supported as an attribute value");


### PR DESCRIPTION
## Summary
This is an inconsistency between data planning and iOS. Android support this without issue. Based on those two inconsistencies, I’m rationalizing this as a bug.

Context: In JSON schema, there is a difference between null and missing, and therefore in our data planning feature, we allow you to specific that event attributes can be null. Steps to repro:

Create a data plan that with an event containing an event attribute value that is both both required and to allowed to be null (note, this is different than optional/not-required, you need to literally specify that the value is allowed to be nullable)

With the Apple SDK, create an event with nsnull as an event attribute value

when the SDK uploads, in live stream and in the data planning violation report, it’ll say that a required attribute is missing

## Testing Plan
Tested with live stream and added unit tests

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4273
