### PR TITLE
fix:Correct Push Notifications Counts for Notification Center

### DIFF
--- a/mParticle-Apple-SDK/MPEnums.m
+++ b/mParticle-Apple-SDK/MPEnums.m
@@ -74,6 +74,8 @@ NSString * const MPKitAPIErrorKey = @"mParticle Kit API Error";
         return MPMessageTypeBreadcrumb;
     } else if ([messageTypeString isEqualToString:kMPMessageTypeStringProfile]) {
         return MPMessageTypeProfile;
+    } else if ([messageTypeString isEqualToString:kMPMessageTypeStringPushNotification]) {
+        return MPMessageTypePushNotification;
     } else if ([messageTypeString isEqualToString:kMPMessageTypeStringPushNotificationInteraction]) {
         return MPMessageTypePushNotificationInteraction;
     } else if ([messageTypeString isEqualToString:kMPMessageTypeStringCommerceEvent]) {


### PR DESCRIPTION
## Summary
 - Push Notifications received for User notification center were not sending forward record counts despite sending the data to the kit. Additionally I observed that push notification responses were being sent as push notifications recieved..

 ## Testing Plan
 - Tested locally in association with corresponding [Braze update](https://github.com/mparticle-integrations/mparticle-apple-integration-appboy/pull/81)
 - confirmed in mparticle UI 
<img width="215" alt="Screenshot 2023-09-27 at 12 25 23 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/9d0a9a2a-bab1-420f-8083-127117fb105a">

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5624
