### PR TITLE
fix: Correct location flag issue when publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ To integrate the SDK using CocoaPods, specify it in your [Podfile](https://guide
 
 target '<Your Target>' do
     pod 'mParticle-Apple-SDK', '~> 8'
-    # If you'd like to use a version of the SDK that doesn't include any location libraries automatically use this subspec'
+    
+    # If you'd like to use a version of the SDK that doesn't include any location libraries automatically use this subspec:
     # pod 'mParticle-Apple-SDK/mParticleNoLocation', '~> 8'
 end
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To integrate the SDK using CocoaPods, specify it in your [Podfile](https://guide
 
 target '<Your Target>' do
     pod 'mParticle-Apple-SDK', '~> 8'
+    # If you'd like to use a version of the SDK that doesn't include any location libraries automatically use this subspec'
+    # pod 'mParticle-Apple-SDK/mParticleNoLocation', '~> 8'
 end
 ```
 

--- a/mParticle-Apple-SDK.podspec
+++ b/mParticle-Apple-SDK.podspec
@@ -49,8 +49,11 @@ Pod::Spec.new do |s|
         ss.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         ss.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp}'
         ss.libraries            = 'c++', 'sqlite3', 'z'
-
+        #ifndef MPARTICLE_LOCATION_DISABLE
         ss.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+        #else
+        ss.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+        #endif
         ss.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ss.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
@@ -62,8 +65,11 @@ Pod::Spec.new do |s|
         ext.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         ext.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp}'
         ext.libraries            = 'c++', 'sqlite3', 'z'
-
+        #ifndef MPARTICLE_LOCATION_DISABLE
         ext.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+        #else
+        ext.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+        #endif
         ext.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ext.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'

--- a/mParticle-Apple-SDK.podspec
+++ b/mParticle-Apple-SDK.podspec
@@ -65,6 +65,11 @@ Pod::Spec.new do |s|
         ss.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ss.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+
+        ss.pod_target_xcconfig  = {
+            'GCC_PREPROCESSOR_DEFINITIONS' => 'MPARTICLE_LOCATION_DISABLE=1',
+            'OTHER_SWIFT_FLAGS' => '-D MPARTICLE_LOCATION_DISABLE=1'
+        }
     end
 
     s.subspec 'AppExtension' do |ext|
@@ -89,6 +94,11 @@ Pod::Spec.new do |s|
         ext.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ext.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+
+        ext.pod_target_xcconfig  = {
+            'GCC_PREPROCESSOR_DEFINITIONS' => 'MPARTICLE_LOCATION_DISABLE=1',
+            'OTHER_SWIFT_FLAGS' => '-D MPARTICLE_LOCATION_DISABLE=1'
+        }
     end
 end
 

--- a/mParticle-Apple-SDK.podspec
+++ b/mParticle-Apple-SDK.podspec
@@ -49,11 +49,19 @@ Pod::Spec.new do |s|
         ss.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         ss.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp}'
         ss.libraries            = 'c++', 'sqlite3', 'z'
-        #ifndef MPARTICLE_LOCATION_DISABLE
         ss.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
-        #else
+        ss.ios.weak_frameworks  = 'iAd', 'UserNotifications'
+
+        ss.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+    end
+    
+    s.subspec 'mParticleNoLocation' do |ss|
+        ss.public_header_files = `./Scripts/find_headers.rb --public`.split("\n")
+
+        ss.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
+        ss.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp}'
+        ss.libraries            = 'c++', 'sqlite3', 'z'
         ss.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
-        #endif
         ss.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ss.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
@@ -65,11 +73,19 @@ Pod::Spec.new do |s|
         ext.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         ext.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp}'
         ext.libraries            = 'c++', 'sqlite3', 'z'
-        #ifndef MPARTICLE_LOCATION_DISABLE
         ext.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
-        #else
+        ext.ios.weak_frameworks  = 'iAd', 'UserNotifications'
+
+        ext.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
+    end
+    
+    s.subspec 'AppExtensionNoLocation' do |ext|
+        ext.public_header_files = `./Scripts/find_headers.rb --public`.split("\n")
+
+        ext.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
+        ext.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp}'
+        ext.libraries            = 'c++', 'sqlite3', 'z'
         ext.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
-        #endif
         ext.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ext.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -7,7 +7,9 @@
 #import <UIKit/UIKit.h>
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     #import <CoreLocation/CoreLocation.h>
+#endif
 #endif
 
 @class MPCommerceEvent;
@@ -66,9 +68,11 @@
 
 #pragma mark Location tracking
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (nonnull MPKitExecStatus *)beginLocationTracking:(CLLocationAccuracy)accuracy minDistance:(CLLocationDistance)distanceFilter;
 - (nonnull MPKitExecStatus *)endLocationTracking;
 - (nonnull MPKitExecStatus *)setLocation:(nonnull CLLocation *)location;
+#endif
 #endif
 
 #pragma mark Session management

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -26,7 +26,9 @@
 #import <UIKit/UIKit.h>
 
 #if TARGET_OS_IOS == 1
-    #import <CoreLocation/CoreLocation.h>
+    #ifndef MPARTICLE_LOCATION_DISABLE
+        #import <CoreLocation/CoreLocation.h>
+    #endif
     #import <WebKit/WebKit.h>
 #endif
 
@@ -980,6 +982,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  */
 @property (nonatomic) BOOL backgroundLocationTracking;
 
+#ifndef MPARTICLE_LOCATION_DISABLE
 /**
  Gets/Sets the current location of the active session.
  @see beginLocationTracking:minDistance:
@@ -1015,6 +1018,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  Ends geographic location tracking.
  */
 - (void)endLocationTracking;
+#endif
 #endif
 
 #pragma mark - Network Performance

--- a/mParticle-Apple-SDK/Location/MPLocationManager.h
+++ b/mParticle-Apple-SDK/Location/MPLocationManager.h
@@ -10,9 +10,7 @@
 
 #if TARGET_OS_IOS == 1
 @property (nonatomic, strong, nullable) CLLocation *location;
-#ifndef MPARTICLE_LOCATION_DISABLE
 @property (nonatomic, strong, nullable) CLLocationManager *locationManager;
-#endif
 @property (nonatomic, readonly) MPLocationAuthorizationRequest authorizationRequest;
 @property (nonatomic, readonly) CLLocationAccuracy requestedAccuracy;
 @property (nonatomic, readonly) CLLocationDistance requestedDistanceFilter;

--- a/mParticle-Apple-SDK/Location/MPLocationManager.h
+++ b/mParticle-Apple-SDK/Location/MPLocationManager.h
@@ -1,3 +1,4 @@
+#ifndef MPARTICLE_LOCATION_DISABLE
 #import <Foundation/Foundation.h>
 #import "MPEnums.h"
 
@@ -24,3 +25,4 @@
 + (BOOL)trackingLocation;
 
 @end
+#endif

--- a/mParticle-Apple-SDK/Location/MPLocationManager.m
+++ b/mParticle-Apple-SDK/Location/MPLocationManager.m
@@ -2,14 +2,11 @@
 #import "MPLocationManager.h"
 #import <UIKit/UIKit.h>
 
-static BOOL trackingLocation = NO;
+static BOOL _trackingLocation = NO;
 
 #if TARGET_OS_IOS == 1
-#ifndef MPARTICLE_LOCATION_DISABLE
 @interface MPLocationManager () <CLLocationManagerDelegate>
-
 @end
-#endif
 #endif
 
 @implementation MPLocationManager
@@ -18,7 +15,6 @@ static BOOL trackingLocation = NO;
 - (instancetype)initWithAccuracy:(CLLocationAccuracy)accuracy distanceFilter:(CLLocationDistance)distance authorizationRequest:(MPLocationAuthorizationRequest)authorizationRequest {
     self = [super init];
     
-#ifndef MPARTICLE_LOCATION_DISABLE
     CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
     
     if (!self || authorizationStatus == kCLAuthorizationStatusRestricted || authorizationStatus == kCLAuthorizationStatusDenied) {
@@ -47,23 +43,21 @@ static BOOL trackingLocation = NO;
     } else {
         [self.locationManager startUpdatingLocation];
     }
-#endif
     
     _authorizationRequest = authorizationRequest;
     _requestedAccuracy = accuracy;
     _requestedDistanceFilter = distance;
-    trackingLocation = NO;
+    _trackingLocation = NO;
     _backgroundLocationTracking = YES;
     
     return self;
 }
 
-#ifndef MPARTICLE_LOCATION_DISABLE
 #pragma mark CLLocationManager Delegate
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    trackingLocation = (status == kCLAuthorizationStatusAuthorizedAlways) || (status == kCLAuthorizationStatusAuthorizedWhenInUse);
+    _trackingLocation = (status == kCLAuthorizationStatusAuthorizedAlways) || (status == kCLAuthorizationStatusAuthorizedWhenInUse);
     
-    if (trackingLocation) {
+    if (_trackingLocation) {
         [self.locationManager startUpdatingLocation];
     }
 }
@@ -74,11 +68,9 @@ static BOOL trackingLocation = NO;
     self.location = newLocation;
 }
 #pragma clang diagnostic pop
-#endif
 
 #pragma mark Public accessors
 - (CLLocationManager *)locationManager {
-#ifndef MPARTICLE_LOCATION_DISABLE
     if (_locationManager) {
         return _locationManager;
     }
@@ -88,7 +80,7 @@ static BOOL trackingLocation = NO;
         if (_locationManager) {
             _locationManager = nil;
             _location = nil;
-            trackingLocation = NO;
+            _trackingLocation = NO;
         }
         
         return nil;
@@ -99,30 +91,21 @@ static BOOL trackingLocation = NO;
     _locationManager.delegate = self;
     [self didChangeValueForKey:@"locationManager"];
     return _locationManager;
-#else
-    return nil;
-#endif
 }
 
 #pragma mark Public methods
 - (void)endLocationTracking {
-#ifndef MPARTICLE_LOCATION_DISABLE
     [_locationManager stopUpdatingLocation];
     _locationManager = nil;
-#endif
     
     _location = nil;
-    trackingLocation = NO;
+    _trackingLocation = NO;
 }
 #endif // #if TARGET_OS_IOS == 1
 
 #pragma mark Class methods
 + (BOOL)trackingLocation {
-#ifndef MPARTICLE_LOCATION_DISABLE
-    return trackingLocation;
-#else
-    return NO;
-#endif
+    return _trackingLocation;
 }
 
 @end

--- a/mParticle-Apple-SDK/Location/MPLocationManager.m
+++ b/mParticle-Apple-SDK/Location/MPLocationManager.m
@@ -1,3 +1,4 @@
+#ifndef MPARTICLE_LOCATION_DISABLE
 #import "MPLocationManager.h"
 #import <UIKit/UIKit.h>
 
@@ -125,3 +126,4 @@ static BOOL trackingLocation = NO;
 }
 
 @end
+#endif

--- a/mParticle-Apple-SDK/MPBackendController.h
+++ b/mParticle-Apple-SDK/MPBackendController.h
@@ -3,7 +3,9 @@
 
 #if TARGET_OS_IOS == 1
     #import "MPNotificationController.h"
-    #import <CoreLocation/CoreLocation.h>
+    #ifndef MPARTICLE_LOCATION_DISABLE
+        #import <CoreLocation/CoreLocation.h>
+    #endif
 
     @class MParticleUserNotification;
 #endif
@@ -105,8 +107,10 @@ extern const NSInteger kInvalidKey;
 - (nonnull NSMutableArray<NSDictionary<NSString *, id> *> *)userIdentitiesForUserId:(nonnull NSNumber *)userId;
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (MPExecStatus)beginLocationTrackingWithAccuracy:(CLLocationAccuracy)accuracy distanceFilter:(CLLocationDistance)distance authorizationRequest:(MPLocationAuthorizationRequest)authorizationRequest;
 - (MPExecStatus)endLocationTracking;
+#endif
 - (void)handleDeviceTokenNotification:(nonnull NSNotification *)notification;
 - (void)logUserNotification:(nonnull MParticleUserNotification *)userNotification;
 #endif

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -34,7 +34,9 @@
 #import "MPDevice.h"
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 #import "MPLocationManager.h"
+#endif
 #endif
 
 const NSInteger kNilAttributeValue = 101;
@@ -286,7 +288,9 @@ static BOOL appBackgrounded = NO;
         
         MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeSessionEnd session:session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
         messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
         message = [[messageBuilder withTimestamp:session.endTime] build];
         
@@ -461,7 +465,9 @@ static BOOL appBackgrounded = NO;
         }
         MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeAppStateTransition session:self.session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
         messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
         messageBuilder = [messageBuilder withStateTransition:YES previousSession:nil];
         MPMessage *message = [messageBuilder build];
@@ -850,8 +856,8 @@ static BOOL skipNextUpload = NO;
         if ([MPLocationManager trackingLocation] && ![MParticle sharedInstance].stateMachine.locationManager.backgroundLocationTracking) {
             [[MParticle sharedInstance].stateMachine.locationManager.locationManager stopUpdatingLocation];
         }
-#endif
         messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
         MPMessage *message = [messageBuilder build];
         
@@ -975,7 +981,9 @@ static BOOL skipNextUpload = NO;
         previousForegroundTime = MPCurrentEpochInMilliseconds;
         messageBuilder = [messageBuilder withStateTransition:sessionExpired previousSession:nil];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
         messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
         MPMessage *message = [messageBuilder build];
         [self saveMessage:message updateSession:YES];
@@ -1198,7 +1206,9 @@ static BOOL skipNextUpload = NO;
         
         MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeSessionStart session:_session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
         messageBuilder = [messageBuilder withLocation:stateMachine.location];
+#endif
 #endif
         MPMessage *message = [[messageBuilder withTimestamp:_session.startTime] build];
         
@@ -1500,7 +1510,9 @@ static BOOL skipNextUpload = NO;
     
     MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeCrashReport session:self.session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
     MPMessage *errorMessage = [messageBuilder build];
     
@@ -1599,7 +1611,9 @@ static BOOL skipNextUpload = NO;
                 [messageBuilder withTimestamp:[event.timestamp timeIntervalSince1970]];
             }
         #if TARGET_OS_IOS == 1
+        #ifndef MPARTICLE_LOCATION_DISABLE
             messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+        #endif
         #endif
             MPMessage *message = [messageBuilder build];
             message.shouldUploadEvent = event.shouldUploadEvent;
@@ -1649,7 +1663,9 @@ static BOOL skipNextUpload = NO;
     
     MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeNetworkPerformance session:self.session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
     MPMessage *message = [messageBuilder build];
     
@@ -1682,7 +1698,9 @@ static BOOL skipNextUpload = NO;
         [messageBuilder withTimestamp:[event.timestamp timeIntervalSince1970]];
     }
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
     MPMessage *message = [messageBuilder build];
     message.shouldUploadEvent = event.shouldUploadEvent;
@@ -1710,7 +1728,9 @@ static BOOL skipNextUpload = NO;
         
         MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeOptOut session:self.session messageInfo:@{kMPOptOutStatus:(optOutStatus ? @"true" : @"false")}];
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
         messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
 #endif
         MPMessage *message = [messageBuilder build];
         
@@ -2136,6 +2156,7 @@ static BOOL skipNextUpload = NO;
 }
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (MPExecStatus)beginLocationTrackingWithAccuracy:(CLLocationAccuracy)accuracy distanceFilter:(CLLocationDistance)distance authorizationRequest:(MPLocationAuthorizationRequest)authorizationRequest {
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:@(accuracy) parameter2:@(distance) parameter3:@(authorizationRequest)];
     
@@ -2162,6 +2183,7 @@ static BOOL skipNextUpload = NO;
     
     return MPExecStatusSuccess;
 }
+#endif
 
 - (MPNotificationController *)notificationController {
     return _notificationController;
@@ -2244,7 +2266,9 @@ static BOOL skipNextUpload = NO;
     }
     
     MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypePushNotification session:_session messageInfo:messageInfo];
+#ifndef MPARTICLE_LOCATION_DISABLE
     messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+#endif
     MPMessage *message = [messageBuilder build];
     
     [self saveMessage:message updateSession:(_session != nil)];

--- a/mParticle-Apple-SDK/Utils/MPCurrentState.m
+++ b/mParticle-Apple-SDK/Utils/MPCurrentState.m
@@ -205,7 +205,7 @@ NSString *const kMPStateFreeDiskSpaceKey = @"fds";
     }
     return _statusBarOrientation;
 }
-#endif
+#endif // TARGET_OS_IOS
 
 #pragma mark Public instance methods
 - (NSDictionary<NSString *, id> *)dictionaryRepresentation {

--- a/mParticle-Apple-SDK/Utils/MPCurrentState.m
+++ b/mParticle-Apple-SDK/Utils/MPCurrentState.m
@@ -190,7 +190,7 @@ NSString *const kMPStateFreeDiskSpaceKey = @"fds";
 }
 
 - (NSNumber *)gpsState {
-    BOOL gpsState = false;
+    BOOL gpsState = NO;
 #ifndef MPARTICLE_LOCATION_DISABLE
     gpsState = [CLLocationManager authorizationStatus] && [CLLocationManager locationServicesEnabled];
 #endif

--- a/mParticle-Apple-SDK/Utils/MPCurrentState.m
+++ b/mParticle-Apple-SDK/Utils/MPCurrentState.m
@@ -188,7 +188,10 @@ NSString *const kMPStateFreeDiskSpaceKey = @"fds";
 }
 
 - (NSNumber *)gpsState {
-    BOOL gpsState = [CLLocationManager authorizationStatus] && [CLLocationManager locationServicesEnabled];
+    BOOL gpsState = false;
+#ifndef MPARTICLE_LOCATION_DISABLE
+    gpsState = [CLLocationManager authorizationStatus] && [CLLocationManager locationServicesEnabled];
+#endif
     return @(gpsState);
 }
 

--- a/mParticle-Apple-SDK/Utils/MPCurrentState.m
+++ b/mParticle-Apple-SDK/Utils/MPCurrentState.m
@@ -5,7 +5,9 @@
 #import "mParticle.h"
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     #import <CoreLocation/CoreLocation.h>
+#endif
 #endif
 
 NSString *const kMPStateInformationKey = @"cs";

--- a/mParticle-Apple-SDK/Utils/MPMessageBuilder.h
+++ b/mParticle-Apple-SDK/Utils/MPMessageBuilder.h
@@ -2,7 +2,9 @@
 #import "MPIConstants.h"
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     #import <CoreLocation/CoreLocation.h>
+#endif
 #endif
 
 @class MPSession;
@@ -47,7 +49,9 @@
 - (nonnull MPMessage *)build;
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (nonnull MPMessageBuilder *)withLocation:(nonnull CLLocation *)location;
+#endif
 #endif
 
 @end

--- a/mParticle-Apple-SDK/Utils/MPMessageBuilder.mm
+++ b/mParticle-Apple-SDK/Utils/MPMessageBuilder.mm
@@ -10,7 +10,9 @@
 #import "MPCommerceEvent+Dictionary.h"
 #import "MPILogger.h"
 #import "NSDictionary+MPCaseInsensitive.h"
+#ifndef MPARTICLE_LOCATION_DISABLE
 #import "MPLocationManager.h"
+#endif
 #import "MPUserAttributeChange.h"
 #import "MPUserIdentityChange.h"
 #import "MPPersistenceController.h"
@@ -396,6 +398,7 @@ NSString *const kMPUserIdentityOldValueKey = @"oi";
 }
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (MPMessageBuilder *)withLocation:(CLLocation *)location {
     MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
     if ([MPStateMachine runningInBackground] && !stateMachine.locationManager.backgroundLocationTracking) {
@@ -417,6 +420,7 @@ NSString *const kMPUserIdentityOldValueKey = @"oi";
     
     return self;
 }
+#endif
 #endif
 
 @end

--- a/mParticle-Apple-SDK/Utils/MPResponseConfig.m
+++ b/mParticle-Apple-SDK/Utils/MPResponseConfig.m
@@ -10,7 +10,9 @@
 #import "MPBackendController.h"
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     #import <CoreLocation/CoreLocation.h>
+#endif
 #endif
 
 @interface MParticle ()
@@ -195,6 +197,7 @@
     NSString *locationMode = locationDictionary[kMPRemoteConfigLocationModeKey];
     [MParticle sharedInstance].stateMachine.locationTrackingMode = locationMode;
     
+#ifndef MPARTICLE_LOCATION_DISABLE
     if ([locationMode isEqualToString:kMPRemoteConfigForceTrue]) {
         NSNumber *accurary = locationDictionary[kMPRemoteConfigLocationAccuracyKey];
         NSNumber *minimumDistance = locationDictionary[kMPRemoteConfigLocationMinimumDistanceKey];
@@ -203,6 +206,7 @@
     } else if ([locationMode isEqualToString:kMPRemoteConfigForceFalse]) {
         [[MParticle sharedInstance] endLocationTracking];
     }
+#endif
 }
 
 - (void)configurePushNotifications:(NSDictionary *)pushNotificationDictionary {

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -6,8 +6,8 @@
 @class MPSession;
 @class MPNotificationController;
 @class MPConsumerInfo;
-#ifndef MPARTICLE_LOCATION_DISABLE
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     @class CLLocation;
     @class MPLocationManager;
 #endif

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -6,13 +6,15 @@
 @class MPSession;
 @class MPNotificationController;
 @class MPConsumerInfo;
-@class MPLocationManager;
+#ifndef MPARTICLE_LOCATION_DISABLE
+#if TARGET_OS_IOS == 1
+    @class CLLocation;
+    @class MPLocationManager;
+#endif
+#endif
 @class MPCustomModule;
 @class MPSearchAdsAttribution;
 @class MPDataPlanOptions;
-#if TARGET_OS_IOS == 1
-    @class CLLocation;
-#endif
 
 @interface MPStateMachine : NSObject
 
@@ -25,9 +27,11 @@
 @property (nonatomic, strong, nullable) NSString *locationTrackingMode;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 @property (nonatomic, strong, nullable) CLLocation *location;
-#endif
 @property (nonatomic, strong, nullable) MPLocationManager *locationManager;
+#endif
+#endif
 @property (nonatomic, strong, nullable) NSString *networkPerformanceMeasuringMode;
 @property (nonatomic, strong, nullable) NSString *pushNotificationMode;
 @property (nonatomic, strong, nonnull) NSString *secret __attribute__((const));

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.mm
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.mm
@@ -11,7 +11,9 @@
 #import "MPILogger.h"
 #import "MPConsumerInfo.h"
 #import "MPPersistenceController.h"
+#ifndef MPARTICLE_LOCATION_DISABLE
 #import "MPLocationManager.h"
+#endif
 #import "MPKitContainer.h"
 #import "MPSearchAdsAttribution.h"
 #import <UIKit/UIKit.h>
@@ -19,7 +21,9 @@
 #import "MPDataPlanFilter.h"
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     #import <CoreLocation/CoreLocation.h>
+#endif
 #endif
 
 NSString *const kCookieDateKey = @"e";
@@ -78,7 +82,9 @@ static BOOL _canWriteMessagesToDB = YES;
 @synthesize networkStatus = _networkStatus;
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 @synthesize location = _location;
+#endif
 #endif
 
 - (instancetype)init {
@@ -479,6 +485,7 @@ static BOOL _canWriteMessagesToDB = YES;
 }
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (CLLocation *)location {
     if ([MPLocationManager trackingLocation]) {
         return self.locationManager.location;
@@ -498,6 +505,7 @@ static BOOL _canWriteMessagesToDB = YES;
         _location = location;
     }
 }
+#endif
 #endif
 
 - (NSString *)locationTrackingMode {

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -26,7 +26,9 @@
 #import "MPResponseConfig.h"
 
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
     #import "MPLocationManager.h"
+#endif
 #endif
 
 static dispatch_queue_t messageQueue = nil;
@@ -639,11 +641,13 @@ NSString *const kMPStateKey = @"state";
                                    self->_trackNotifications = [strongSelf.configSettings[kMPConfigTrackNotifications] boolValue];
                                }
 #if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
                                if ([strongSelf.configSettings[kMPConfigLocationTracking] boolValue]) {
                                    CLLocationAccuracy accuracy = [strongSelf.configSettings[kMPConfigLocationAccuracy] doubleValue];
                                    CLLocationDistance distanceFilter = [strongSelf.configSettings[kMPConfigLocationDistanceFilter] doubleValue];
                                    [strongSelf beginLocationTracking:accuracy minDistance:distanceFilter];
                                }
+#endif
 #endif
                            }
                            
@@ -1344,15 +1348,24 @@ NSString *const kMPStateKey = @"state";
 - (BOOL)backgroundLocationTracking {
     [MPListenerController.sharedInstance onAPICalled:_cmd];
     
+#ifndef MPARTICLE_LOCATION_DISABLE
     return [MParticle sharedInstance].stateMachine.locationManager.backgroundLocationTracking;
+#else
+    return false;
+#endif
 }
 
 - (void)setBackgroundLocationTracking:(BOOL)backgroundLocationTracking {
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:@(backgroundLocationTracking)];
     
+#ifndef MPARTICLE_LOCATION_DISABLE
     [MParticle sharedInstance].stateMachine.locationManager.backgroundLocationTracking = backgroundLocationTracking;
+#else
+    MPILogDebug(@"Automatic background tracking has been disabled to support users excluding location services from their applications.");
+#endif
 }
 
+#ifndef MPARTICLE_LOCATION_DISABLE
 - (CLLocation *)location {
     [MPListenerController.sharedInstance onAPICalled:_cmd];
     
@@ -1411,6 +1424,7 @@ NSString *const kMPStateKey = @"state";
         MPILogError(@"Could not end location tracking: %@", [_backendController execStatusDescription:execStatus]);
     }
 }
+#endif
 #endif
 
 - (void)logNetworkPerformance:(NSString *)urlString httpMethod:(NSString *)httpMethod startTime:(NSTimeInterval)startTime duration:(NSTimeInterval)duration bytesSent:(NSUInteger)bytesSent bytesReceived:(NSUInteger)bytesReceived {

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -1424,8 +1424,8 @@ NSString *const kMPStateKey = @"state";
         MPILogError(@"Could not end location tracking: %@", [_backendController execStatusDescription:execStatus]);
     }
 }
-#endif
-#endif
+#endif // MPARTICLE_LOCATION_DISABLE
+#endif // TARGET_OS_IOS
 
 - (void)logNetworkPerformance:(NSString *)urlString httpMethod:(NSString *)httpMethod startTime:(NSTimeInterval)startTime duration:(NSTimeInterval)duration bytesSent:(NSUInteger)bytesSent bytesReceived:(NSUInteger)bytesReceived {
     NSURL *url = [NSURL URLWithString:urlString];


### PR DESCRIPTION
 ## Summary
  - These commits give two options for the issue where clients attempts at publishing are triggering the NSLocationAlwaysAndWhenInUsageDescription flag from Apple. The first commit expands the pre processor flag to a CLLocation call that was not included before. The second commit removes all uses of CLLocation. When reviewing please give your opinion on which is the preferred solution.

 ## Testing Plan
 - Both commits tested on simulator to confirm no crash or issue in that respect

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-4997
