### PR TITLE
fix: Remove unnecessary calls to remove observer

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitActivity.m
+++ b/mParticle-Apple-SDK/Kits/MPKitActivity.m
@@ -58,12 +58,6 @@
     return self;
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:mParticleKitDidBecomeActiveNotification
-                                                  object:nil];
-}
-
 #pragma mark Private accessors
 - (NSMutableArray<MPKitActivityMapping *> *)activityMappings {
     if (!_activityMappings) {

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -125,12 +125,6 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     return self;
 }
 
-- (void)dealloc {
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationDidFinishLaunchingNotification object:nil];
-}
-
 #pragma mark Notification handlers
 - (void)handleApplicationDidBecomeActive:(NSNotification *)notification {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -167,19 +167,6 @@ static BOOL appBackgrounded = NO;
 }
 
 - (void)dealloc {
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationDidFinishLaunchingNotification object:nil];
-    [notificationCenter removeObserver:self name:kMPNetworkPerformanceMeasurementNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationWillResignActiveNotification object:nil];
-    
-#if TARGET_OS_IOS == 1
-    [notificationCenter removeObserver:self name:kMPRemoteNotificationDeviceTokenNotification object:nil];
-#endif
-    
     [self endUploadTimer];
 }
 

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.mm
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.mm
@@ -139,12 +139,6 @@ static BOOL runningInBackground = NO;
 }
 
 - (void)dealloc {
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationWillTerminateNotification object:nil];
-    [notificationCenter removeObserver:self name:MParticleReachabilityChangedNotification object:nil];
-    
     if (_reachability != nil) {
         [_reachability stopNotifier];
     }

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -320,12 +320,6 @@ NSString *const kMPStateKey = @"state";
     return self;
 }
 
-- (void)dealloc {
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
-    [notificationCenter removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
-}
-
 #pragma mark Private accessors
 - (NSMutableDictionary *)configSettings {
     if (_configSettings) {


### PR DESCRIPTION
## Summary
Remove calls to removeObserver no longer necessary now that we no longer support iOS 8

## Testing Plan
Validated per Apple [docs](https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver) that this is no longer necessary since observer will be removed automatically.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4830
