### PR TITLE
fix: Add Hash Methods where isEqual called

### DIFF
--- a/mParticle-Apple-SDK/Custom Modules/MPCustomModule.m
+++ b/mParticle-Apple-SDK/Custom Modules/MPCustomModule.m
@@ -66,6 +66,10 @@
     return [[self dictionaryRepresentation] isEqualToDictionary:[(MPCustomModule *)object dictionaryRepresentation]];
 }
 
+- (NSUInteger)hash {
+    return [[self dictionaryRepresentation] hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPCustomModule *copyObject = [[[self class] alloc] init];

--- a/mParticle-Apple-SDK/Data Model/MPBreadcrumb.m
+++ b/mParticle-Apple-SDK/Data Model/MPBreadcrumb.m
@@ -42,7 +42,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.uuid hash] ^ [self.sessionUUID hash] ^ [self.breadcrumbData hash];
+    return @(self.breadcrumbId).intValue ^ @(self.timestamp).intValue ^ [self.uuid hash] ^ [self.sessionUUID hash] ^ [self.breadcrumbData hash];
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPBreadcrumb.m
+++ b/mParticle-Apple-SDK/Data Model/MPBreadcrumb.m
@@ -41,6 +41,10 @@
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.uuid hash] ^ [self.sessionUUID hash] ^ [self.breadcrumbData hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPBreadcrumb *copyObject = [[MPBreadcrumb alloc] initWithSessionUUID:[_sessionUUID copy]

--- a/mParticle-Apple-SDK/Data Model/MPBreadcrumb.m
+++ b/mParticle-Apple-SDK/Data Model/MPBreadcrumb.m
@@ -42,7 +42,7 @@
 }
 
 - (NSUInteger)hash {
-    return @(self.breadcrumbId).intValue ^ @(self.timestamp).intValue ^ [self.uuid hash] ^ [self.sessionUUID hash] ^ [self.breadcrumbData hash];
+    return (NSUInteger)self.breadcrumbId ^ (NSUInteger)self.timestamp ^ [self.uuid hash] ^ [self.sessionUUID hash] ^ [self.breadcrumbData hash];
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPConsumerInfo.mm
+++ b/mParticle-Apple-SDK/Data Model/MPConsumerInfo.mm
@@ -48,6 +48,10 @@ NSString *const kMPCKExpiration = @"e";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.name hash];
+}
+
 #pragma mark NSSecureCoding
 - (void)encodeWithCoder:(NSCoder *)coder {
     [coder encodeObject:_name forKey:@"name"];

--- a/mParticle-Apple-SDK/Data Model/MPForwardRecord.mm
+++ b/mParticle-Apple-SDK/Data Model/MPForwardRecord.mm
@@ -174,7 +174,7 @@ NSString *const kMPFROptOutState = @"s";
 }
 
 - (NSUInteger)hash {
-    return [self.dataDictionary hash] ^ [self.mpid hash];
+    return [self.dataDictionary hash] ^ self.forwardRecordId ^ [self.mpid hash];
 }
 
 #pragma mark Public methods

