### PR TITLE
fix: Limit Currency Values to 2 Decimal Points

### DIFF
--- a/UnitTests/MPCommerceEventTests.m
+++ b/UnitTests/MPCommerceEventTests.m
@@ -229,7 +229,7 @@
     XCTAssertNotNil(transactionAttributes, @"Transaction attributes should not have been nil.");
     
     transactionAttributes.affiliation = @"ELB, Inc.";
-    transactionAttributes.shipping = @1.23;
+    transactionAttributes.shipping = @10000000.232;
     transactionAttributes.tax = @4.56;
     transactionAttributes.revenue = @5.79;
     transactionAttributes.transactionId = @"noroads_2015";
@@ -240,7 +240,7 @@
     
     __block NSArray *keys = @[@"ti", @"ts", @"ta", @"tr", @"tt"];
     
-    __block NSArray *values = @[@"noroads_2015", @"1.23", @"ELB, Inc.", @"5.79", @"4.56"];
+    __block NSArray *values = @[@"noroads_2015", @"10000000.23", @"ELB, Inc.", @"5.79", @"4.56"];
     
     [keys enumerateObjectsUsingBlock:^(NSString *key, NSUInteger idx, BOOL *stop) {
         XCTAssertNotNil(transactionattributesDictionary[key], @"There should have been a key/value pair.");

--- a/mParticle-Apple-SDK/Utils/NSNumber+MPFormatter.m
+++ b/mParticle-Apple-SDK/Utils/NSNumber+MPFormatter.m
@@ -14,7 +14,7 @@
         numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
         numberFormatter.maximumFractionDigits = 2;
         NSString *stringRepresentation = [numberFormatter stringFromNumber:self];
-        formattedNumber = @([[numberFormatter numberFromString:stringRepresentation] doubleValue]);
+        formattedNumber = [numberFormatter numberFromString:stringRepresentation];
     }
     
     return formattedNumber;

--- a/mParticle-Apple-SDK/Utils/NSNumber+MPFormatter.m
+++ b/mParticle-Apple-SDK/Utils/NSNumber+MPFormatter.m
@@ -4,18 +4,15 @@
 
 - (NSNumber *)formatWithNonScientificNotation {
     double minThreshold = 1.0E-5;
-    double maxThreshold = 1.0E10;
     double selfAbsoluteValue = fabs([self doubleValue]);
     NSNumber *formattedNumber;
     
     if (selfAbsoluteValue < minThreshold) {
         formattedNumber = @0;
-    } else if (selfAbsoluteValue < maxThreshold) {
-        formattedNumber = self;
     } else {
         NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
-        numberFormatter.maximumFractionDigits = 5;
-        numberFormatter.numberStyle = NSNumberFormatterNoStyle;
+        numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+        numberFormatter.maximumFractionDigits = 2;
         NSString *stringRepresentation = [numberFormatter stringFromNumber:self];
         formattedNumber = @([[numberFormatter numberFromString:stringRepresentation] doubleValue]);
     }


### PR DESCRIPTION
## Summary
 - Change number formatter to 2 decimals

 ## Testing Plan
 - Tested locally and updated unit test to check

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-4795
