### PR TITLE
Add nil check for kitContainer inside onAttributionCompleteWithResult

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitAPI.m
+++ b/mParticle-Apple-SDK/Kits/MPKitAPI.m
@@ -102,34 +102,37 @@
 }
 
 - (void)onAttributionCompleteWithResult:(MPAttributionResult *)result error:(NSError *)error {
-    if (error || !result) {
+    if ([MParticle sharedInstance].kitContainer != nil) {
         
-        NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-        if (_kitCode != nil) {
-            userInfo[mParticleKitInstanceKey] = _kitCode;
+        if (error || !result) {
+
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+            if (_kitCode != nil) {
+                userInfo[mParticleKitInstanceKey] = _kitCode;
+            }
+
+            NSString *errorMessage = nil;
+
+            if (error) {
+                errorMessage = @"mParticle Kit Attribution Error";
+                userInfo[NSUnderlyingErrorKey] = error;
+            }
+
+            if (!result) {
+                errorMessage = @"mParticle Kit Attribution handler was called with nil info and no error";
+            }
+
+            userInfo[MPKitAPIErrorKey] = errorMessage;
+            NSError *attributionError = [NSError errorWithDomain:MPKitAPIErrorDomain code:0 userInfo:userInfo];
+            [MParticle sharedInstance].kitContainer.attributionCompletionHandler(nil, attributionError);
+            return;
         }
-        
-        NSString *errorMessage = nil;
-        
-        if (error) {
-            errorMessage = @"mParticle Kit Attribution Error";
-            userInfo[NSUnderlyingErrorKey] = error;
-        }
-        
-        if (!result) {
-            errorMessage = @"mParticle Kit Attribution handler was called with nil info and no error";
-        }
-        
-        userInfo[MPKitAPIErrorKey] = errorMessage;
-        NSError *attributionError = [NSError errorWithDomain:MPKitAPIErrorDomain code:0 userInfo:userInfo];
-        [MParticle sharedInstance].kitContainer.attributionCompletionHandler(nil, attributionError);
-        return;
+
+        result.kitCode = _kitCode;
+        result.kitName = [self kitName];
+
+        [MParticle sharedInstance].kitContainer.attributionCompletionHandler(result, nil);
     }
-    
-    result.kitCode = _kitCode;
-    result.kitName = [self kitName];
-    
-    [MParticle sharedInstance].kitContainer.attributionCompletionHandler(result, nil);
 }
 
 #pragma mark Kit Identity methods


### PR DESCRIPTION
 ## Summary
 - Added a nil check for kitContainer inside onAttributionCompleteWithResult so that, should the kitContainer be nil (e.g. after reset) it does not end up crashing the app.

 ## Testing Plan
 - TBD

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - [ZD11524](https://mparticlehelp.zendesk.com/agent/tickets/11524)
