### PR TITLE
feat: Add Sideloaded Kit Filtering Support to API

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -1,6 +1,5 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
-#import "Swift.h"
 #import "MPKitContainer.h"
 #import "MPIConstants.h"
 #import "MPForwardQueueItem.h"
@@ -29,6 +28,7 @@
 #import "MPBaseTestCase.h"
 #import "MPKitProtocol.h"
 #import "MPKitTestClassSideloaded.h"
+#import "Swift.h"
 
 @interface MParticle ()
 

--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
+#import "Swift.h"
 #import "MPKitContainer.h"
 #import "MPIConstants.h"
 #import "MPForwardQueueItem.h"
@@ -2494,7 +2495,7 @@
     id sideloadedKitMock = OCMPartialMock(sideloadedKit);
     [(id <MPKitProtocol>)[sideloadedKitMock expect] didFinishLaunchingWithConfiguration:OCMOCK_ANY];
     
-    kitContainer.sideloadedKits = @[sideloadedKit];
+    kitContainer.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:sideloadedKit]];
     [kitContainer initializeKits];
     
     [sideloadedKitMock verifyWithDelay:5.0];
@@ -2513,7 +2514,9 @@
     id sideloadedKitMock3 = OCMPartialMock(sideloadedKit3);
     [(id <MPKitProtocol>)[sideloadedKitMock3 expect] didFinishLaunchingWithConfiguration:OCMOCK_ANY];
     
-    kitContainer.sideloadedKits = @[sideloadedKit1, sideloadedKit2, sideloadedKit3];
+    kitContainer.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:sideloadedKit1],
+                                    [[MPSideloadedKit alloc] initWithKitInstance:sideloadedKit2],
+                                    [[MPSideloadedKit alloc] initWithKitInstance:sideloadedKit3]];
     [kitContainer initializeKits];
     
     [sideloadedKitMock1 verifyWithDelay:5.0];
@@ -2534,7 +2537,7 @@
     //       calling [kitContainer configureKits:nil] even though that
     //       shouldn't matter since the whole thing is reconstructed in setUp...
     dispatch_async(dispatch_get_main_queue(), ^{
-        self->kitContainer.sideloadedKits = @[sideloadedKit];
+        self->kitContainer.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:sideloadedKit]];
         [self->kitContainer initializeKits];
         
         [[MParticle sharedInstance] logEvent:event];

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -517,6 +517,8 @@
 		53A79DBD29CE23F700E7489F /* MPLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79AA629CDFB1E00E7489F /* MPLocationManager.m */; };
 		53A79DBE29CE23F700E7489F /* MPUserAttributeChange.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79B2729CDFB1F00E7489F /* MPUserAttributeChange.m */; };
 		53A79DBF29CE23F700E7489F /* MPIdentityApiManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79AA229CDFB1E00E7489F /* MPIdentityApiManager.m */; };
+		53B33E8A2A4606CD00CC8A19 /* MPSideloadedKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */; };
+		53B33E8B2A4606CD00CC8A19 /* MPSideloadedKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -808,6 +810,7 @@
 		53A79CFE29CE12AB00E7489F /* mParticle-Apple-SDK.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = "mParticle-Apple-SDK.modulemap"; path = "Framework/mParticle-Apple-SDK.modulemap"; sourceTree = "<group>"; };
 		53A79CFF29CE23D600E7489F /* mParticle-Apple-SDK-NoLocation.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = "mParticle-Apple-SDK-NoLocation.modulemap"; path = "Framework/mParticle-Apple-SDK-NoLocation.modulemap"; sourceTree = "<group>"; };
 		53A79DC629CE23F700E7489F /* mParticle_Apple_SDK_NoLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_SDK_NoLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPSideloadedKit.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1159,6 +1162,7 @@
 				53A79B5F29CDFB1F00E7489F /* MPKitConfiguration.h */,
 				53A79B6029CDFB1F00E7489F /* MPKitFilter.h */,
 				53A79B6129CDFB1F00E7489F /* MPBaseProjection.h */,
+				53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */,
 			);
 			path = Kits;
 			sourceTree = "<group>";
@@ -1807,6 +1811,7 @@
 				53A79B8029CDFB2000E7489F /* MPNetworkPerformance.m in Sources */,
 				53A79BCD29CDFB2000E7489F /* MPZip.m in Sources */,
 				53A79C0929CDFB2100E7489F /* MPDataPlanFilter.m in Sources */,
+				53B33E8A2A4606CD00CC8A19 /* MPSideloadedKit.swift in Sources */,
 				53A79B9629CDFB2000E7489F /* MPSession.m in Sources */,
 				53A79B9729CDFB2000E7489F /* MPIntegrationAttributes.m in Sources */,
 				53A79B6A29CDFB2000E7489F /* MPAliasRequest.m in Sources */,
@@ -1971,6 +1976,7 @@
 				53A79D9729CE23F700E7489F /* MPNetworkPerformance.m in Sources */,
 				53A79D9829CE23F700E7489F /* MPZip.m in Sources */,
 				53A79D9929CE23F700E7489F /* MPDataPlanFilter.m in Sources */,
