### PR TITLE
fix: Prevent Unplanned User Identities

### DIFF
--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -22,6 +22,12 @@
 
 @end
 
+@interface MParticleUser ()
+- (void)setIdentitySync:(NSString *)identityString identityType:(MPIdentity)identityType;
+- (void)setUserId:(NSNumber *)userId;
+
+@end
+
 @interface MPUploadBuilderTests : MPBaseTestCase
 
 @end
@@ -559,6 +565,9 @@
                                 }
     ];
     
+    MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
+    [currentUser setIdentitySync:@"C56A4180-65AA-42EC-A945-5FD21DEC0538" identityType:MPIdentityIOSAdvertiserId];
+    
     [uploadBuilder withUserIdentities:userIdentities];
     
     NSString *description = [uploadBuilder description];
@@ -640,6 +649,9 @@
                                     @"i":@"C56A4180-65AA-42EC-A945-5FD21DEC0538"
                                 }
     ];
+    
+    MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
+    [currentUser setIdentitySync:@"C56A4180-65AA-42EC-A945-5FD21DEC0538" identityType:MPIdentityIOSAdvertiserId];
     
     [uploadBuilder withUserIdentities:userIdentities];
     

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -214,7 +214,7 @@ static BOOL appBackgrounded = NO;
     }
 }
 
-- (NSMutableArray<NSDictionary<NSString *, id> *> *)userIdentitiesForUserId:(NSNumber *)userId {
+- (NSMutableArray<NSDictionary<NSString *, id> *> *)identitiesForUserId:(NSNumber *)userId {
     
     NSMutableArray *userIdentities = [[NSMutableArray alloc] initWithCapacity:10];
     MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
@@ -238,6 +238,27 @@ static BOOL appBackgrounded = NO;
     NSNumber *currentStatus = [MParticle sharedInstance].stateMachine.attAuthorizationStatus;
     if (existingEntryIndex != NSNotFound && currentStatus != nil && currentStatus.integerValue != MPATTAuthorizationStatusAuthorized) {
         [userIdentities removeObjectAtIndex:existingEntryIndex];
+    }
+
+    return userIdentities;
+}
+
+- (NSMutableArray<NSDictionary<NSString *, id> *> *)userIdentitiesForUserId:(NSNumber *)userId {
+    
+    NSMutableArray *identities = [[NSMutableArray alloc] initWithCapacity:10];
+    MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
+    NSArray *identityArray = [userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:userId];
+    if (identityArray) {
+        [identities addObjectsFromArray:identityArray];
+    }
+    
+    NSMutableArray *userIdentities = [identities mutableCopy];
+    int i;
+    for (i = 0; i < [identities count]; i++) {
+        NSNumber *currentIdentityType = [identities objectAtIndex:i][kMPUserIdentityTypeKey];
+        if (currentIdentityType.intValue >= MPIdentityIOSAdvertiserId) {
+            [userIdentities removeObjectAtIndex:i];
+        }
     }
 
     return userIdentities;
@@ -2062,7 +2083,7 @@ static BOOL skipNextUpload = NO;
                                                                                      value:identityString];
     
     MPUserIdentityChange *userIdentityChange = [[MPUserIdentityChange alloc] initWithNewUserIdentity:userIdentityNew
-                                                                                      userIdentities:[self userIdentitiesForUserId:[MPPersistenceController mpId]]];
+                                                                                      userIdentities:[self identitiesForUserId:[MPPersistenceController mpId]]];
     
     userIdentityChange.timestamp = timestamp;
     

--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -253,8 +253,7 @@ static BOOL appBackgrounded = NO;
     }
     
     NSMutableArray *userIdentities = [identities mutableCopy];
-    int i;
-    for (i = 0; i < [identities count]; i++) {
+    for (int i = 0; i < [identities count]; i++) {
         NSNumber *currentIdentityType = [identities objectAtIndex:i][kMPUserIdentityTypeKey];
         if (currentIdentityType.intValue >= MPIdentityIOSAdvertiserId) {
             [userIdentities removeObjectAtIndex:i];

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.mm
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.mm
@@ -178,14 +178,9 @@ using namespace std;
     
     // Update the IDFA if it changed after the session was created/saved (the IDFA changed or the ATTStatus has been set to authorized)
     NSNumber *authStatus = [MParticle sharedInstance].stateMachine.attAuthorizationStatus;
-    NSMutableArray *userIdentities = uploadDictionary[kMPUserIdentityArrayKey];
-    NSString *advertiserId;
-    for (NSMutableDictionary *userIdentityDictionary in userIdentities) {
-        NSNumber *identityTypeKey = userIdentityDictionary[kMPUserIdentityTypeKey];
-        if ([identityTypeKey isEqualToNumber:@(MPIdentityIOSAdvertiserId)]) {
-            advertiserId = userIdentityDictionary[kMPUserIdentityIdKey];
-        }
-    }
+    NSNumber *mpid = uploadDictionary[kMPRemoteConfigMPIDKey];
+    NSDictionary *userIdentities = [[[MParticle sharedInstance] identity] getUser:mpid].identities;
+    NSString *advertiserId = userIdentities[@(MPIdentityIOSAdvertiserId)];
 
     if (authStatus && advertiserId && authStatus.intValue == MPATTAuthorizationStatusAuthorized) {
         NSMutableDictionary *deviceInfoDictCopy = [uploadDictionary[kMPDeviceInformationKey] mutableCopy];


### PR DESCRIPTION
## Summary
 - ensured only userIdentities and not all identities are being included in the userIdentities section of the upload

 ## Testing Plan
 - Tested locally using attached data plan and my workspace livestream

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5233
