### PR TITLE
feat: Upload build artifacts to S3 for SPM

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -43,9 +43,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate environment
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MP_IOS_SDK_S3_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MP_IOS_SDK_S3_SECRET }}
+          AWS_DEFAULT_REGION: ${{ secrets.MP_IOS_SDK_S3_REGION }}
         run: |
           env | grep -q '^GITHUB_ACCESS_TOKEN=' || (echo "Required environment variable GITHUB_ACCESS_TOKEN is not set" && exit 1)
           env | grep -q '^COCOAPODS_TRUNK_TOKEN=' || (echo "Required environment variable COCOAPODS_TRUNK_TOKEN is not set" && exit 1)
+          env | grep -q '^AWS_ACCESS_KEY_ID=' || (echo "Required environment variable AWS_ACCESS_KEY_ID is not set" && exit 1)
+          env | grep -q '^AWS_SECRET_ACCESS_KEY=' || (echo "Required environment variable AWS_SECRET_ACCESS_KEY is not set" && exit 1)
+          env | grep -q '^AWS_DEFAULT_REGION=' || (echo "Required environment variable AWS_DEFAULT_REGION is not set" && exit 1)
 
       - name: Setup git config
         run: |
@@ -89,6 +96,9 @@ jobs:
           GIT_AUTHOR_EMAIL: developers@mparticle.com
           GIT_COMMITTER_NAME: mparticle-bot
           GIT_COMMITTER_EMAIL: developers@mparticle.com
+          AWS_ACCESS_KEY_ID: ${{ secrets.MP_IOS_SDK_S3_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MP_IOS_SDK_S3_SECRET }}
+          AWS_DEFAULT_REGION: ${{ secrets.MP_IOS_SDK_S3_REGION }}
         run: |
           npx \
           -p lodash \

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -23,14 +23,20 @@ sed -i '' 's/\(^    s.version[^=]*= \).*/\1"'"$VERSION"'"/' mParticle-Apple-SDK.
 
 ./Scripts/make_artifacts.sh
 
+# Upload XCFrameworks to S3 bucket
+#
+
+aws s3 cp mParticle_Apple_SDK.xcframework.zip s3://static.mparticle.com/sdk/ios/$PREFIXED_VERSION/mParticle_Apple_SDK.xcframework.zip
+aws s3 cp mParticle_Apple_SDK_NoLocation.xcframework.zip s3://static.mparticle.com/sdk/ios/$PREFIXED_VERSION/mParticle_Apple_SDK_NoLocation.xcframework.zip
+
 # Update SPM package.swift file
 #
 
-SDK_URL="https:\/\/github.com\/mParticle\/mparticle-apple-sdk\/releases\/download\/$PREFIXED_VERSION\/mParticle_Apple_SDK.xcframework.zip"
+SDK_URL="https:\/\/static.mparticle.com\/sdk\/ios\/$PREFIXED_VERSION\/mParticle_Apple_SDK.xcframework.zip"
 SDK_CHECKSUM=$(swift package compute-checksum mParticle_Apple_SDK.xcframework.zip)
 sed -i '' 's/\(^let mParticle_Apple_SDK_URL[^=]*= \).*/\1"'"$SDK_URL"'"/' Package.swift
 sed -i '' 's/\(^let mParticle_Apple_SDK_Checksum[^=]*= \).*/\1"'"$SDK_CHECKSUM"'"/' Package.swift
-SDK_URL="https:\/\/github.com\/mParticle\/mparticle-apple-sdk\/releases\/download\/$PREFIXED_VERSION\/mParticle_Apple_SDK_NoLocation.xcframework.zip"
+SDK_URL="https:\/\/static.mparticle.com\/sdk\/ios\/$PREFIXED_VERSION\/mParticle_Apple_SDK_NoLocation.xcframework.zip"
 SDK_CHECKSUM=$(swift package compute-checksum mParticle_Apple_SDK_NoLocation.xcframework.zip)
 sed -i '' 's/\(^let mParticle_Apple_SDK_NoLocation_URL[^=]*= \).*/\1"'"$SDK_URL"'"/' Package.swift
 sed -i '' 's/\(^let mParticle_Apple_SDK_NoLocation_Checksum[^=]*= \).*/\1"'"$SDK_CHECKSUM"'"/' Package.swift


### PR DESCRIPTION
 ## Summary
 - Upload build artifacts used by SPM to an S3 bucket to work around an Xcode bug that unnecessarily requires credentials to download artifacts from the Github release which breaks CI for some users.

 ## Testing Plan
- Tested each piece independently (tested uploading to this S3 bucket using these credentials, tested running the release script but uploading to a test bucket on a fork to show that the env variables would work inside the release script)
- Can't do a full end to end test until our next release of the SDK, but everything should work, and if we run into issues, changes should be minimal as all pieces have been validated. 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5416
