### PR TITLE
feat: Custom local kit loading aka kit sideloading

### DIFF
--- a/UnitTests/MPKitTestClassSideloaded.h
+++ b/UnitTests/MPKitTestClassSideloaded.h
@@ -1,0 +1,22 @@
+//
+//  MPKitTestClassSideloaded.h
+//  mParticle-Apple-SDK
+//
+//  Created by Ben Baron on 3/2/23.
+//  Copyright © 2023 mParticle, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MPKitProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MPKitTestClassSideloaded : NSObject<MPKitProtocol>
+
+@property (nonatomic, readonly) BOOL started;
+@property (nonatomic, strong, nullable) MPKitAPI *kitApi;
+@property (nonatomic, strong, nonnull) NSNumber *sideloadedKitCode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/UnitTests/MPKitTestClassSideloaded.m
+++ b/UnitTests/MPKitTestClassSideloaded.m
@@ -1,0 +1,41 @@
+//
+//  MPKitTestClassSideloaded.m
+//  mParticle-Apple-SDK
+//
+//  Created by Ben Baron on 3/2/23.
+//  Copyright © 2023 mParticle, Inc. All rights reserved.
+//
+
+#import "MPKitTestClassSideloaded.h"
+#import "MPKitExecStatus.h"
+
+@implementation MPKitTestClassSideloaded
++ (NSNumber *)kitCode {
+    return @(-1);
+}
+
+- (BOOL)started {
+    return YES;
+}
+
+- (nonnull MPKitExecStatus *)didFinishLaunchingWithConfiguration:(nonnull NSDictionary *)configuration {
+    return [[MPKitExecStatus alloc] initWithSDKCode:self.sideloadedKitCode returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)didBecomeActive {
+    return [[MPKitExecStatus alloc] initWithSDKCode:self.sideloadedKitCode returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)beginSession {
+    return [[MPKitExecStatus alloc] initWithSDKCode:self.sideloadedKitCode returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)endSession {
+    return [[MPKitExecStatus alloc] initWithSDKCode:self.sideloadedKitCode returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)logBaseEvent:(nonnull MPBaseEvent *)event {
+    return [[MPKitExecStatus alloc] initWithSDKCode:self.sideloadedKitCode returnCode:MPKitReturnCodeSuccess];
+}
+
+@end

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		04610F5A215D8C8C001A36AB /* MParticleUserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 04610F58215D8C8B001A36AB /* MParticleUserTests.m */; };
 		04B1670B20000E0F0027F077 /* MPIdentityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DB4F166C1F1511B100D625CD /* MPIdentityTests.m */; };
 		04B1670C20000E0F0027F077 /* MPIdentityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DB4F166C1F1511B100D625CD /* MPIdentityTests.m */; };
+		5384E41029B101230019483D /* MPKitTestClassSideloaded.m in Sources */ = {isa = PBXBuildFile; fileRef = 5384E40F29B101230019483D /* MPKitTestClassSideloaded.m */; };
+		5384E41129B101230019483D /* MPKitTestClassSideloaded.m in Sources */ = {isa = PBXBuildFile; fileRef = 5384E40F29B101230019483D /* MPKitTestClassSideloaded.m */; };
 		B263073D26E29965000A12E9 /* MPConnectorResponseProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B263073C26E29965000A12E9 /* MPConnectorResponseProtocol.h */; };
 		B26307A826E2FEC0000A12E9 /* MPNetworkCommunication.h in Headers */ = {isa = PBXBuildFile; fileRef = B26307A726E2FEC0000A12E9 /* MPNetworkCommunication.h */; };
 		B26307B626E2FEFB000A12E9 /* MPConnectorProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B26307B526E2FEFB000A12E9 /* MPConnectorProtocol.h */; };