+				53B33E8B2A4606CD00CC8A19 /* MPSideloadedKit.swift in Sources */,
 				53A79D9A29CE23F700E7489F /* MPSession.m in Sources */,
 				53A79D9B29CE23F700E7489F /* MPIntegrationAttributes.m in Sources */,
 				53A79D9C29CE23F700E7489F /* MPAliasRequest.m in Sources */,

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -38,6 +38,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MPSideloadedKit;
+
 /**
  An SDK session.
  
@@ -381,7 +383,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 @property (nonatomic, strong, readwrite, nullable) NSNumber *configMaxAgeSeconds;
 
 /**
- Set an array of instances of kit (MPKitProtocol) objects to be "sideloaded".
+ Set an array of instances of kit (MPKitProtocol wrapped in MPSideloadedKit) objects to be "sideloaded".
  
  The difference between these kits and mParticle UI enabled kits is that they do not receive a server side configuration and are always activated.
  Registration is done locally, and these kits will receive all of the usual MPKitProtocol callback method calls. Some use cases
@@ -389,7 +391,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  
  At the moment, all events are forwarded as event filtering is not yet supported. This will come in a future release.
  */
-@property (nonatomic, strong, readwrite, nullable) NSArray<NSObject<MPKitProtocol>*> *sideloadedKits;
+@property (nonatomic, strong, readwrite, nullable) NSArray<MPSideloadedKit*> *sideloadedKits;
 
 /**
  Identify callback.

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -9,7 +9,6 @@
 @class MPBaseEvent;
 @class MPForwardQueueParameters;
 @class MPKitConfiguration;
-@class MPSideloadedKit;
 
 @interface MPKitContainer : NSObject
 

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -9,6 +9,7 @@
 @class MPBaseEvent;
 @class MPForwardQueueParameters;
 @class MPKitConfiguration;
+@class MPSideloadedKit;
 
 @interface MPKitContainer : NSObject
 
@@ -16,7 +17,7 @@
 @property (nonatomic, strong, nonnull) NSMutableDictionary<NSNumber *, MPAttributionResult *> *attributionInfo;
 @property (nonatomic, strong, nonnull) NSArray<NSDictionary *> *originalConfig;
 
-@property (nonatomic, strong, nonnull) NSArray<NSObject<MPKitProtocol>*> *sideloadedKits;
+@property (nonatomic, strong, nonnull) NSArray<MPSideloadedKit*> *sideloadedKits;
 
 + (BOOL)registerKit:(nonnull id<MPExtensionKitProtocol>)kitRegister;
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1,4 +1,5 @@
 #import "MPKitContainer.h"
+#import "Swift.h"
 #import "MPKitExecStatus.h"
 #import "MPEnums.h"
 #import "MPStateMachine.h"
@@ -241,12 +242,12 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 }
 
 - (void)registerSideloadedKits {
-    for (NSObject<MPKitProtocol>* kitInstance in self.sideloadedKits) {
+    for (MPSideloadedKit *sideloadedKit in self.sideloadedKits) {
         // Get kit code from sideloaded kits range and increment it for the next kit
         NSNumber *kitCode = @(sideloadedKitCodeNextValue);
         sideloadedKitCodeNextValue++;
-        if ([kitInstance respondsToSelector:@selector(sideloadedKitCode)]) {
-            kitInstance.sideloadedKitCode = kitCode;
+        if ([sideloadedKit.kitInstance respondsToSelector:@selector(sideloadedKitCode)]) {
+            sideloadedKit.kitInstance.sideloadedKitCode = kitCode;
         } else {
             NSString *message = @"Sideloaded kits must implement the sideloadedKitCode property or they will not receive callbacks";
             NSAssert(NO, message);
@@ -254,7 +255,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         }
         
         // Call through to the main registration method so any listeners will receive a callback
-        MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithInstance:kitInstance kitCode:kitCode];
+        MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithInstance:sideloadedKit.kitInstance kitCode:kitCode];
         [MParticle registerExtension:kitRegister];
         
         // Create default kit configuration

--- a/mParticle-Apple-SDK/Kits/MPSideloadedKit.swift
+++ b/mParticle-Apple-SDK/Kits/MPSideloadedKit.swift
@@ -1,0 +1,16 @@
+//
+//  MPSideloadedKit.swift
+//  mParticle-Apple-SDK
+//
+//  Created by Ben Baron on 6/23/23.
+//
+
+import Foundation
+
+@objc public class MPSideloadedKit: NSObject {
+    @objc public var kitInstance: MPKitProtocol
+    
+    @objc public init(kitInstance: MPKitProtocol) {
+        self.kitInstance = kitInstance
+    }
+}


### PR DESCRIPTION
 ## Summary
 - Update public API to use MPSideloadedKit object in preparation for filtering support.

 ## Testing Plan
- Unit tests updated and ran locally (also run in CI).

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5483
