### PR TITLE
feat: Direct routing to correct pod

### DIFF
--- a/UnitTests/MPNetworkCommunication+Tests.h
+++ b/UnitTests/MPNetworkCommunication+Tests.h
@@ -2,12 +2,19 @@
 
 @class MPURL;
 
+extern NSString * _Nonnull const kMPURLHostEventSubdomain;
+extern NSString * _Nonnull const kMPURLHostIdentitySubdomain;
+
 @interface MPNetworkCommunication(Tests)
 
-- (MPURL *)configURL;
-- (MPURL *)eventURL;
-- (MPURL *)aliasURL;
-- (MPURL *)modifyURL;
-- (MPURL *)identifyURL;
+- (nonnull NSString *)defaultHostWithSubdomain:(nonnull NSString *)subdomain apiKey:(nonnull NSString *)apiKey enableDirectRouting:(BOOL)enableDirectRouting;
+- (nonnull NSString *)defaultEventHost;
+- (nonnull NSString *)defaultIdentityHost;
+
+- (nonnull MPURL *)configURL;
+- (nonnull MPURL *)eventURL;
+- (nonnull MPURL *)aliasURL;
+- (nonnull MPURL *)modifyURL;
+- (nonnull MPURL *)identifyURL;
 
 @end

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -838,4 +838,31 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     XCTAssertEqualObjects([networkCommunication maxAgeForCache:test5], @16);
 }
 
+- (void)testPodURLRouting {
+    // NOTE: All keys are fake and randomly generated just for this test
+    NSArray *testKeys = @[
+        @[@"4u8wmsug0pf5tbf58lgjiouma3qukrgbu",     @"nativesdks.us1.mparticle.com", @"identity.us1.mparticle.com"],
+        @[@"us1-1vc4gbp24cdtx6e31s58icnymzy83f1uf", @"nativesdks.us1.mparticle.com", @"identity.us1.mparticle.com"],
+        @[@"us2-v2p8lr3w2g90vtpaumbq21zy05cl50qm3", @"nativesdks.us2.mparticle.com", @"identity.us2.mparticle.com"],
+        @[@"eu1-bkabfno0b8zpv5bwi2zm2mfa1kfml19al", @"nativesdks.eu1.mparticle.com", @"identity.eu1.mparticle.com"],
+        @[@"au1-iermuj83dbeoshm0n32f10feotclq6i4a", @"nativesdks.au1.mparticle.com", @"identity.au1.mparticle.com"],
+        @[@"st1-k77ivhkbbqf4ce0s3y12zpcthyn1ixfyu", @"nativesdks.st1.mparticle.com", @"identity.st1.mparticle.com"],
+        @[@"us3-w1y2y8yj8q58d5bx9u2dvtxzl4cpa7cuf", @"nativesdks.us3.mparticle.com", @"identity.us3.mparticle.com"]
+    ];
+    NSString *oldEventHost = @"nativesdks.mparticle.com";
+    NSString *oldIdentityHost = @"identity.mparticle.com";
+    
+    MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
+    for (NSArray *test in testKeys) {
+        NSString *key = test[0];
+        NSString *eventHost = test[1];
+        NSString *identityHost = test[2];
+        
+        XCTAssertEqualObjects(eventHost, [networkCommunication defaultHostWithSubdomain:kMPURLHostEventSubdomain apiKey:key enableDirectRouting:YES]);
+        XCTAssertEqualObjects(identityHost, [networkCommunication defaultHostWithSubdomain:kMPURLHostIdentitySubdomain apiKey:key enableDirectRouting:YES]);
+        XCTAssertEqualObjects(oldEventHost, [networkCommunication defaultHostWithSubdomain:kMPURLHostEventSubdomain apiKey:key enableDirectRouting:NO]);
+        XCTAssertEqualObjects(oldIdentityHost, [networkCommunication defaultHostWithSubdomain:kMPURLHostIdentitySubdomain apiKey:key enableDirectRouting:NO]);
+    }
+}
+
 @end

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
@@ -11,8 +11,6 @@
 
 
 extern NSString * _Nonnull const kMPURLScheme;
-extern NSString * _Nonnull const kMPURLHost;
-extern NSString * _Nonnull const kMPURLHostConfig;
 
 typedef NS_ENUM(NSInteger, MPNetworkError) {
     MPNetworkErrorTimeout = 1,

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -57,6 +57,7 @@
 @property (nonatomic) BOOL automaticSessionTracking;
 @property (nonatomic) BOOL allowASR;
 @property (nonatomic, nullable) MPDataPlanOptions *dataPlanOptions;
+@property (nonatomic) BOOL enableDirectRouting;
 
 + (MPEnvironment)environment;
 + (void)setEnvironment:(MPEnvironment)environment;


### PR DESCRIPTION
 ## Summary
 - Directly route to the correct pod using the api key prefix when feature flag is enabled

 ## Testing Plan
 - Added unit tests
 - E2E tested against all pods

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5771
