### PR TITLE
fix:Push Registration events to show forwarded for kits

### DIFF
--- a/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.mm
+++ b/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.mm
@@ -105,7 +105,7 @@
         [[MParticle sharedInstance].kitContainer forwardSDKCall:deviceTokenSelector
                                                           event:nil
                                                      parameters:queueParameters
-                                                    messageType:MPMessageTypeUnknown
+                                                    messageType:MPMessageTypePushRegistration
                                                        userInfo:nil
          ];
     });


### PR DESCRIPTION
 ## Summary
 - It was reported by one of our clients that push registration events were showing as 0 for Braze even though it was incrementing for the inbound count in the event forwarding view even though it was working as expected. After further investigation, I've noticed in our code that when we forward the call to the kits, its being passed as MPMessageTypeUnknown in stead of MPMessageTypePushRegistration which then is dropped since the if statement in kitContainer at line 2341 drops any event with MPMessageTypeUnknown

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - E2E testing
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-5650
