### PR TITLE
fix: Update imports for react native compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ The mParticle-Apple-SDK is available via [CocoaPods](https://cocoapods.org/?q=mp
 To integrate the SDK using CocoaPods, specify it in your [Podfile](https://guides.cocoapods.org/syntax/podfile.html):
 
 ```ruby
-# The line below is required since we're using Swift
-use_frameworks!
-
 target '<Your Target>' do
     pod 'mParticle-Apple-SDK', '~> 8'
     
@@ -47,9 +44,6 @@ Configuring your `Podfile` with the statement above will include only the _Core_
 If you'd like to add any kits, you can do so as follows:
 
 ```ruby
-# The line below is required since we're using Swift
-use_frameworks!
-
 target '<Your Target>' do
     pod 'mParticle-Appboy', '~> 8'
     pod 'mParticle-BranchMetrics', '~> 8'

--- a/mParticle-Apple-SDK/Swift.h
+++ b/mParticle-Apple-SDK/Swift.h
@@ -5,12 +5,10 @@
 //  Created by Ben Baron on 3/24/23.
 //
 
-#ifndef MPARTICLE_LOCATION_DISABLE
+#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
     #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-    #ifndef COCOAPODS
-        #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
-    #else
-        #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
-    #endif
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif

--- a/mParticle-Apple-SDK/Swift.h
+++ b/mParticle-Apple-SDK/Swift.h
@@ -5,9 +5,9 @@
 //  Created by Ben Baron on 3/24/23.
 //
 
-#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
+#if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>)
     #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
-#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>)
     #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
     #import "mParticle_Apple_SDK-Swift.h"


### PR DESCRIPTION
## Summary
 - React Native was having trouble with the imports and in the process of correcting the imports for that we realized 'use_frameworks!' was no longer required for initializing with cocaopods.

 ## Testing Plan
 - Tested for React Native, Cocaopods, and SPM for Location and No-Location builds

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5564
