### PR TITLE
fix: Identify API call using CNAME domain

### DIFF
--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -771,18 +771,24 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     
     MPILogVerbose(@"Identity request:\nURL: %@ \nBody:%@", url, jsonRequest);
     
-    MPEndpoint endpointType = MPEndpointIdentityModify;
+    MPEndpoint endpointType;
+    MPURL *mpURL;
     if ([self.identifyURL.url.absoluteString isEqualToString:url.absoluteString]) {
         endpointType = MPEndpointIdentityIdentify;
+        mpURL = self.identifyURL;
     } else if ([self.loginURL.url.absoluteString isEqualToString:url.absoluteString ]) {
         endpointType = MPEndpointIdentityLogin;
+        mpURL = self.loginURL;
     } else if ([self.logoutURL.url.absoluteString isEqualToString:url.absoluteString]) {
         endpointType = MPEndpointIdentityLogout;
+        mpURL = self.logoutURL;
+    } else {
+        endpointType = MPEndpointIdentityModify;
+        mpURL = self.modifyURL;
     }
     [MPListenerController.sharedInstance onNetworkRequestStarted:endpointType url:url.absoluteString body:data];
 
     NSObject<MPConnectorProtocol> *connector = [self makeConnector];
-    MPURL *mpURL = [[MPURL alloc] initWithURL:url defaultURL:url];
     NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:mpURL
                                                                     message:nil
                                                            serializedParams:data];


### PR DESCRIPTION
 ## Summary
 - Fix identify API call using CNAME domain

 ## Testing Plan
- Tested locally using a test app with custom CNAME domains that previously didn't work

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5025
