### PR TITLE
feat: Add wrapper sdk info setter

### DIFF
--- a/mParticle-Apple-SDK/Include/MPEnums.h
+++ b/mParticle-Apple-SDK/Include/MPEnums.h
@@ -440,6 +440,15 @@ typedef NS_ENUM(NSUInteger, MPIdentityErrorResponseCode) {
     MPIdentityErrorResponseCodeRetry = 429
 };
 
+typedef NS_ENUM(NSUInteger, MPWrapperSdk) {
+    MPWrapperSdkNone = 0,
+    MPWrapperSdkUnity = 1,
+    MPWrapperSdkReactNative = 2,
+    MPWrapperSdkCordova = 3,
+    MPWrapperSdkXamarin = 4,
+    MPWrapperSdkFlutter = 5
+};
+
 /**
  @see https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/authorizationstatus
  */

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -1132,7 +1132,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 /**
  Internal use only. Used by our wrapper SDKs to identify themselves during initialization.
  */
-+ (void)setWrapperSdk:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion;
++ (void)_setWrapperSdk_internal:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion;
 
 @end
 

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -1127,6 +1127,13 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 
 #endif
 
+#pragma mark - Wrapper SDK Information
+
+/**
+ Internal use only. Used by our wrapper SDKs to identify themselves during initialization.
+ */
++ (void)setWrapperSdk:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -1860,7 +1860,7 @@ NSString *const kMPStateKey = @"state";
 /**
  Internal use only. Used by our wrapper SDKs to identify themselves during initialization.
  */
-+ (void)setWrapperSdk:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion {
++ (void)_setWrapperSdk_internal:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion {
     static dispatch_once_t predicate;
     dispatch_once(&predicate, ^{
         _wrapperSdk = wrapperSdk;

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -36,6 +36,9 @@ static NSArray *eventTypeStrings = nil;
 static MParticle *_sharedInstance = nil;
 static dispatch_once_t predicate;
 
+static MPWrapperSdk _wrapperSdk = MPWrapperSdkNone;
+static NSString *_wrapperSdkVersion = nil;
+
 NSString *const kMPEventNameLogTransaction = @"Purchase";
 NSString *const kMPEventNameLTVIncrease = @"Increase LTV";
 NSString *const kMParticleFirstRun = @"firstrun";
@@ -1851,5 +1854,18 @@ NSString *const kMPStateKey = @"state";
     [self.backendController logUserNotification:userNotification];
 }
 #endif
+
+#pragma mark - Wrapper SDK Information
+
+/**
+ Internal use only. Used by our wrapper SDKs to identify themselves during initialization.
+ */
++ (void)setWrapperSdk:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion {
+    static dispatch_once_t predicate;
+    dispatch_once(&predicate, ^{
+        _wrapperSdk = wrapperSdk;
+        _wrapperSdkVersion = wrapperSdkVersion;
+    });
+}
 
 @end


### PR DESCRIPTION
## Summary
Add ability for wrapper SDKs to set their name and version on the core SDK.

## Testing Plan
Tested locally.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4756