@@ -550,6 +552,8 @@
 
 /* Begin PBXFileReference section */
 		04610F58215D8C8B001A36AB /* MParticleUserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MParticleUserTests.m; sourceTree = "<group>"; };
+		5384E40E29B101230019483D /* MPKitTestClassSideloaded.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPKitTestClassSideloaded.h; sourceTree = "<group>"; };
+		5384E40F29B101230019483D /* MPKitTestClassSideloaded.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPKitTestClassSideloaded.m; sourceTree = "<group>"; };
 		B263073C26E29965000A12E9 /* MPConnectorResponseProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPConnectorResponseProtocol.h; sourceTree = "<group>"; };
 		B26307A726E2FEC0000A12E9 /* MPNetworkCommunication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPNetworkCommunication.h; sourceTree = "<group>"; };
 		B26307B526E2FEFB000A12E9 /* MPConnectorProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPConnectorProtocol.h; sourceTree = "<group>"; };
@@ -1030,6 +1034,8 @@
 				DB3935101F8E4F5500AD073E /* MPKitSecondTestClassNoStartImmediately.m */,
 				DB3935131F8E4F5500AD073E /* MPKitTestClassNoStartImmediately.h */,
 				DB3935121F8E4F5500AD073E /* MPKitTestClassNoStartImmediately.m */,
+				5384E40E29B101230019483D /* MPKitTestClassSideloaded.h */,
+				5384E40F29B101230019483D /* MPKitTestClassSideloaded.m */,
 				C9DD20AB1D8A190600D3ABBE /* MPLaunchInfoTests.m */,
 				C21FB07B260A2CFD00B1EB91 /* MPMessageTests.m */,
 				C9DD20AC1D8A190600D3ABBE /* MPMessageBuilderTests.m */,
@@ -1840,6 +1846,7 @@
 				C911FD961D8A365A002A3516 /* MPKitAppsFlyerTest.m in Sources */,
 				C911FD871D8A365A002A3516 /* BracketTests.mm in Sources */,
 				C911FD8A1D8A365A002A3516 /* MPBackendControllerTests.mm in Sources */,
+				5384E41129B101230019483D /* MPKitTestClassSideloaded.m in Sources */,
 				C911FD9A1D8A365A002A3516 /* MPKitSecondTestClass.m in Sources */,
 				04B1670C20000E0F0027F077 /* MPIdentityTests.m in Sources */,
 				C911FD941D8A365A002A3516 /* MPForwardRecordTests.m in Sources */,
@@ -2058,6 +2065,7 @@
 				DB89B696228CA0BE007A5565 /* MPAliasResponseTests.m in Sources */,
 				C9DD20F01D8A1FAF00D3ABBE /* MPIntegrationAttributesTest.m in Sources */,
 				04610F59215D8C8C001A36AB /* MParticleUserTests.m in Sources */,
+				5384E41029B101230019483D /* MPKitTestClassSideloaded.m in Sources */,
 				C9AB50681DFF0C4B0036BEE9 /* MPKitActivityTests.m in Sources */,
 				C9DD20ED1D8A1FA500D3ABBE /* MPEventTests.mm in Sources */,
 				C9DD20E41D8A194D00D3ABBE /* MPAppNotificationHandlerTests.m in Sources */,

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -34,6 +34,7 @@
 
 - (nonnull MPKitExecStatus *)didFinishLaunchingWithConfiguration:(nonnull NSDictionary *)configuration;
 
+// Value ignored for sideloaded kits, so a value like -1 is recommended, sideloadedKitCode is used instead which is set by the SDK
 + (nonnull NSNumber *)kitCode;
 
 #pragma mark - Optional methods

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -44,6 +44,9 @@
 @property (nonatomic, strong, nullable, readonly) id providerKitInstance;
 @property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 
+// Only used for sideloaded kits
+@property (nonatomic, strong, nonnull) NSNumber *sideloadedKitCode;
+
 #pragma mark Kit lifecycle
 - (void)start;
 - (void)deinit;

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -380,6 +380,8 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  */
 @property (nonatomic, strong, readwrite, nullable) NSNumber *configMaxAgeSeconds;
 
+@property (nonatomic, strong, readwrite, nullable) NSArray<NSObject<MPKitProtocol>*> *sideloadedKits;
+
 /**
  Identify callback.
  

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -383,7 +383,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 /**
  Set an array of instances of kit (MPKitProtocol) objects to be "sideloaded".
  
- The difference between these kits and normal kits is that they do not receive a server side configuration and are always activated.
+ The difference between these kits and mParticle UI enabled kits is that they do not receive a server side configuration and are always activated.
  Registration is done locally, and these kits will receive all of the usual MPKitProtocol callback method calls. Some use cases
  include debugging (logging all MPKitProtocol callbacks) and creating custom integrations that are not yet officially supported.
  

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -380,6 +380,15 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  */
 @property (nonatomic, strong, readwrite, nullable) NSNumber *configMaxAgeSeconds;
 