--- a/mParticle-Apple-SDK/Data Model/MPForwardRecord.mm
+++ b/mParticle-Apple-SDK/Data Model/MPForwardRecord.mm
@@ -173,6 +173,10 @@ NSString *const kMPFROptOutState = @"s";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.dataDictionary hash] ^ [self.mpid hash];
+}
+
 #pragma mark Public methods
 - (NSData *)dataRepresentation {
     if (MPIsNull(_dataDictionary) || ![_dataDictionary isKindOfClass:[NSDictionary class]]) {

--- a/mParticle-Apple-SDK/Data Model/MPMessage.m
+++ b/mParticle-Apple-SDK/Data Model/MPMessage.m
@@ -124,7 +124,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ self.messageId ^ @(self.timestamp).intValue ^ [self.messageType hash] ^ [self.messageData hash]  ^ @(self.shouldUploadEvent).intValue;
+    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ self.messageId ^ (NSUInteger)self.timestamp ^ [self.messageType hash] ^ [self.messageData hash]  ^ (NSUInteger)self.shouldUploadEvent;
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPMessage.m
+++ b/mParticle-Apple-SDK/Data Model/MPMessage.m
@@ -123,6 +123,10 @@
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ [self.messageType hash] ^ [self.messageType hash] ^ [self.messageData hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPMessage *copyObject = [[MPMessage alloc] initWithSessionId:[_sessionId copy]

--- a/mParticle-Apple-SDK/Data Model/MPMessage.m
+++ b/mParticle-Apple-SDK/Data Model/MPMessage.m
@@ -124,7 +124,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ [self.messageType hash] ^ [self.messageType hash] ^ [self.messageData hash];
+    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ self.messageId ^ @(self.timestamp).intValue ^ [self.messageType hash] ^ [self.messageData hash]  ^ @(self.shouldUploadEvent).intValue;
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPSegment.m
+++ b/mParticle-Apple-SDK/Data Model/MPSegment.m
@@ -71,6 +71,10 @@ NSString *const kMPSegmentMembershipListKey = @"c";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.segmentId hash] ^ [self.name hash] ^ [self.memberships hash];
+}
+
 #pragma mark KVO
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     if ([keyPath isEqualToString:@"memberships"]) {

--- a/mParticle-Apple-SDK/Data Model/MPSegmentMembership.m
+++ b/mParticle-Apple-SDK/Data Model/MPSegmentMembership.m
@@ -54,6 +54,10 @@ NSString *const kMPSegmentMembershipDrop = @"drop";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return self.segmentMembershipId ^ self.action;
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPSegmentMembership *copyObject = [[MPSegmentMembership alloc] initWithSegmentId:_segmentId

--- a/mParticle-Apple-SDK/Data Model/MPSegmentMembership.m
+++ b/mParticle-Apple-SDK/Data Model/MPSegmentMembership.m
@@ -55,7 +55,7 @@ NSString *const kMPSegmentMembershipDrop = @"drop";
 }
 
 - (NSUInteger)hash {
-    return self.segmentMembershipId ^ @(self.timestamp).intValue ^ self.action;
+    return self.segmentMembershipId ^ (NSUInteger)self.timestamp ^ self.action;
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPSegmentMembership.m
+++ b/mParticle-Apple-SDK/Data Model/MPSegmentMembership.m
@@ -55,7 +55,7 @@ NSString *const kMPSegmentMembershipDrop = @"drop";
 }
 
 - (NSUInteger)hash {
-    return self.segmentMembershipId ^ self.action;
+    return self.segmentMembershipId ^ @(self.timestamp).intValue ^ self.action;
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPSession.m
+++ b/mParticle-Apple-SDK/Data Model/MPSession.m
@@ -108,7 +108,7 @@ NSString *const sessionUUIDKey = @"sessionId";
 }
 
 - (NSUInteger)hash {
-    return [self.uuid hash];
+    return self.sessionId ^ self.eventCounter ^ [self.uuid hash];
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPSession.m
+++ b/mParticle-Apple-SDK/Data Model/MPSession.m
@@ -107,6 +107,10 @@ NSString *const sessionUUIDKey = @"sessionId";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.uuid hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPSession *copyObject = [[MPSession alloc] initWithSessionId:_sessionId

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -57,6 +57,10 @@
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPUpload *copyObject = [[MPUpload alloc] initWithSessionId:[_sessionId copy]

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -58,7 +58,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash];
+    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ self.uploadId ^ @(self.timestamp).intValue;
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -58,7 +58,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ self.uploadId ^ @(self.timestamp).intValue;
+    return [self.sessionId hash] ^ [self.dataPlanId hash] ^ [self.dataPlanVersion hash] ^ self.uploadId ^ (NSUInteger)self.timestamp;
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
+++ b/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
@@ -89,7 +89,7 @@ NSString *const kMPUserNotificationCategoryKey = @"category";
 }
 
 - (NSUInteger)hash {
-    return [self.uuid hash];
+    return @(self.userNotificationId).intValue;
 }
 
 #pragma mark Private methods

--- a/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
+++ b/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
@@ -88,6 +88,10 @@ NSString *const kMPUserNotificationCategoryKey = @"category";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.uuid hash];
+}
+
 #pragma mark Private methods
 - (NSString *)redactUserNotification:(NSDictionary *)notificationDictionary {
     NSString * (^dictionaryToString)(NSDictionary *) = ^(NSDictionary *dictionary) {

--- a/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
+++ b/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
@@ -89,7 +89,7 @@ NSString *const kMPUserNotificationCategoryKey = @"category";
 }
 
 - (NSUInteger)hash {
-    return @(self.userNotificationId).intValue;
+    return (NSUInteger)self.userNotificationId;
 }
 
 #pragma mark Private methods

--- a/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
@@ -340,7 +340,7 @@ static NSArray *actionNames;
 }
 
 - (NSUInteger)hash {
-    return [self.productActionAttributes hash] ^ [self.beautifiedAttributes hash] ^ [self.productsList hash] ^ [self.productImpressions hash] ^ [self.promotionContainer hash] ^ [self.transactionAttributes hash] ^ self->commerceEventKind ^ [self.currency hash];
+    return [self.productActionAttributes hash] ^ [self.beautifiedAttributes hash] ^ [self.productsList hash] ^ [self.productImpressions hash] ^ [self.promotionContainer hash] ^ [self.transactionAttributes hash] ^ commerceEventKind ^ [self.currency hash];
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
@@ -340,7 +340,7 @@ static NSArray *actionNames;
 }
 
 - (NSUInteger)hash {
-    return [self.productActionAttributes hash] ^ [self.beautifiedAttributes hash] ^ [self.productsList hash] ^ [self.productImpressions hash] ^ [self.promotionContainer hash] ^ [self.transactionAttributes hash] ^ [self.currency hash];
+    return [self.productActionAttributes hash] ^ [self.beautifiedAttributes hash] ^ [self.productsList hash] ^ [self.productImpressions hash] ^ [self.promotionContainer hash] ^ [self.transactionAttributes hash] ^ self->commerceEventKind ^ [self.currency hash];
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.mm
@@ -339,6 +339,10 @@ static NSArray *actionNames;
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.productActionAttributes hash] ^ [self.beautifiedAttributes hash] ^ [self.productsList hash] ^ [self.productImpressions hash] ^ [self.promotionContainer hash] ^ [self.transactionAttributes hash] ^ [self.currency hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPCommerceEvent *copyObject = [super copyWithZone:zone];

--- a/mParticle-Apple-SDK/Ecommerce/MPProduct.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPProduct.mm
@@ -99,6 +99,10 @@ NSString *const kMPExpProductTotalAmount = @"Total Product Amount";
     return [_objectDictionary isEqualToDictionary:((MPProduct *)object)->_objectDictionary];
 }
 
+- (NSUInteger)hash {
+    return [self.objectDictionary hash];
+}
+
 #pragma mark Private accessors
 - (NSMutableDictionary<NSString *, id> *)beautifiedAttributes {
     if (_beautifiedAttributes) {

--- a/mParticle-Apple-SDK/Ecommerce/MPPromotion.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPPromotion.mm
@@ -61,6 +61,10 @@ static NSArray *actionNames;
     }
 }
 
+- (NSUInteger)hash {
+    return [self.attributes hash];
+}
+
 #pragma mark Private accessors
 - (NSMutableDictionary<NSString *, NSString *> *)attributes {
     if (_attributes) {
@@ -247,6 +251,10 @@ static NSArray *actionNames;
     }
     
     return isEqual;
+}
+
+- (NSUInteger)hash {
+    return [self.promotionsArray hash];
 }
 
 #pragma mark Private accessors

--- a/mParticle-Apple-SDK/Ecommerce/MPPromotion.mm
+++ b/mParticle-Apple-SDK/Ecommerce/MPPromotion.mm
@@ -254,7 +254,7 @@ static NSArray *actionNames;
 }
 
 - (NSUInteger)hash {
-    return [self.promotionsArray hash];
+    return self.action ^ [self.promotionsArray hash];
 }
 
 #pragma mark Private accessors

--- a/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes.m
+++ b/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes.m
@@ -50,6 +50,10 @@ NSString *const kMPExpTACouponCode = @"Coupon Code";
     return [_attributes isEqualToDictionary:((MPTransactionAttributes *)object)->_attributes];
 }
 
