### PR TITLE
fix: crash in userIdentitiesForUserId with multiple invalid identity types

### DIFF
--- a/mParticle-Apple-SDK/MPBackendController.mm
+++ b/mParticle-Apple-SDK/MPBackendController.mm
@@ -244,22 +244,23 @@ static BOOL appBackgrounded = NO;
 }
 
 - (NSMutableArray<NSDictionary<NSString *, id> *> *)userIdentitiesForUserId:(NSNumber *)userId {
-    
+
     NSMutableArray *identities = [[NSMutableArray alloc] initWithCapacity:10];
     MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
     NSArray *identityArray = [userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:userId];
     if (identityArray) {
         [identities addObjectsFromArray:identityArray];
     }
-    
-    NSMutableArray *userIdentities = [identities mutableCopy];
-    for (int i = 0; i < [identities count]; i++) {
-        NSNumber *currentIdentityType = [identities objectAtIndex:i][kMPUserIdentityTypeKey];
-        if (currentIdentityType.intValue >= MPIdentityIOSAdvertiserId) {
-            [userIdentities removeObjectAtIndex:i];
-        }
-    }
 
+    // Remove invalid identities
+    NSMutableArray *userIdentities = [identities mutableCopy];
+    [identities enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        id currentIdentityType = [identities objectAtIndex:idx][kMPUserIdentityTypeKey];
+        // Should be a number and should be one of the valid identity types
+        if (![currentIdentityType isKindOfClass:[NSNumber class]] || [(NSNumber *)currentIdentityType intValue] >= MPIdentityIOSAdvertiserId) {
+            [userIdentities removeObjectAtIndex:idx];
+        }
+    }];
     return userIdentities;
 }
 


### PR DESCRIPTION
 ## Summary
The SDK could crash on start if multiple invalid user identity types are saved (e.g. `MPIdentityIOSAdvertiserId` and `MPIdentityPushToken`).

Issue reported here: https://github.com/mParticle/mparticle-apple-sdk/issues/204

 ## Testing Plan
New unit tests were written to confirm the crash, then the logic was fixed and tests confirmed no crash and correct logic.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5537
