### PR TITLE
feat: Block writes on invalid API key based on Identity/Config responses

### DIFF
--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -1579,6 +1579,12 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)logBaseEvent:(MPBaseEvent *)event completionHandler:(void (^)(MPBaseEvent *event, MPExecStatus execStatus))completionHandler {
+    if (![MPStateMachine canWriteMessagesToDB]) {
+        MPILogError(@"Not saving message for event to prevent excessive local database growth because API Key appears to be invalid based on server response");
+        completionHandler(event, MPExecStatusFail);
+        return;
+    }
+    
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:event];
     
     if (event.shouldBeginSession) {
@@ -1829,6 +1835,10 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)saveMessage:(MPMessage *)message updateSession:(BOOL)updateSession {
+    if (![MPStateMachine canWriteMessagesToDB]) {
+        MPILogError(@"Not saving message for event to prevent excessive local database growth because API Key appears to be invalid based on server response");
+        return;
+    }
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -426,6 +426,12 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     NSInteger responseCode = [httpResponse statusCode];
     MPILogVerbose(@"Config Response Code: %ld, Execution Time: %.2fms", (long)responseCode, ([[NSDate date] timeIntervalSince1970] - start) * 1000.0);
     
+    if (responseCode == HTTPStatusCodeForbidden) {
+        [MPStateMachine setCanWriteMessagesToDB:NO];
+    } else {
+        [MPStateMachine setCanWriteMessagesToDB:YES];
+    }
+    
     if (responseCode == HTTPStatusCodeNotModified) {
         MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
         [userDefaults setConfiguration:[userDefaults getConfiguration] eTag:userDefaults[kMPHTTPETagHeaderKey] requestTimestamp:[[NSDate date] timeIntervalSince1970] currentAge:ageString maxAge:maxAge];

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -1557,6 +1557,9 @@ const int MaxBreadcrumbs = 50;
 }
 
 - (void)saveMessage:(MPMessage *)message {
+    if (![MPStateMachine canWriteMessagesToDB]) {
+        return;
+    }
     if (!message.shouldUploadEvent) {
         MPILogDebug(@"Not saving message for event because shouldUploadEvent was set to NO, message id: %lld, type: %@", message.messageId, message.messageType);
         return;

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -1558,6 +1558,7 @@ const int MaxBreadcrumbs = 50;
 
 - (void)saveMessage:(MPMessage *)message {
     if (![MPStateMachine canWriteMessagesToDB]) {
+        MPILogError(@"Not saving message for event to prevent excessive local database growth because API Key appears to be invalid based on server response");
         return;
     }
     if (!message.shouldUploadEvent) {

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -60,6 +60,8 @@
 + (BOOL)runningInBackground;
 + (void)setRunningInBackground:(BOOL)background;
 + (BOOL)isAppExtension;
++ (BOOL)canWriteMessagesToDB;
++ (void)setCanWriteMessagesToDB:(BOOL)canWriteMessagesToDB;
 - (void)configureCustomModules:(nullable NSArray<NSDictionary *> *)customModuleSettings;
 - (void)configureRampPercentage:(nullable NSNumber *)rampPercentage;
 - (void)configureTriggers:(nullable NSDictionary *)triggerDictionary;

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.mm
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.mm
@@ -29,6 +29,7 @@ NSString *const kMPStateKey = @"state";
 
 static MPEnvironment runningEnvironment = MPEnvironmentAutoDetect;
 static BOOL runningInBackground = NO;
+static BOOL _canWriteMessagesToDB = YES;
 
 @interface MParticle ()
 + (dispatch_queue_t)messageQueue;
@@ -340,6 +341,18 @@ static BOOL runningInBackground = NO;
 #else
     return NO;
 #endif
+}
+
++ (BOOL)canWriteMessagesToDB {
+    @synchronized(self) {
+        return _canWriteMessagesToDB;
+    }
+}
+
++ (void)setCanWriteMessagesToDB:(BOOL)canWriteMessagesToDB {
+    @synchronized(self) {
+        _canWriteMessagesToDB = canWriteMessagesToDB;
+    }
 }
 
 #pragma mark Public accessors


### PR DESCRIPTION
## Summary
Prevent storage of the SDK from growing indefinitely if we don't have a valid key and thus can't upload

## Testing Plan
Tested using an iOS sample app with an invalid key and secret

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4796
