### PR TITLE
test: Handle different URL formatting in iOS 17

### DIFF
--- a/UnitTests/MPURLRequestBuilderTests.m
+++ b/UnitTests/MPURLRequestBuilderTests.m
@@ -456,7 +456,7 @@
     result = builder.url.defaultURL.absoluteString;
     XCTAssertEqualObjects(result, @"https://identity.mparticle.com/v1/12/modify");
     result = builder.url.url.absoluteString;
-    XCTAssertEqualObjects(result, @"https://https://example.com/12/modify");
+    XCTAssertTrue([result isEqualToString:@"https://https://example.com/12/modify"] || [result isEqualToString:@"https://https//example.com/12/modify"]);
     
     networkOptions.identityHost = (id _Nonnull)nil;
     baseURL = [networkCommunication modifyURL];


### PR DESCRIPTION
 ## Summary
This test just confirms that if a customer sets their custom hosts incorrectly by prepending `https://`, the URL will be incorrect. In iOS 17 it's still incorrect, just in a slightly different way. This won't affect customers with currently correct configurations, so I've just adjusted the test to handle both formats.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed it works on both iOS 16 and 17

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5712
