### PR TITLE
ci: Remove Xcode 14 from test matrix

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -12,12 +12,10 @@ jobs:
   native-unit-tests:
     strategy:
       matrix:
-        xcode: ["14.3.1", "15.0"]
+        xcode: ["15.0"]
         platform: [iOS, tvOS]
         scheme: [mParticle-Apple-SDK, mParticle-Apple-SDK-NoLocation]
         include:
-          - xcode: "14.3.1"
-            os: "16.4"
           - xcode: "15.0"
             os: "17.0"
           - platform: iOS


### PR DESCRIPTION
 ## Summary
 - Remove Xcode 14 from test matrix

 ## Testing Plan
 - This is a CI only change, we'll confirm it when CI passes

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5907
