### PR TITLE
fix: Update Imports For React Native

### DIFF
--- a/mParticle-Apple-SDK/Swift.h
+++ b/mParticle-Apple-SDK/Swift.h
@@ -5,12 +5,10 @@
 //  Created by Ben Baron on 3/24/23.
 //
 
-#ifndef MPARTICLE_LOCATION_DISABLE
+#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
     #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-    #ifndef COCOAPODS
-        #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
-    #else
-        #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
-    #endif
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif

--- a/mParticle-Apple-SDK/Swift.h
+++ b/mParticle-Apple-SDK/Swift.h
@@ -5,9 +5,9 @@
 //  Created by Ben Baron on 3/24/23.
 //
 
-#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
+#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>)
     #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
-#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>)
     #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
     #import "mParticle_Apple_SDK-Swift.h"


### PR DESCRIPTION
## Summary
 - Imports were not working with Cocoapods without the 'use_frameworks!` directive which also prevented usage with React Native which doesn't support that directive without a bunch of workarounds.

 ## Testing Plan
 - Testing across CocaoPods, SPM, No-Location/Locations builds, and React Native Projects

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-4646
