### PR TITLE
feat: 5343 Refactor Kit Filter Hash Functions

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -61,7 +61,6 @@
 - (nullable NSString *)nameForKitCode:(nonnull NSNumber *)integrationId;
 - (id<MPKitProtocol>)startKit:(NSNumber *)integrationId configuration:(MPKitConfiguration *)kitConfiguration;
 - (void)flushSerializedKits;
-- (NSDictionary *)methodMessageTypeMapping;
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forEvent:(MPEvent *const)event selector:(SEL)selector;
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forBaseEvent:(MPBaseEvent *const)event forSelector:(SEL)selector;
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forUserAttributeKey:(NSString *)key value:(id)value;

--- a/mParticle-Apple-SDK/Include/MPIHasher.h
+++ b/mParticle-Apple-SDK/Include/MPIHasher.h
@@ -8,6 +8,12 @@
 + (NSString *)hashStringUTF16:(NSString *)stringToHash;
 + (NSString *)hashEventType:(MPEventType)eventType;
 + (MPEventType)eventTypeForHash:(NSString *)hashString;
-
++ (NSString *)hashEventName:(MPEventType)eventType eventName:(NSString *)eventName isLogScreen:(BOOL)isLogScreen;
++ (NSString *)hashEventAttributeKey:(MPEventType)eventType eventName:(NSString *)eventName customAttributeName:(NSString *)customAttributeName isLogScreen:(BOOL)isLogScreen;
++ (NSString *)hashUserAttributeKey:(NSString *)userAttributeKey;
++ (NSString *)hashUserAttributeValue:(NSString *)userAttributeValue;
++ (NSString *)hashUserIdentity:(MPUserIdentity)userIdentity;
++ (NSString *)hashConsentPurpose:(NSString *)regulationPrefix purpose:(NSString *)purpose;
++ (NSString *)hashCommerceEventAttribute:(MPEventType)commerceEventType key:(NSString *)key;
 
 @end

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -35,6 +35,7 @@
 #import "MPIConstants.h"
 #import "MPDataPlanFilter.h"
 #import <objc/message.h>
+#include <vector>
 
 #define DEFAULT_ALLOCATION_FOR_KITS 2
 

--- a/mParticle-Apple-SDK/Utils/MPIHasher.mm
+++ b/mParticle-Apple-SDK/Utils/MPIHasher.mm
@@ -33,4 +33,51 @@
     
     return MPEventTypeOther;
 }
+
++ (NSString *)hashEventName:(MPEventType)eventType eventName:(NSString *)eventName isLogScreen:(BOOL)isLogScreen {
+    NSString *stringToBeHashed;
+    if (isLogScreen) {
+        stringToBeHashed = [NSString stringWithFormat:@"%@%@", @"0", [eventName lowercaseString]];
+
+    } else {
+        stringToBeHashed = [NSString stringWithFormat:@"%@%@", [@(eventType) stringValue], [eventName lowercaseString]];
+    }
+    return [NSString stringWithCString:mParticle::Hasher::hashString([stringToBeHashed cStringUsingEncoding:NSUTF8StringEncoding]).c_str() encoding:NSUTF8StringEncoding];
+}
+
++ (NSString *)hashEventAttributeKey:(MPEventType)eventType eventName:(NSString *)eventName customAttributeName:(NSString *)customAttributeName isLogScreen:(BOOL)isLogScreen {
+    NSString *stringToBeHashed;
+    if (isLogScreen) {
+        stringToBeHashed = [NSString stringWithFormat:@"%@%@%@", @"0", eventName, customAttributeName];
+
+    } else {
+        stringToBeHashed = [NSString stringWithFormat:@"%@%@%@", [@(eventType) stringValue], eventName, customAttributeName];
+    }
+    return [NSString stringWithCString:mParticle::Hasher::hashString([stringToBeHashed cStringUsingEncoding:NSUTF8StringEncoding]).c_str() encoding:NSUTF8StringEncoding];
+}
+
++ (NSString *)hashUserAttributeKey:(NSString *)userAttributeKey {
+    return [NSString stringWithCString:mParticle::Hasher::hashString([[userAttributeKey lowercaseString] cStringUsingEncoding:NSUTF8StringEncoding]).c_str() encoding:NSUTF8StringEncoding];
+}
+
++ (NSString *)hashUserAttributeValue:(NSString *)userAttributeValue {
+    return [NSString stringWithCString:mParticle::Hasher::hashString([[userAttributeValue lowercaseString] cStringUsingEncoding:NSUTF8StringEncoding]).c_str() encoding:NSUTF8StringEncoding];
+}
+
+    // User Identities are not actually hashed, this method is named this way to
+    // be consistent with the filter class. UserIdentityType is also a number
++ (NSString *)hashUserIdentity:(MPUserIdentity)userIdentity {
+    return [[NSString alloc] initWithFormat:@"%lu", (unsigned long)userIdentity];
+}
+
++ (NSString *)hashConsentPurpose:(NSString *)regulationPrefix purpose:(NSString *)purpose {
+    NSString *stringToBeHashed = [NSString stringWithFormat:@"%@%@", regulationPrefix, [purpose lowercaseString]];
+    return [NSString stringWithCString:mParticle::Hasher::hashString([stringToBeHashed cStringUsingEncoding:NSUTF8StringEncoding]).c_str() encoding:NSUTF8StringEncoding];
+}
+
++ (NSString *)hashCommerceEventAttribute:(MPEventType)commerceEventType key:(NSString *)key {
+    NSString *stringToBeHashed = [NSString stringWithFormat:@"%@%@", [@(commerceEventType) stringValue], key];
+    return [NSString stringWithCString:mParticle::Hasher::hashString([[stringToBeHashed lowercaseString] UTF8String]).c_str() encoding:NSUTF8StringEncoding];
+}
+
 @end


### PR DESCRIPTION
## Summary
 - Currently the code that hashes each value and compares those hashes to the ones from the kit config is scattered all over the codebase. Since we’ll need to reuse that code in the MPSideloadedKit class to implement the “add filter” methods, we should first refactor it into a static utility class.

 ## Testing Plan
 - Tested locally and with new unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5343
