### PR TITLE
test: Update string check for Xcode 15 compat

### DIFF
--- a/UnitTests/MParticleTests.m
+++ b/UnitTests/MParticleTests.m
@@ -640,9 +640,9 @@
         NSDictionary *userInfo = self->lastNotification.userInfo;
         XCTAssertEqual(2, userInfo.count);
         NSNumber *sessionID = userInfo[mParticleSessionId];
-        XCTAssertEqualObjects(NSStringFromClass([sessionID class]), @"__NSCFNumber");
+        XCTAssertTrue([sessionID isKindOfClass:[NSNumber class]]);
         NSString *sessionUUID = userInfo[mParticleSessionUUID];
-        XCTAssertEqualObjects(NSStringFromClass([sessionUUID class]), @"__NSCFString");
+        XCTAssertTrue([sessionUUID isKindOfClass:[NSString class]]);
         [expectation fulfill];
     };
     testNotificationHandler = block;
@@ -660,9 +660,9 @@
         NSDictionary *userInfo = self->lastNotification.userInfo;
         XCTAssertEqual(2, userInfo.count);
         NSNumber *sessionID = userInfo[mParticleSessionId];
-        XCTAssertEqualObjects(NSStringFromClass([sessionID class]), @"__NSCFNumber");
+        XCTAssertTrue([sessionID isKindOfClass:[NSNumber class]]);
         NSString *sessionUUID = userInfo[mParticleSessionUUID];
-        XCTAssertEqualObjects(NSStringFromClass([sessionUUID class]), @"__NSCFString");
+        XCTAssertTrue([sessionUUID isKindOfClass:[NSString class]]);
         [expectation fulfill];
     };
     testNotificationHandler = block;


### PR DESCRIPTION
## Summary
We were previously directly checking the internal obj-c string class name in 2 unit tests. This has changed to the internal swift class name in iOS 17/Xcode 15. I modified the checks to use the more generic `isKindOfClass:` and now they work on both iOS 17 and earlier versions.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tests confirmed using both Xcode 14 and 15

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5711
