### PR TITLE
fix: CFNetwork upload warning setting body twice

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -16,10 +16,8 @@ jobs:
         platform: [iOS, tvOS]
         scheme: [mParticle-Apple-SDK, mParticle-Apple-SDK-NoLocation]
         include:
-          - xcode: "15.0"
-            os: "17.0"
           - platform: iOS
-            device: iPhone 14
+            device: iPhone 15
           - platform: tvOS
             device: Apple TV
     runs-on: macos-13
@@ -31,4 +29,4 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
         
       - name: Run iOS unit tests
-        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme ${{ matrix.scheme }} -destination 'platform=${{ matrix.platform }} Simulator,name=${{ matrix.device }},OS=${{ matrix.os }}' test
+        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme ${{ matrix.scheme }} -destination 'platform=${{ matrix.platform }} Simulator,name=${{ matrix.device }},OS=latest' test

--- a/mParticle-Apple-SDK/Network/MPConnector.m
+++ b/mParticle-Apple-SDK/Network/MPConnector.m
@@ -242,10 +242,8 @@ static NSArray *mpStoredCertificates = nil;
 
 - (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams {
     MPConnectorResponse *response = [[MPConnectorResponse alloc] init];
-
-    NSMutableURLRequest *urlRequest = [[[MPURLRequestBuilder newBuilderWithURL:url message:message httpMethod:kMPHTTPMethodPost]
-                                             withPostData:serializedParams]
-                                            build];
+    
+    NSMutableURLRequest *urlRequest = [[[MPURLRequestBuilder newBuilderWithURL:url message:message httpMethod:kMPHTTPMethodPost] withPostData:serializedParams] build];
     
     if (urlRequest) {
         requestStartTime = [NSDate date];
@@ -261,7 +259,7 @@ static NSArray *mpStoredCertificates = nil;
             completionHttpResponse = httpResponse;
             dispatch_semaphore_signal(requestSemaphore);
         };
-        self.dataTask = [self.urlSession uploadTaskWithRequest:urlRequest fromData:serializedParams];
+        self.dataTask = [self.urlSession dataTaskWithRequest:urlRequest];
         [_dataTask resume];
         long exitCode = dispatch_semaphore_wait(requestSemaphore, dispatch_time(DISPATCH_TIME_NOW, (NETWORK_REQUEST_MAX_WAIT_SECONDS + 1) * NSEC_PER_SEC));
         if (exitCode == 0) {


### PR DESCRIPTION
 ## Summary
 - Starting with Xcode 15/iOS 17, there is a new warning in CFNetwork if you call `[NSURLSession uploadTaskWithRequest:fromData:]` if the request passed in already has its body set. In this case, we set the same data as the `HTTPBody` property of the request that we pass in to that method, so in the end the call worked fine, but now warns that we're setting it twice. Since we always set the post body on the request when we call `[MPURLRequestBuilder build]` on line 246, I've switched to using the more correct `[NSURLSession dataTaskWithRequest]` which just uses the HTTPBody from the request instead of the data we pass in. This works exactly the same, but fixes the warning.

 ## Testing Plan
- E2E tested using a test app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5921
