### PR TITLE
fix: Move _dyld_register_func_for_add_image call to initialize

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPApplication.m
+++ b/mParticle-Apple-SDK/Utils/MPApplication.m
@@ -90,6 +90,12 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 @synthesize initialLaunchTime = _initialLaunchTime;
 @synthesize pirated = _pirated;
 
++ (void)initialize {
+    if (self == [MPApplication class]) {
+        _dyld_register_func_for_add_image(addImageListCallback);
+    }
+}
+
 - (id)init {
     self = [super init];
     if (!self) {
@@ -97,8 +103,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     }
     
     userDefaults = [MPIUserDefaults standardUserDefaults];
-    
-    _dyld_register_func_for_add_image(addImageListCallback);
     
     return self;
 }


### PR DESCRIPTION
## Summary
We use `_dyld_register_func_for_add_image` to register a callback function to receive a list of all loaded dynamic libraries. We are using this to include that information with error and exception reports from customers when they call the -[MParticle logError] or -[MParticle logException] methods.

Previously we registered this callback in the `init` method of `MPApplication`, however that object may be initialized many times during the course of an app session. This can cause a high number of unnecessary function pointer allocations to the callback function.

I've moved this to the `initialize` method so that it will only be called once per app session, which is all we need. This will resolve the allocations issue as it will now only allocate a single pointer.

## Testing Plan
Tested in a sample app to confirm that the registration caused no issues and that calling `appImageInfo` returns the same list of dylib info as before.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4825