+- (NSUInteger)hash {
+    return [self.attributes hash];
+}
+
 #pragma mark Private accessors
 - (NSMutableDictionary *)attributes {
     if (_attributes) {

--- a/mParticle-Apple-SDK/Event/MPBaseEvent.m
+++ b/mParticle-Apple-SDK/Event/MPBaseEvent.m
@@ -154,7 +154,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.customAttributes hash];
+    return self.type ^ [self.customAttributes hash];
 }
 
 #pragma mark NSCopying

--- a/mParticle-Apple-SDK/Event/MPBaseEvent.m
+++ b/mParticle-Apple-SDK/Event/MPBaseEvent.m
@@ -153,6 +153,10 @@
     return (self.type == object.type) && [self.customAttributes isEqualToDictionary:object.customAttributes];
 }
 
+- (NSUInteger)hash {
+    return [self.customAttributes hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPBaseEvent *copyObject = [[[self class] allocWithZone:zone] init];

--- a/mParticle-Apple-SDK/Event/MPEvent.m
+++ b/mParticle-Apple-SDK/Event/MPEvent.m
@@ -91,6 +91,10 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.name hash] ^ [self.duration hash] ^ [self.category hash];
+}
+
 #pragma mark NSCopying
 - (id)copyWithZone:(NSZone *)zone {
     MPEvent *copyObject = [super copyWithZone:zone];

--- a/mParticle-Apple-SDK/Kits/MPAttributeProjection.m
+++ b/mParticle-Apple-SDK/Kits/MPAttributeProjection.m
@@ -39,7 +39,7 @@
 }
 
 - (NSUInteger)hash {
-    return [super hash];
+    return self.dataType ^ self.required;
 }
 
 #pragma mark NSSecureCoding

