### PR TITLE
docs: Update Readme for use_frameworks! updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ The mParticle-Apple-SDK is available via [CocoaPods](https://cocoapods.org/?q=mp
 To integrate the SDK using CocoaPods, specify it in your [Podfile](https://guides.cocoapods.org/syntax/podfile.html):
 
 ```ruby
-# The line below is required since we're using Swift
-use_frameworks!
-
 target '<Your Target>' do
     pod 'mParticle-Apple-SDK', '~> 8'
     
@@ -47,9 +44,6 @@ Configuring your `Podfile` with the statement above will include only the _Core_
 If you'd like to add any kits, you can do so as follows:
 
 ```ruby
-# The line below is required since we're using Swift
-use_frameworks!
-
 target '<Your Target>' do
     pod 'mParticle-Appboy', '~> 8'
     pod 'mParticle-BranchMetrics', '~> 8'
@@ -58,19 +52,6 @@ end
 ```
 
 In the cases above, the _Appboy_, _Branch Metrics_, and _Localytics_ kits would be integrated together with the core SDK.
-
-#### Working with Static Libraries
-
-mParticle's iOS SDK and its embedded kits are [dynamic libraries](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/OverviewOfDynamicLibraries.html), meaning their code is loaded into an app's address space only as needed, as opposed to a 'static' library, which is always included in full in the app's executable file. Some mParticle embedded kits rely on static libraries maintained by our partners. A static framework, wrapped in a dynamic library is incompatible with CocoaPods' `use frameworks!` option. Affected kits are: Appboy, AppsFlyer, comScore, Kahuna, Kochava, Localytics and Radar.
-
-Attempting to use these kits with `use_frameworks!` will result in the following error message:
-
-`[!] The '<your Target>' target has transitive dependencies that include static binaries: (<path to framework>)`
-
-If you need to reference these kits' methods from user-level code, you must incorporate them manually. To do this:
-
-1. Add the partner SDK (for example, `Appboy-iOS-SDK` or `AppsFlyer-SDK`) directly to your Podfile.
-2. Remove the embedded kit pod(`mParticle-<partner name>`) from the Podfile, download the source code from Github and manually drag its `.m` and `.h` files directly into your project.
 
 #### Crash Reporter
 


### PR DESCRIPTION
## Summary
 - `use_frameworks!` for a period of time was required to solve several issues when importing 3rd party libraries including this sdk. Recently with Swift static framework support it no longer became required for our SDK

 ## Testing Plan
 - Tested across all forms of SDK integration

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5564
