### PR TITLE
feat: Use direct url routing config feature flag

### DIFF
--- a/mParticle-Apple-SDK/MPIConstants.h
+++ b/mParticle-Apple-SDK/MPIConstants.h
@@ -273,6 +273,8 @@ extern NSString * _Nonnull const kMPRemoteConfigRestrictIDFA;
 extern NSString * _Nonnull const kMPRemoteConfigAliasMaxWindow;
 extern NSString * _Nonnull const kMPRemoteConfigAllowASR;
 extern NSString * _Nonnull const kMPRemoteConfigExcludeAnonymousUsersKey;
+extern NSString * _Nonnull const kMPRemoteConfigDirectURLRouting;
+
 extern NSString * _Nonnull const kMPRemoteConfigBlockUnplannedEvents;
 extern NSString * _Nonnull const kMPRemoteConfigBlockUnplannedEventAttributes;
 extern NSString * _Nonnull const kMPRemoteConfigBlockUnplannedIdentities;
@@ -323,8 +325,6 @@ extern NSString * _Nonnull const kMPRemoteConfigDataPlanningDataPlanVersionValue
 extern NSString * _Nonnull const kMPRemoteConfigDataPlanningDataPlanVersionValueImpressionUnknown;
 extern NSString * _Nonnull const kMPRemoteConfigDataPlanningDataPlanVersionValueImpressionView;
 extern NSString * _Nonnull const kMPRemoteConfigDataPlanningDataPlanVersionValueImpressionClick;
-
-
 
 // Notifications
 extern NSString * _Nonnull const kMPCrashReportOccurredNotification;

--- a/mParticle-Apple-SDK/MPIConstants.m
+++ b/mParticle-Apple-SDK/MPIConstants.m
@@ -224,6 +224,7 @@ NSString *const kMPRemoteConfigRestrictIDFA = @"rdlat";
 NSString *const kMPRemoteConfigAliasMaxWindow = @"alias_max_window";
 NSString *const kMPRemoteConfigAllowASR = @"iasr";
 NSString *const kMPRemoteConfigExcludeAnonymousUsersKey = @"eau";
+NSString *const kMPRemoteConfigDirectURLRouting = @"dur";
 NSString *const kMPRemoteConfigDataPlanningResults = @"dpr";
 NSString *const kMPRemoteConfigDataPlanning = @"dtpn";
 NSString *const kMPRemoteConfigDataPlanningBlock = @"blok";

--- a/mParticle-Apple-SDK/Utils/MPResponseConfig.m
+++ b/mParticle-Apple-SDK/Utils/MPResponseConfig.m
@@ -99,6 +99,7 @@
     [stateMachine configureDataBlocking:_configuration[kMPRemoteConfigDataPlanningResults]];
     
     stateMachine.allowASR = [_configuration[kMPRemoteConfigAllowASR] boolValue];
+    stateMachine.enableDirectRouting = [_configuration[kMPRemoteConfigDirectURLRouting] boolValue];
         
     // Exception handling
     NSString *auxString = !MPIsNull(_configuration[kMPRemoteConfigExceptionHandlingModeKey]) ? _configuration[kMPRemoteConfigExceptionHandlingModeKey] : nil;


### PR DESCRIPTION
 ## Summary
 - Reads the feature flag from the server config to decide whether to enable direct url routing or not (defaults to off if the key isn't included in the config)

 ## Testing Plan
 - Tested using a QA environment with the feature flag present as well as tested against production without the feature flag to confirm it defaults to false
 - Confirmed that new installs will grab the config and have access to the feature flag before making more API calls

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5777
