### PR TITLE
fix: Remove Unnecessary Synchronize in Dealloc

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPApplication.m
+++ b/mParticle-Apple-SDK/Utils/MPApplication.m
@@ -77,7 +77,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 @interface MPApplication() {
     NSDictionary *appInfo;
     MPIUserDefaults *userDefaults;
-    BOOL syncUserDefaults;
 }
 
 @end
@@ -98,19 +97,10 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     }
     
     userDefaults = [MPIUserDefaults standardUserDefaults];
-    syncUserDefaults = NO;
     
     _dyld_register_func_for_add_image(addImageListCallback);
     
     return self;
-}
-
-- (void)dealloc {
-    if (syncUserDefaults) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[MPIUserDefaults standardUserDefaults] synchronize];
-        });
-    }
 }
 
 - (NSString *)description {
@@ -200,7 +190,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     if (_initialLaunchTime == nil) {
         _initialLaunchTime = MPCurrentEpochInMilliseconds;
         userDefaults[kMPAppInitialLaunchTimeKey] = _initialLaunchTime;
-        syncUserDefaults = YES;
     }
     
     return _initialLaunchTime;
@@ -222,7 +211,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 
 - (void)setLastUseDate:(NSNumber *)lastUseDate {
     userDefaults[kMPAppLastUseDateKey] = lastUseDate;
-    syncUserDefaults = YES;
 }
 
 - (NSNumber *)launchCount {
@@ -232,7 +220,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 
 - (void)setLaunchCount:(NSNumber *)launchCount {
     userDefaults[kMPAppLaunchCountKey] = launchCount;
-    syncUserDefaults = YES;
 }
 
 - (NSNumber *)launchCountSinceUpgrade {
@@ -242,7 +229,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 
 - (void)setLaunchCountSinceUpgrade:(NSNumber *)launchCountSinceUpgrade {
     userDefaults[kMPAppLaunchCountSinceUpgradeKey] = launchCountSinceUpgrade;
-    syncUserDefaults = YES;
 }
 
 - (NSNumber *)pirated {
@@ -261,8 +247,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     } else {
         [userDefaults removeMPObjectForKey:kMPAppStoredBuildKey];
     }
-    
-    syncUserDefaults = YES;
 }
 
 - (NSString *)storedVersion {
@@ -276,8 +260,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     } else {
         [userDefaults removeMPObjectForKey:kMPAppStoredVersionKey];
     }
-    
-    syncUserDefaults = YES;
 }
 
 - (NSNumber *)upgradeDate {
@@ -287,7 +269,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 
 - (void)setUpgradeDate:(NSNumber *)upgradeDate {
     userDefaults[kMPAppUpgradeDateKey] = upgradeDate;
-    syncUserDefaults = YES;
 }
 
 - (NSString *)version {
@@ -321,7 +302,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     if (![MPStateMachine isAppExtension]) {
         MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
         userDefaults[kMPAppBadgeNumberKey] = badgeNumber;
-        syncUserDefaults = YES;
     }
 }
 #endif


### PR DESCRIPTION
## Summary
Inspected all uses of dealloc method

MPApplication
Removed as synchronize has been unneeded since iOS 7

MPBackendController
 Our in-app documentation provides full reasoning for this code as it supports our proxying of the app delegate.

MPSegment
[Apple Docs](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/KeyValueObserving/Articles/KVOBasics.html) (_"A typical pattern is to register as an observer during the observer’s initialization (for example in init or viewDidLoad) and unregister during deallocation (usually in dealloc)"_) actually suggest including your removeObserver code in the dealloc: method. Adding the observer doesn’t cause a retain on the class object and using instruments I wasn’t able to find any leaks. If you have a .trace recorded from instruments showing it, that would be a huge help.

MParticleReachability & MPStateMachine by extension
This is the [standard shared reachability code written by Apple](https://developer.apple.com/library/archive/samplecode/Reachability/Listings/Reachability_Reachability_m.html#//apple_ref/doc/uid/DTS40007324-Reachability_Reachability_m-DontLinkElementID_9) used across multiple organizations.  I agree we should update to the [swift version](https://github.com/ashleymills/Reachability.swift) when we update fully to Swift but for now it is appropriate to use.

## Testing Plan
Ran through unit tests and putting code through its paces in a sample application. Also tested for leaks through instruments.

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4831