--- a/mParticle-Apple-SDK/Kits/MPAttributeProjection.m
+++ b/mParticle-Apple-SDK/Kits/MPAttributeProjection.m
@@ -38,6 +38,10 @@
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [super hash];
+}
+
 #pragma mark NSSecureCoding
 - (void)encodeWithCoder:(NSCoder *)coder {
     [super encodeWithCoder:coder];

--- a/mParticle-Apple-SDK/Kits/MPBaseProjection.m
+++ b/mParticle-Apple-SDK/Kits/MPBaseProjection.m
@@ -130,7 +130,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.name hash] ^ [self.projectedName hash];
+    return [self.name hash] ^ [self.projectedName hash] ^ self.matchType ^ self.projectionType;
 }
 
 - (NSString *)description {

--- a/mParticle-Apple-SDK/Kits/MPBaseProjection.m
+++ b/mParticle-Apple-SDK/Kits/MPBaseProjection.m
@@ -129,6 +129,10 @@
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.name hash] ^ [self.projectedName hash];
+}
+
 - (NSString *)description {
     NSMutableString *description = [[NSMutableString alloc] init];
     

--- a/mParticle-Apple-SDK/Kits/MPEventProjection.mm
+++ b/mParticle-Apple-SDK/Kits/MPEventProjection.mm
@@ -183,7 +183,7 @@ using namespace std;
 }
 
 - (NSUInteger)hash {
-    return [self.projectionMatches hash];
+    return [self.projectionMatches hash] ^ self.messageType ^ self.maxCustomParameters ^ self.appendAsIs ^ self.isDefault ^ [self.attributeProjections hash];
 }
 
 #pragma mark NSSecureCoding

--- a/mParticle-Apple-SDK/Kits/MPEventProjection.mm
+++ b/mParticle-Apple-SDK/Kits/MPEventProjection.mm
@@ -20,6 +20,10 @@ using namespace std;
     return isEqual;
 }
 
+- (NSUInteger)hash {
+    return [self.attributeKey hash] ^ [self.attributeValues hash];
+}
+
 #pragma mark NSSecureCoding
 - (void)encodeWithCoder:(NSCoder *)coder {
     if (self.attributeKey) {
@@ -176,6 +180,10 @@ using namespace std;
     }
     
     return isEqual;
+}
+
+- (NSUInteger)hash {
+    return [self.projectionMatches hash];
 }
 
 #pragma mark NSSecureCoding

--- a/mParticle-Apple-SDK/Kits/MPKitConfiguration.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitConfiguration.mm
@@ -99,6 +99,10 @@
     return [_configurationHash isEqualToNumber:object.configurationHash];
 }
 
+- (NSUInteger)hash {
+    return [self.configurationHash hash];
+}
+
 #pragma mark NSSecureCoding
 - (void)encodeWithCoder:(NSCoder *)coder {
     [coder encodeObject:self.configurationDictionary forKey:@"configurationDictionary"];


### PR DESCRIPTION
## Summary
All instances where `isEqual:` implemented should also implement `hash`

## Testing Plan
Ran sample app and unit tests

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4834