+/**
+ Set an array of instances of kit (MPKitProtocol) objects to be "sideloaded".
+ 
+ The difference between these kits and normal kits is that they do not receive a server side configuration and are always activated.
+ Registration is done locally, and these kits will receive all of the usual MPKitProtocol callback method calls. Some use cases
+ include debugging (logging all MPKitProtocol callbacks) and creating custom integrations that are not yet officially supported.
+ 
+ At the moment, all events are forwarded as event filtering is not yet supported. This will come in a future release.
+ */
 @property (nonatomic, strong, readwrite, nullable) NSArray<NSObject<MPKitProtocol>*> *sideloadedKits;
 
 /**

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -16,6 +16,8 @@
 @property (nonatomic, strong, nonnull) NSMutableDictionary<NSNumber *, MPAttributionResult *> *attributionInfo;
 @property (nonatomic, strong, nonnull) NSArray<NSDictionary *> *originalConfig;
 
+@property (nonatomic, strong, nonnull) NSArray<NSObject<MPKitProtocol>*> *sideloadedKits;
+
 + (BOOL)registerKit:(nonnull id<MPExtensionKitProtocol>)kitRegister;
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;
 

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -42,7 +42,6 @@ NSString *const kitFileExtension = @"eks";
 static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 
 @interface MParticle ()
-
 @property (nonatomic, strong, readonly) MPPersistenceController *persistenceController;
 @property (nonatomic, strong, readonly) MPStateMachine *stateMachine;
 @property (nonatomic, strong, readonly) MPKitContainer *kitContainer;
@@ -50,13 +49,10 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 @property (nonatomic, strong, nonnull) MParticleOptions *options;
 @property (nonatomic, strong) MPDataPlanFilter *dataPlanFilter;
 - (void)executeKitsInitializedBlocks;
-
 @end
 
 @interface MPKitAPI ()
-
 - (id)initWithKitCode:(NSNumber *)integrationId;
-
 @end
 
 @interface MPForwardRecord ()
@@ -66,16 +62,21 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 - (nonnull instancetype)initWithMessageType:(MPMessageType)messageType execStatus:(nonnull MPKitExecStatus *)execStatus;
 @end
 
-@interface MPKitContainer() {
+@interface MPKitRegister ()
+- (nullable instancetype)initWithInstance:(nonnull NSObject<MPKitProtocol> *)instance kitCode:(nonnull NSNumber *)kitCode;
+@end
+
+static const NSInteger sideloadedKitCodeStartValue = 1000000000;
+
+@interface MPKitContainer () {
     dispatch_semaphore_t kitsSemaphore;
     std::map<NSNumber *, std::shared_ptr<mParticle::Bracket>> brackets;
+    NSInteger sideloadedKitCodeNextValue;
 }
-
 @property (nonatomic, strong) NSMutableArray<MPForwardQueueItem *> *forwardQueue;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, MPKitConfiguration *> *kitConfigurations;
 @property (nonatomic) BOOL kitsInitialized;
 @property (nonatomic, strong) NSDate *initializedTime;
-
 @end
 
 
@@ -97,6 +98,7 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         NSMutableDictionary *linkInfo = _attributionInfo;
         _initializedTime = [NSDate date];
         kitsSemaphore = dispatch_semaphore_create(1);
+        sideloadedKitCodeNextValue = sideloadedKitCodeStartValue;
         
         _attributionCompletionHandler = [^void(MPAttributionResult *_Nullable attributionResult, NSError * _Nullable error) {
             if (attributionResult && attributionResult.kitCode) {
@@ -238,10 +240,34 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     }
 }
 
+- (void)registerSideloadedKits {
+    for (NSObject<MPKitProtocol>* kitInstance in self.sideloadedKits) {
+        // Get kit code from sideloaded kits range and increment it for the next kit
+        NSNumber *kitCode = @(sideloadedKitCodeNextValue);
+        sideloadedKitCodeNextValue++;
+        kitInstance.sideloadedKitCode = kitCode;
+        
+        // Call through to the main registration method so any listeners will receive a callback
+        MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithInstance:kitInstance kitCode:kitCode];
+        [MParticle registerExtension:kitRegister];
+        
+        // Create default kit configuration
+        NSDictionary *remoteConfigDict = @{@"eaa": @{}, @"ear": @{}, @"eas": @{}};
+        NSDictionary *configDict = @{@"id": kitCode, @"as": @{}, kMPRemoteConfigKitHashesKey: remoteConfigDict};
+        MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configDict];
+        self.kitConfigurations[kitConfiguration.integrationId] = kitConfiguration;
+        
+        // Finish registering kit and call its callbacks
+        [self startKitRegister:kitRegister configuration:kitConfiguration];
+    }
+}
+
 - (void)initializeKits {
     if (self.kitsInitialized) {
         return;
     }
+    
+    [self registerSideloadedKits];
     
     NSArray<NSNumber *> *supportedKits = [self supportedKits];
     BOOL anyKitsIncluded = supportedKits != nil && supportedKits.count > 0;
@@ -260,6 +286,9 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         self.kitConfigurations[kitConfiguration.integrationId] = kitConfiguration;
         [self startKit:kitConfiguration.integrationId configuration:kitConfiguration];
         
+        self.kitsInitialized = YES;
+    }
+    if (self.sideloadedKits.count > 0) {
         self.kitsInitialized = YES;
     }
     if ([MParticle sharedInstance].stateMachine.logLevel >= MPILogLevelDebug) {
@@ -469,7 +498,9 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     
     NSDictionary * configuration = kitConfiguration.configuration;
     if (configuration.count > 0) {
-        kitRegister.wrapperInstance = [[NSClassFromString(kitRegister.className) alloc] init];
+        if (!kitRegister.wrapperInstance) {
+            kitRegister.wrapperInstance = [[NSClassFromString(kitRegister.className) alloc] init];
+        }
         
         MPKitAPI *kitApi = [[MPKitAPI alloc] initWithKitCode:kitRegister.code];
         if ([kitRegister.wrapperInstance respondsToSelector:@selector(setKitApi:)]) {

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -245,7 +245,13 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         // Get kit code from sideloaded kits range and increment it for the next kit
         NSNumber *kitCode = @(sideloadedKitCodeNextValue);
         sideloadedKitCodeNextValue++;
-        kitInstance.sideloadedKitCode = kitCode;
+        if ([kitInstance respondsToSelector:@selector(sideloadedKitCode)]) {
+            kitInstance.sideloadedKitCode = kitCode;
+        } else {
+            NSString *message = @"Sideloaded kits must implement the sideloadedKitCode property or they will not receive callbacks";
+            NSAssert(NO, message);
+            MPILogError(@"%@", message);
+        }
         
         // Call through to the main registration method so any listeners will receive a callback
         MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithInstance:kitInstance kitCode:kitCode];

--- a/mParticle-Apple-SDK/Kits/MPKitRegister.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitRegister.mm
@@ -37,6 +37,22 @@
     return self;
 }
 
+- (nullable instancetype)initWithInstance:(nonnull NSObject<MPKitProtocol> *)instance kitCode:(nonnull NSNumber *)kitCode {
+    NSString *className = NSStringFromClass([instance class]);
+    self = [self initWithName:className className:className];
+    if (!self || MPIsNull(className) || MPIsNull(instance)) {
+        return nil;
+    }
+    
+    // All sideloaded kits have an internally generated code in a specified range determined by MPKitContainer
+    _code = kitCode;
+    
+    // Use the already initialized instance instead of creating one later
+    _wrapperInstance = instance;
+    
+    return self;
+}
+
 - (NSString *)description {
     NSMutableString *description = [[NSMutableString alloc] initWithFormat:@"%@ {\n", [self class]];
     [description appendFormat:@"    code: %@,\n", _code];

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -566,6 +566,7 @@ NSString *const kMPStateKey = @"state";
     }
     
     _kitContainer = [[MPKitContainer alloc] init];
+    _kitContainer.sideloadedKits = options.sideloadedKits ?: [NSArray array];
 
     [self.backendController startWithKey:apiKey
                                   secret:secret


### PR DESCRIPTION
 ## Summary
This adds the ability to "sideload" local custom kits.

The difference between these kits and normal kits is that they do not receive a server side configuration and are always activated. Registration is done locally, and these kits will receive all of the usual MPKitProtocol callback method calls. Some use cases include debugging (logging all MPKitProtocol callbacks) and creating custom integrations that are not yet officially supported.
 
At the moment, all events are forwarded as event filtering is not yet supported. This will come in a future release.

 ## Testing Plan
- Added unit tests
- Tested functionality in a local test app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5111
