### PR TITLE
feat: Identity API response caching

### DIFF
--- a/UnitTests/MPIdentityApiRequestTests.m
+++ b/UnitTests/MPIdentityApiRequestTests.m
@@ -21,7 +21,7 @@
     [request setIdentity:@"foo" identityType:MPIdentityOther];
     XCTAssertEqualObjects(@"foo", [request.identities objectForKey:@(MPIdentityOther)]);
     [request setIdentity:nil identityType:MPIdentityOther];
-    XCTAssertEqual([NSNull null], [request.identities objectForKey:@(MPIdentityOther)]);
+    XCTAssertEqualObjects([NSNull null], [request.identities objectForKey:@(MPIdentityOther)]);
 }
 
 - (void)testSetNullIdentity {
@@ -29,7 +29,7 @@
     [request setIdentity:@"foo" identityType:MPIdentityOther];
     XCTAssertEqualObjects(@"foo", [request.identities objectForKey:@(MPIdentityOther)]);
     [request setIdentity:(id)[NSNull null] identityType:MPIdentityOther];
-    XCTAssertEqual([NSNull null], [request.identities objectForKey:@(MPIdentityOther)]);
+    XCTAssertEqualObjects([NSNull null], [request.identities objectForKey:@(MPIdentityOther)]);
 }
 
 - (void)testsetIdentity {
@@ -53,8 +53,8 @@
     MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
     request.customerId = nil;
     request.email = nil;
-    XCTAssertNotEqual((NSNull *)request.email, [NSNull null]);
-    XCTAssertNotEqual((NSNull *)request.customerId, [NSNull null]);
+    XCTAssertNotEqualObjects(request.email, [NSNull null]);
+    XCTAssertNotEqualObjects(request.customerId, [NSNull null]);
 }
 
 @end

--- a/UnitTests/MPIdentityCachingTests.m
+++ b/UnitTests/MPIdentityCachingTests.m
@@ -248,9 +248,9 @@ static NSString *const kMPIdentityCachingExpires = @"kMPIdentityCachingExpires";
     
     NSDictionary *identities = [MPIdentityCaching identitiesFromIdentityRequest:modifyRequest];
     NSDictionary *expected = @{
-        @"email": @{@"identity_type": @"email", @"old_value": @"test1@test1.com", @"new_value": @"test2@test2.com"},
-        @"customerid": @{@"identity_type": @"customerid", @"old_value": [NSNull null], @"new_value": @"12345"},
-        @"other2": @{@"identity_type": @"other2", @"old_value": @"1234", @"new_value": @"5678"}
+        @"email": @"f7d23cbd1bf6f52cb02dc284975e82d6736e7f78c91debe52b8ff662a91bba3f",
+        @"customerid": @"01b5fceb64d02bf05e06b21e733ad2352f603535c278b1c5da37f7d36e51ed57",
+        @"other2": @"e544742c897e61c4a4d6fddf3bec3182ba9f611a5f6b6c6bc4b20cfdf4bd7495"
     };
     XCTAssertEqualObjects(identities, expected);
 }

--- a/UnitTests/MPIdentityCachingTests.m
+++ b/UnitTests/MPIdentityCachingTests.m
@@ -1,0 +1,318 @@
+#ifndef MPARTICLE_LOCATION_DISABLE
+@import mParticle_Apple_SDK;
+#else
+@import mParticle_Apple_SDK_NoLocation;
+#endif
+
+#import <XCTest/XCTest.h>
+#import "MPBaseTestCase.h"
+#import "MPIdentityCaching.h"
+#import "MPIdentityDTO.h"
+
+// Dictionary keys
+static NSString *const kMPIdentityCachingBodyData = @"kMPIdentityCachingBodyData";
+static NSString *const kMPIdentityCachingStatusCode = @"kMPIdentityCachingStatusCode";
+static NSString *const kMPIdentityCachingExpires = @"kMPIdentityCachingExpires";
+
+@interface MPIdentityCachedResponse()
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dictionary;
+@end
+
+@interface MPIdentityCaching()
++ (void)cacheIdentityResponse:(nonnull MPIdentityCachedResponse *)cachedResponse endpoint:(MPEndpoint)endpoint identities:(nonnull NSDictionary *)identities;
++ (nullable MPIdentityCachedResponse *)getCachedIdentityResponseForEndpoint:(MPEndpoint)endpoint identities:(nonnull NSDictionary *)identities;
++ (nullable NSDictionary<NSString*, NSDictionary*> *)getCache;
++ (void)setCache:(nullable NSDictionary<NSString*, NSDictionary*> *)cache;
++ (nonnull NSString *)keyWithEndpoint:(MPEndpoint)endpoint identities:(nonnull NSDictionary *)identities;
++ (nullable NSDictionary *)identitiesFromIdentityRequest:(nonnull MPIdentityHTTPBaseRequest *)identityRequest;
++ (nullable NSString *)hashIdentities:(NSDictionary *)identities;
++ (nullable NSString *)serializeIdentities:(NSDictionary *)identities;
++ (nullable NSString *)sha256Hash:(NSString *)string;
+@end
+
+@interface MPIdentityCachingTests : MPBaseTestCase
+@end
+
+@implementation MPIdentityCachingTests
+
+- (void)setUp {
+    [super setUp];
+    [MPIdentityCaching setCache:nil];
+}
+
+- (void)tearDown {
+    [super tearDown];
+    [MPIdentityCaching setCache:nil];
+}
+
+- (void)testGetCachedResponse {
+    NSDictionary *identities = @{
+        @"ios_idfv": @"abcdefg",
+        @"email": @"test1@test2.com",
+        @"customerid": @"12345",
+        @"google": [NSNull null]
+    };
+    
+    NSDictionary *cache = @{
+        @"0::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1": @{
+            kMPIdentityCachingBodyData: [@"0" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [NSDate date] // Expired
+        },
+        @"1::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1": @{
+            kMPIdentityCachingBodyData: [@"1" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:50] // Valid
+        },
+        @"2::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1": @{
+            kMPIdentityCachingBodyData: [@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:-100] // Expired
+        },
+        @"3::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1": @{
+            kMPIdentityCachingBodyData: [@"3" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:8000] // Valid
+        }
+    };
+    [MPIdentityCaching setCache:cache];
+    
+    // Test valid match
+    MPIdentityCachedResponse *cached1 = [MPIdentityCaching getCachedIdentityResponseForEndpoint:MPEndpointIdentityLogout identities:identities];
+    NSDictionary *dict1 = [cache objectForKey:@"1::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1"];
+    MPIdentityCachedResponse *original1 = [[MPIdentityCachedResponse alloc] initWithDictionary:dict1];
+    XCTAssertEqualObjects(cached1, original1);
+    
+    // Test expired match
+    MPIdentityCachedResponse *cached2 = [MPIdentityCaching getCachedIdentityResponseForEndpoint:MPEndpointIdentityLogin identities:identities];
+    XCTAssertNil(cached2);
+    
+    // Test partial match
+    NSDictionary *partialIdentities = @{
+        @"email": @"test1@test2.com",
+        @"customerid": @"12345"
+    };
+    MPIdentityCachedResponse *cached3 = [MPIdentityCaching getCachedIdentityResponseForEndpoint:MPEndpointIdentityModify identities:partialIdentities];
+    XCTAssertNil(cached3);
+    
+    // Test no match
+    NSDictionary *noMatchIdentities = @{
+        @"MPIdentityEmail": @"test5@test10.com",
+        @"MPIdentityCustomerId": @"67890"
+    };
+    MPIdentityCachedResponse *cached4 = [MPIdentityCaching getCachedIdentityResponseForEndpoint:MPEndpointIdentityModify identities:noMatchIdentities];
+    XCTAssertNil(cached4);
+}
+
+- (void)testSetGetCache {
+    NSDictionary *cache = @{
+        @"0::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"0" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [NSDate date] // Expired
+        },
+        @"1::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"1" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:50] // Valid
+        },
+        @"2::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:-100] // Expired
+        },
+        @"3::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"3" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:8000] // Valid
+        }
+    };
+    
+    XCTAssertNil([MPIdentityCaching getCache]);
+    
+    [MPIdentityCaching setCache:cache];
+    XCTAssertEqualObjects(cache, [MPIdentityCaching getCache]);
+}
+
+- (void)testClearAllCache {
+    NSDictionary *cache = @{
+        @"0::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"0" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [NSDate date] // Expired
+        },
+        @"1::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"1" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:50] // Valid
+        },
+        @"2::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:-100] // Expired
+        },
+        @"3::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"3" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:8000] // Valid
+        }
+    };
+    [MPIdentityCaching setCache:cache];
+    XCTAssertEqualObjects(cache, [MPIdentityCaching getCache]);
+    
+    [MPIdentityCaching clearAllCache];
+    XCTAssertNil([MPIdentityCaching getCache]);
+}
+
+- (void)testClearExpiredCache {
+    NSDictionary *cache = @{
+        @"0::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"0" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [NSDate date] // Expired
+        },
+        @"1::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"1" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:50] // Valid
+        },
+        @"2::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:-100] // Expired
+        },
+        @"3::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d": @{
+            kMPIdentityCachingBodyData: [@"3" dataUsingEncoding:NSUTF8StringEncoding],
+            kMPIdentityCachingStatusCode: @200,
+            kMPIdentityCachingExpires: [[NSDate date] dateByAddingTimeInterval:8000] // Valid
+        }
+    };
+    
+    NSMutableDictionary *onlyValidCache = [cache mutableCopy];
+    [onlyValidCache removeObjectForKey:@"0::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d"];
+    [onlyValidCache removeObjectForKey:@"2::fd54ce706ef89564f0d25321dc38cefce06fc0b886aae7c71f38e293fb67789d"];
+    
+    [MPIdentityCaching setCache:cache];
+    XCTAssertEqualObjects(cache, [MPIdentityCaching getCache]);
+    
+    [MPIdentityCaching clearExpiredCache];
+    XCTAssertEqualObjects(onlyValidCache, [MPIdentityCaching getCache]);
+}
+
+- (void)testKeyWithEndpointAndIdentities {
+    NSDictionary *identities = @{
+        @"ios_idfv": @"abcdefg",
+        @"email": @"test1@test2.com",
+        @"customerid": @"12345",
+        @"google": [NSNull null]
+    };
+    
+    NSString *key1 = [MPIdentityCaching keyWithEndpoint:MPEndpointIdentityLogin identities:identities];
+    XCTAssertEqualObjects(key1, @"0::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1");
+    
+    NSString *key2 = [MPIdentityCaching keyWithEndpoint:MPEndpointIdentityLogout identities:identities];
+    XCTAssertEqualObjects(key2, @"1::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1");
+    
+    NSString *key3 = [MPIdentityCaching keyWithEndpoint:MPEndpointIdentityIdentify identities:identities];
+    XCTAssertEqualObjects(key3, @"2::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1");
+    
+    NSString *key4 = [MPIdentityCaching keyWithEndpoint:MPEndpointIdentityModify identities:identities];
+    XCTAssertEqualObjects(key4, @"3::6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1");
+}
+
+- (void)testIdentitiesFromIdentifyHTTPRequest {
+    MPIdentifyHTTPRequest *identifyRequest = [[MPIdentifyHTTPRequest alloc] init];
+    identifyRequest.knownIdentities = [[MPIdentityHTTPIdentities alloc] initWithIdentities:@{
+        @(MPIdentityIOSVendorId): @"abcdefg",
+        @(MPIdentityEmail): @"test1@test2.com",
+        @(MPIdentityCustomerId): @"12345",
+        @(MPIdentityGoogle): [NSNull null]
+    }];
+    
+    NSDictionary *identities = [MPIdentityCaching identitiesFromIdentityRequest:identifyRequest];
+    NSDictionary *expected = @{
+        @"ios_idfv": @"abcdefg",
+        @"email": @"test1@test2.com",
+        @"customerid": @"12345",
+        @"google": [NSNull null]
+    };
+    XCTAssertEqualObjects(identities, expected);
+}
+
+- (void)testIdentitiesFromModifyHTTPRequest {
+    MPIdentityHTTPModifyRequest *modifyRequest = [[MPIdentityHTTPModifyRequest alloc] initWithIdentityChanges:@[
+        [[MPIdentityHTTPIdentityChange alloc] initWithOldValue:@"test1@test1.com" value:@"test2@test2.com" identityType:@"email"],
+        [[MPIdentityHTTPIdentityChange alloc] initWithOldValue:nil value:@"12345" identityType:@"customerid"],
+        [[MPIdentityHTTPIdentityChange alloc] initWithOldValue:@"1234" value:@"5678" identityType:@"other2"]
+    ]];
+    
+    NSDictionary *identities = [MPIdentityCaching identitiesFromIdentityRequest:modifyRequest];
+    NSDictionary *expected = @{
+        @"email": @{@"identity_type": @"email", @"old_value": @"test1@test1.com", @"new_value": @"test2@test2.com"},
+        @"customerid": @{@"identity_type": @"customerid", @"old_value": [NSNull null], @"new_value": @"12345"},
+        @"other2": @{@"identity_type": @"other2", @"old_value": @"1234", @"new_value": @"5678"}
+    };
+    XCTAssertEqualObjects(identities, expected);
+}
+
+- (void)testHashIdentities {
+    NSString *hash1 = [MPIdentityCaching hashIdentities:nil];
+    XCTAssertNil(hash1);
+    
+    NSString *hash2 = [MPIdentityCaching hashIdentities:@{}];
+    XCTAssertNil(hash2);
+    
+    NSDictionary *dict3 = @{
+        @(MPIdentityEmail): @"test@test.com"
+    };
+    NSString *hash3 = [MPIdentityCaching hashIdentities:dict3];
+    XCTAssertEqualObjects(hash3, @"c610ba538a9a66cd34b4eb0bc7937ce944bbcf48ca292d500ed85b805aca3e02");
+
+    NSDictionary *dict4 = @{
+        @"ios_idfv": @"abcdefg",
+        @"email": @"test1@test2.com",
+        @"customerid": @"12345",
+        @"google": [NSNull null]
+    };
+    NSString *hash4 = [MPIdentityCaching hashIdentities:dict4];
+    XCTAssertEqualObjects(hash4, @"6aeb076bd3732431628b4d88c6019274b3d4444393ec041f8975f4e69773e4f1");
+}
+
+- (void)testSerializeIdentities {
+    NSString *string1 = [MPIdentityCaching serializeIdentities:nil];
+    XCTAssertEqualObjects(string1, @"");
+    
+    NSString *string2 = [MPIdentityCaching serializeIdentities:@{}];
+    XCTAssertEqualObjects(string2, @"");
+    
+    NSDictionary *dict3 = @{
+        @(MPIdentityEmail): @"test@test.com"
+    };
+    NSString *string3 = [MPIdentityCaching serializeIdentities:dict3];
+    XCTAssertEqualObjects(string3, @"::7:test@test.com");
+    
+    NSDictionary *dict4 = @{
+        @"ios_idfv": @"abcdefg",
+        @"email": @"test1@test2.com",
+        @"customerid": @"12345",
+        @"google": [NSNull null]
+    };
+    NSString *string4 = [MPIdentityCaching serializeIdentities:dict4];
+    XCTAssertEqualObjects(string4, @"::customerid:12345::email:test1@test2.com::google:null::ios_idfv:abcdefg");
+}
+
+- (void)testSha256Hash {
+    NSString *hash1 = [MPIdentityCaching sha256Hash:nil];
+    XCTAssertNil(hash1);
+    
+    NSString *hash2 = [MPIdentityCaching sha256Hash:@""];
+    XCTAssertNil(hash2);
+    
+    NSString *hash3 = [MPIdentityCaching sha256Hash:@"::email:test@test.com::customerid:12435"];
+    XCTAssertEqualObjects(hash3, @"aa58bbc1adccecb75fbb00cf9f424ca2098b8b7273a235a07c473b1b129810b5");
+    
+    NSString *hash4 = [MPIdentityCaching sha256Hash:@"::email:null"];
+    XCTAssertEqualObjects(hash4, @"46bdfb15bd51f77b7955516d3ac92ec1a90856cac70e9343c510cf39532d2007");
+}
+
+@end

--- a/UnitTests/MPIdentityCachingTests.m
+++ b/UnitTests/MPIdentityCachingTests.m
@@ -23,7 +23,7 @@ static NSString *const kMPIdentityCachingExpires = @"kMPIdentityCachingExpires";
 + (nullable MPIdentityCachedResponse *)getCachedIdentityResponseForEndpoint:(MPEndpoint)endpoint identities:(nonnull NSDictionary *)identities;
 + (nullable NSDictionary<NSString*, NSDictionary*> *)getCache;
 + (void)setCache:(nullable NSDictionary<NSString*, NSDictionary*> *)cache;
-+ (nonnull NSString *)keyWithEndpoint:(MPEndpoint)endpoint identities:(nonnull NSDictionary *)identities;
++ (nullable NSString *)keyWithEndpoint:(MPEndpoint)endpoint identities:(nonnull NSDictionary *)identities;
 + (nullable NSDictionary *)identitiesFromIdentityRequest:(nonnull MPIdentityHTTPBaseRequest *)identityRequest;
 + (nullable NSString *)hashIdentities:(NSDictionary *)identities;
 + (nullable NSString *)serializeIdentities:(NSDictionary *)identities;

--- a/UnitTests/MPIdentityTests.m
+++ b/UnitTests/MPIdentityTests.m
@@ -63,12 +63,6 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 
 @end
 
-@interface MPIdentityApiRequest ()
-
-- (NSDictionary<NSString *, id> *)dictionaryRepresentation;
-
-@end
-
 @implementation MPIdentityTests
 
 - (void)setUp {
@@ -1079,42 +1073,4 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     XCTAssertNotNil(dictionary[@"request_id"]);
 }
 
-- (void)testDictionaryRepresentation {
-    MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
-    NSData *testDeviceToken = [@"<000000000000000000000000000000>" dataUsingEncoding:NSUTF8StringEncoding];
-    userDefaults[kMPDeviceTokenKey] = testDeviceToken;
-    
-    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
-    [request setIdentity:@"other id" identityType:MPIdentityOther];
-    [request setIdentity:@"other id 2" identityType:MPIdentityOther2];
-    [request setIdentity:@"other id 3" identityType:MPIdentityOther3];
-    [request setIdentity:@"other id 4" identityType:MPIdentityOther4];
-    [request setIdentity:@"other id 5" identityType:MPIdentityOther5];
-    [request setIdentity:@"other id 6" identityType:MPIdentityOther6];
-    [request setIdentity:@"other id 7" identityType:MPIdentityOther7];
-    [request setIdentity:@"other id 8" identityType:MPIdentityOther8];
-    [request setIdentity:@"other id 9" identityType:MPIdentityOther9];
-    [request setIdentity:@"other id 10" identityType:MPIdentityOther10];
-    [request setIdentity:@"mobile number" identityType:MPIdentityMobileNumber];
-    [request setIdentity:@"phone number 2" identityType:MPIdentityPhoneNumber2];
-    [request setIdentity:@"phone number 3" identityType:MPIdentityPhoneNumber3];
-    
-    NSDictionary *dictionary = request.dictionaryRepresentation;
-#if TARGET_OS_IOS == 1
-    XCTAssertEqualObjects(dictionary[@"push_token"], @"3c3030303030303030303030303030303030303030303030303030303030303e");
-#endif
-    XCTAssertEqualObjects(dictionary[@"other"], @"other id");
-    XCTAssertEqualObjects(dictionary[@"other2"], @"other id 2");
-    XCTAssertEqualObjects(dictionary[@"other3"], @"other id 3");
-    XCTAssertEqualObjects(dictionary[@"other4"], @"other id 4");
-    XCTAssertEqualObjects(dictionary[@"other5"], @"other id 5");
-    XCTAssertEqualObjects(dictionary[@"other6"], @"other id 6");
-    XCTAssertEqualObjects(dictionary[@"other7"], @"other id 7");
-    XCTAssertEqualObjects(dictionary[@"other8"], @"other id 8");
-    XCTAssertEqualObjects(dictionary[@"other9"], @"other id 9");
-    XCTAssertEqualObjects(dictionary[@"other10"], @"other id 10");
-    XCTAssertEqualObjects(dictionary[@"mobile_number"], @"mobile number");
-    XCTAssertEqualObjects(dictionary[@"phone_number_2"], @"phone number 2");
-    XCTAssertEqualObjects(dictionary[@"phone_number_3"], @"phone number 3");
-}
 @end

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		531BCF342B28A23400F5C573 /* MPIdentityCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 531BCF322B28A23400F5C573 /* MPIdentityCaching.h */; };
+		531BCF352B28A23400F5C573 /* MPIdentityCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 531BCF322B28A23400F5C573 /* MPIdentityCaching.h */; };
+		531BCF362B28A23400F5C573 /* MPIdentityCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 531BCF332B28A23400F5C573 /* MPIdentityCaching.m */; };
+		531BCF372B28A23400F5C573 /* MPIdentityCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 531BCF332B28A23400F5C573 /* MPIdentityCaching.m */; };
+		531BCF3A2B28A83E00F5C573 /* MPIdentityCachingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */; };
+		531BCF3B2B28A83E00F5C573 /* MPIdentityCachingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */; };
 		534CD25C29CE2877008452B3 /* NSNumber+MPFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A79B2629CDFB1F00E7489F /* NSNumber+MPFormatter.swift */; };
 		534CD25E29CE2BF1008452B3 /* Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 534CD25D29CE2BF1008452B3 /* Swift.h */; };
 		534CD25F29CE2BF1008452B3 /* Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 534CD25D29CE2BF1008452B3 /* Swift.h */; };
@@ -127,7 +133,7 @@
 		53A79B9629CDFB2000E7489F /* MPSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79ACC29CDFB1E00E7489F /* MPSession.m */; };
 		53A79B9729CDFB2000E7489F /* MPIntegrationAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79ACD29CDFB1E00E7489F /* MPIntegrationAttributes.m */; };
 		53A79B9829CDFB2000E7489F /* MPConsumerInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79ACE29CDFB1F00E7489F /* MPConsumerInfo.h */; };
-		53A79B9929CDFB2000E7489F /* MPIConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79ACF29CDFB1F00E7489F /* MPIConstants.h */; };
+		53A79B9929CDFB2000E7489F /* MPIConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79ACF29CDFB1F00E7489F /* MPIConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53A79B9A29CDFB2000E7489F /* MPEnums.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79AD029CDFB1F00E7489F /* MPEnums.m */; };
 		53A79BBD29CDFB2000E7489F /* MPBackendController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79AF429CDFB1F00E7489F /* MPBackendController.m */; };
 		53A79BBE29CDFB2000E7489F /* MPCCPAConsent.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79AF629CDFB1F00E7489F /* MPCCPAConsent.m */; };
@@ -531,6 +537,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		531BCF322B28A23400F5C573 /* MPIdentityCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPIdentityCaching.h; sourceTree = "<group>"; };
+		531BCF332B28A23400F5C573 /* MPIdentityCaching.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPIdentityCaching.m; sourceTree = "<group>"; };
+		531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPIdentityCachingTests.m; sourceTree = "<group>"; };
 		534CD25D29CE2BF1008452B3 /* Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Swift.h; sourceTree = "<group>"; };
 		534CD2AA29CE2CE1008452B3 /* mParticle-Apple-SDK-NoLocationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-Apple-SDK-NoLocationTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		53A79A7929CCCD6400E7489F /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -950,6 +959,8 @@
 				53A79AB929CDFB1E00E7489F /* MPDatabaseMigrationController.m */,
 				53A79ABA29CDFB1E00E7489F /* MPDatabaseMigrationController.h */,
 				53A79ABB29CDFB1E00E7489F /* MPPersistenceController.h */,
+				531BCF322B28A23400F5C573 /* MPIdentityCaching.h */,
+				531BCF332B28A23400F5C573 /* MPIdentityCaching.m */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -1279,6 +1290,7 @@
 				53A79CB529CE019F00E7489F /* MPAppNotificationHandlerTests.m */,
 				53A79CB629CE019F00E7489F /* MPKitRegisterTests.m */,
 				53A79CB729CE019F00E7489F /* HasherTests.m */,
+				531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1388,6 +1400,7 @@
 				53A79BFE29CDFB2100E7489F /* MPAppNotificationHandler.h in Headers */,
 				53A79C1E29CDFB2100E7489F /* MPKitFilter.h in Headers */,
 				53A79C1529CDFB2100E7489F /* MPDataPlanFilter.h in Headers */,
+				531BCF342B28A23400F5C573 /* MPIdentityCaching.h in Headers */,
 				53A79C0029CDFB2100E7489F /* MPPromotion+Dictionary.h in Headers */,
 				53A79B9229CDFB2000E7489F /* MPBreadcrumb.h in Headers */,
 				53A79B7B29CDFB2000E7489F /* MPConnectorProtocol.h in Headers */,
@@ -1494,6 +1507,7 @@
 				53A79D4A29CE23F700E7489F /* MPAppNotificationHandler.h in Headers */,
 				53A79D4B29CE23F700E7489F /* MPKitFilter.h in Headers */,
 				53A79D4C29CE23F700E7489F /* MPDataPlanFilter.h in Headers */,
+				531BCF352B28A23400F5C573 /* MPIdentityCaching.h in Headers */,
 				53A79D4D29CE23F700E7489F /* MPPromotion+Dictionary.h in Headers */,
 				53A79D4E29CE23F700E7489F /* MPBreadcrumb.h in Headers */,
 				53A79D4F29CE23F700E7489F /* MPConnectorProtocol.h in Headers */,
@@ -1734,6 +1748,7 @@
 				534CD29D29CE2CE1008452B3 /* MPLaunchInfoTests.m in Sources */,
 				534CD29E29CE2CE1008452B3 /* MPConvertJSTests.m in Sources */,
 				534CD29F29CE2CE1008452B3 /* MPAppNotificationHandlerTests.m in Sources */,
+				531BCF3B2B28A83E00F5C573 /* MPIdentityCachingTests.m in Sources */,
 				534CD2A029CE2CE1008452B3 /* MParticleTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1761,6 +1776,7 @@
 				53A79C0D29CDFB2100E7489F /* MPKitConfiguration.mm in Sources */,
 				53A79BC129CDFB2000E7489F /* MPConsentState.m in Sources */,
 				53A79BE329CDFB2000E7489F /* MPBracket.cpp in Sources */,
+				531BCF362B28A23400F5C573 /* MPIdentityCaching.m in Sources */,
 				53A79B9129CDFB2000E7489F /* MParticleUserNotification.m in Sources */,
 				53A79C2129CDFB2100E7489F /* MPIConstants.m in Sources */,
 				53A79BEE29CDFB2000E7489F /* MPLaunchInfo.m in Sources */,
@@ -1897,6 +1913,7 @@
 				53A79CE229CE019F00E7489F /* MPLaunchInfoTests.m in Sources */,
 				53A79CD429CE019F00E7489F /* MPConvertJSTests.m in Sources */,
 				53A79CF729CE019F00E7489F /* MPAppNotificationHandlerTests.m in Sources */,
+				531BCF3A2B28A83E00F5C573 /* MPIdentityCachingTests.m in Sources */,
 				53A79CD829CE019F00E7489F /* MParticleTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1924,6 +1941,7 @@
 				53A79D7829CE23F700E7489F /* MPConsentState.m in Sources */,
 				53A79D7929CE23F700E7489F /* MPBracket.cpp in Sources */,
 				53A79D7A29CE23F700E7489F /* MParticleUserNotification.m in Sources */,
+				531BCF372B28A23400F5C573 /* MPIdentityCaching.m in Sources */,
 				53A79D7B29CE23F700E7489F /* MPIConstants.m in Sources */,
 				53A79D7C29CE23F700E7489F /* MPLaunchInfo.m in Sources */,
 				53A79D7D29CE23F700E7489F /* MPPromotion.m in Sources */,

--- a/mParticle-Apple-SDK/Identity/MPIdentityApiManager.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApiManager.m
@@ -28,17 +28,15 @@
 - (void)identify:(MPIdentityApiRequest *)identifyRequest completion:(nullable MPIdentityApiManagerCallback)completion {
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:identifyRequest parameter2:completion];
     
-    [[MParticle sharedInstance].backendController.networkCommunication identify:identifyRequest completion:^(MPIdentityHTTPBaseSuccessResponse *
-       _Nonnull httpResponse, NSError * _Nullable error) {
-                   completion(httpResponse, error);
-     }];
+    [[MParticle sharedInstance].backendController.networkCommunication identify:identifyRequest completion:^(MPIdentityHTTPBaseSuccessResponse * _Nonnull httpResponse, NSError * _Nullable error) {
+        completion(httpResponse, error);
+    }];
 }
 
 - (void)loginRequest:(MPIdentityApiRequest *)loginRequest completion:(nullable MPIdentityApiManagerCallback)completion {
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:loginRequest parameter2:completion];
     
-    [[MParticle sharedInstance].backendController.networkCommunication login:loginRequest completion:^(MPIdentityHTTPBaseSuccessResponse *
-                                                                                                             _Nonnull httpResponse, NSError * _Nullable error) {
+    [[MParticle sharedInstance].backendController.networkCommunication login:loginRequest completion:^(MPIdentityHTTPBaseSuccessResponse * _Nonnull httpResponse, NSError * _Nullable error) {
         completion(httpResponse, error);
     }];
 }
@@ -46,8 +44,7 @@
 - (void)logout:(MPIdentityApiRequest *)logoutRequest completion:(nullable MPIdentityApiManagerCallback)completion {
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:logoutRequest parameter2:completion];
     
-    [[MParticle sharedInstance].backendController.networkCommunication logout:logoutRequest completion:^(MPIdentityHTTPBaseSuccessResponse *
-                                                                                                             _Nonnull httpResponse, NSError * _Nullable error) {
+    [[MParticle sharedInstance].backendController.networkCommunication logout:logoutRequest completion:^(MPIdentityHTTPBaseSuccessResponse * _Nonnull httpResponse, NSError * _Nullable error) {
         completion(httpResponse, error);
     }];
 }

--- a/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
@@ -11,7 +11,7 @@
 #import "MPIdentityDTO.h"
 
 @interface MPIdentityApiRequest ()
-@property (nonatomic) NSMutableDictionary *mutableIdentities;
+@property (nonatomic) NSMutableDictionary<NSNumber*, NSString*> *mutableIdentities;
 @end
 
 @implementation MPIdentityApiRequest
@@ -49,40 +49,9 @@
     return request;
 }
 
-- (NSDictionary<NSString *, id> *)dictionaryRepresentation {
-    NSMutableDictionary *knownIdentities = [NSMutableDictionary dictionary];
-    
-    [_mutableIdentities enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
-        
-        NSString *identityKey = [MPIdentityHTTPIdentities stringForIdentityType:[key intValue]];
-        knownIdentities[identityKey] = obj;
-    }];
-    
-    MPDevice *device = [[MPDevice alloc] init];
-    
-    NSString *vendorId = device.vendorId;
-    if (vendorId && !knownIdentities[@"ios_idfv"]) {
-        knownIdentities[@"ios_idfv"] = vendorId;
-    }
-    
-#if TARGET_OS_IOS == 1
-    if (![MPStateMachine isAppExtension]) {
-        NSData *deviceTokenData = [MPNotificationController deviceToken];
-        if (deviceTokenData) {
-            NSString *deviceTokenString = [MPIUserDefaults stringFromDeviceToken:deviceTokenData];
-            if (deviceTokenString && [deviceTokenString length] > 0) {
-                knownIdentities[@"push_token"] = deviceTokenString;
-            }
-        }
-    }
-#endif
-    
-    return knownIdentities;
-}
-
 - (NSString *)email {
     NSString *result = _mutableIdentities[@(MPIdentityEmail)];
-    if ((NSNull *)result == [NSNull null]) {
+    if ([result isEqual:[NSNull null]]) {
         result = nil;
     }
     return result;
@@ -94,7 +63,7 @@
 
 - (NSString *)customerId {
     NSString *result = _mutableIdentities[@(MPIdentityCustomerId)];
-    if ((NSNull *)result == [NSNull null]) {
+    if ([result isEqual:[NSNull null]]) {
         result = nil;
     }
     return result;
@@ -104,7 +73,7 @@
     [self setIdentity:customerId identityType:MPIdentityCustomerId];
 }
 
-- (NSDictionary *)identities {
+- (NSDictionary<NSNumber*, NSString*> *)identities {
     return [_mutableIdentities copy];
 }
 

--- a/mParticle-Apple-SDK/Identity/MPIdentityDTO.h
+++ b/mParticle-Apple-SDK/Identity/MPIdentityDTO.h
@@ -78,9 +78,8 @@
 @interface MPIdentityHTTPModifyRequest : MPIdentityHTTPBaseRequest
 
 @property (nonatomic) NSArray *identityChanges;
-@property (nonatomic) NSString *mpid;
 
-- (instancetype)initWithMPID:(NSString *)mpid identityChanges:(NSArray *)identityChanges;
+- (instancetype)initWithIdentityChanges:(NSArray *)identityChanges;
 
 @end
 

--- a/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
@@ -130,11 +130,10 @@
 
 @implementation MPIdentityHTTPModifyRequest
 
-- (instancetype)initWithMPID:(NSString *)mpid identityChanges:(NSArray *)identityChanges {
+- (instancetype)initWithIdentityChanges:(NSArray *)identityChanges {
     self = [super init];
     if (self) {
         _identityChanges = identityChanges;
-        _mpid = mpid;
     }
     return self;
 }

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -62,16 +62,12 @@
     return [NSDate dateWithTimeIntervalSince1970:lastSeenMs.doubleValue/1000.0];
 }
 
--(NSDictionary*) identities {
-    NSMutableArray *userIdentitiesArray = [[NSMutableArray alloc] initWithCapacity:10];
+- (NSDictionary*) identities {
     MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
     NSArray *userIdentityArray = [userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:_userId];
-    if (userIdentityArray) {
-        [userIdentitiesArray addObjectsFromArray:userIdentityArray];
-    }
     
     NSMutableDictionary *userIdentities = [NSMutableDictionary dictionary];
-    [userIdentitiesArray enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    [userIdentityArray enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         NSString *identity = obj[@"i"];
         NSNumber *type = obj[@"n"];
         [userIdentities setObject:identity forKey:type];

--- a/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
+++ b/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSString *email;
 @property (nonatomic, strong, nullable) NSString *customerId;
-@property (nonatomic, strong, nullable, readonly) NSDictionary *identities;
+@property (nonatomic, strong, nullable, readonly) NSDictionary<NSNumber*, NSString*> *identities;
 
 @end
 

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -31,6 +31,7 @@
 #import "MPListenerController.h"
 #import "MParticleWebView.h"
 #import "MPDevice.h"
+#import "MPIdentityCaching.h"
 #import "Swift.h"
 
 #if TARGET_OS_IOS == 1
@@ -2089,6 +2090,7 @@ static BOOL skipNextUpload = NO;
         nextCleanUpTime = currentTime + TWENTY_FOUR_HOURS;
     }
     [persistence purgeMemory];
+    [MPIdentityCaching clearExpiredCache];
 }
 
 - (void)handleApplicationDidEnterBackground:(NSNotification *)notification {

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -984,9 +984,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         return;
     }
 
-    NSString *mpid = [MPPersistenceController mpId].stringValue;
-    MPIdentityHTTPModifyRequest *request = [[MPIdentityHTTPModifyRequest alloc] initWithMPID:mpid identityChanges:[identityChanges copy]];
-    
+    MPIdentityHTTPModifyRequest *request = [[MPIdentityHTTPModifyRequest alloc] initWithIdentityChanges:[identityChanges copy]];
     [self identityApiRequestWithURL:self.modifyURL.url identityRequest:request blockOtherRequests:blockOtherRequests completion:^(MPIdentityHTTPBaseSuccessResponse * _Nullable httpResponse, NSError * _Nullable error) {
         if (completion) {
             completion((MPIdentityHTTPModifySuccessResponse *)httpResponse, error);

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -27,6 +27,7 @@
 #import "MPResponseConfig.h"
 #import "MPURL.h"
 #import "MPConnectorFactoryProtocol.h"
+#import "MPIdentityCaching.h"
 
 NSString *const urlFormat = @"%@://%@/%@/%@%@"; // Scheme, URL Host, API Version, API key, path
 NSString *const urlFormatOverride = @"%@://%@/%@%@"; // Scheme, URL Host, API key, path
@@ -52,6 +53,8 @@ NSString *const kMPURLScheme = @"https";
 NSString *const kMPURLHostConfig = @"config2.mparticle.com";
 NSString *const kMPURLHostEventSubdomain = @"nativesdks";
 NSString *const kMPURLHostIdentitySubdomain = @"identity";
+
+NSString *const kMPIdentityCachingMaxAgeHeader = @"X-MP-Max-Age";
 
 static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
@@ -415,9 +418,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         completionHandler(YES);
         return;
     }
-    
-    __weak MPNetworkCommunication *weakSelf = self;
-    
+        
     MPILogVerbose(@"Starting config request");
     NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
     
@@ -441,14 +442,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     
     NSString *cacheControl = httpResponse.allHeaderFields[kMPHTTPCacheControlHeaderKey];
     NSString *ageString = httpResponse.allHeaderFields[kMPHTTPAgeHeaderKey];
-
     NSNumber *maxAge = [self maxAgeForCache:cacheControl];
-        
-    __strong MPNetworkCommunication *strongSelf = weakSelf;
-    if (!strongSelf) {
-        completionHandler(NO);
-        return;
-    }
     
     if (![MPStateMachine isAppExtension]) {
         if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
@@ -769,32 +763,6 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     if (blockOtherRequests) {
         self.identifying = YES;
     }
-    __weak MPNetworkCommunication *weakSelf = self;
-    
-    __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-    
-    if (![MPStateMachine isAppExtension]) {
-        backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
-            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-                __strong MPNetworkCommunication *strongSelf = weakSelf;
-                if (strongSelf) {
-                    strongSelf.identifying = NO;
-                }
-                
-                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
-                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-            }
-        }];
-    }
-    
-    NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
-    
-    NSDictionary *dictionary = [identityRequest dictionaryRepresentation];
-    NSData *data = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:nil];
-    NSString *jsonRequest = [[NSString alloc] initWithData:data
-                                                  encoding:NSUTF8StringEncoding];
-    
-    MPILogVerbose(@"Identity request:\nURL: %@ \nBody:%@", url, jsonRequest);
     
     MPEndpoint endpointType;
     MPURL *mpURL;
@@ -811,64 +779,113 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         endpointType = MPEndpointIdentityModify;
         mpURL = self.modifyURL;
     }
+    
+    NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
+    
+    NSDictionary *dictionary = [identityRequest dictionaryRepresentation];
+    NSData *data = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:nil];
+    NSString *jsonRequest = [[NSString alloc] initWithData:data
+                                                  encoding:NSUTF8StringEncoding];
+    
+    MPILogVerbose(@"Identity request:\nURL: %@ \nBody:%@", url, jsonRequest);
+    
+    
     [MPListenerController.sharedInstance onNetworkRequestStarted:endpointType url:url.absoluteString body:data];
-
-    NSObject<MPConnectorProtocol> *connector = [self makeConnector];
-    NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:mpURL
-                                                                    message:nil
-                                                           serializedParams:data];
-    NSData *responseData = response.data;
-    NSError *error = response.error;
-    NSHTTPURLResponse *httpResponse = response.httpResponse;
     
-    __strong MPNetworkCommunication *strongSelf = weakSelf;
-    
-    if (!strongSelf) {
-        if (completion) {
-            MPIdentityHTTPErrorResponse *errorResponse = [[MPIdentityHTTPErrorResponse alloc] initWithJsonObject:nil httpCode:0];
-            completion(nil, [NSError errorWithDomain:mParticleIdentityErrorDomain code:MPIdentityErrorResponseCodeUnknown userInfo:@{mParticleIdentityErrorKey:errorResponse}]);
-        }
-        
-        return;
-    }
-    
-    if (![MPStateMachine isAppExtension]) {
-        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-            [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
-            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-        }
-    }
-    
+    BOOL success = NO;
+    NSError *error = nil;
     NSDictionary *responseDictionary = nil;
     NSString *responseString = nil;
-    NSInteger responseCode = [httpResponse statusCode];
-    BOOL success = responseCode == HTTPStatusCodeSuccess || responseCode == HTTPStatusCodeAccepted;
+    NSInteger responseCode = 0;
     
-    success = success && [responseData length] > 0;
-    
-    NSError *serializationError = nil;
-    
-    MPILogVerbose(@"Identity response code: %ld", (long)responseCode);
-    
-    [self checkResponseCodeToDisableEventLogging:[httpResponse statusCode]];
-    
-    if (success) {
+    MPIdentityCachedResponse *cachedResponse = [MPIdentityCaching getCachedIdentityResponseForEndpoint:endpointType identityRequest:identityRequest];
+    if (cachedResponse) {
         @try {
-            responseString = [[NSString alloc] initWithData:responseData
-                                                   encoding:NSUTF8StringEncoding];
-            responseDictionary = [NSJSONSerialization JSONObjectWithData:responseData
-                                                                 options:0
-                                                                   error:&serializationError];
+            NSError *serializationError = nil;
+            responseString = [[NSString alloc] initWithData:cachedResponse.bodyData encoding:NSUTF8StringEncoding];
+            responseDictionary = [NSJSONSerialization JSONObjectWithData:cachedResponse.bodyData options:0 error:&serializationError];
+            
+            if (serializationError) {
+                responseDictionary = nil;
+                success = NO;
+                MPILogError(@"Identity response serialization error: %@", [serializationError localizedDescription]);
+            }
         } @catch (NSException *exception) {
             responseDictionary = nil;
             success = NO;
             MPILogError(@"Identity response serialization error: %@", [exception reason]);
         }
+    } else {
+        __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+        
+        if (![MPStateMachine isAppExtension]) {
+            backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
+                if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                    self.identifying = NO;
+                    
+                    [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                    backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+                }
+            }];
+        }
+        
+        NSObject<MPConnectorProtocol> *connector = [self makeConnector];
+        NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:mpURL
+                                                                        message:nil
+                                                               serializedParams:data];
+        
+        NSData *responseData = response.data;
+        error = response.error;
+        NSHTTPURLResponse *httpResponse = response.httpResponse;
+        
+        if (![MPStateMachine isAppExtension]) {
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }
+        
+        responseCode = [httpResponse statusCode];
+        success = responseCode == HTTPStatusCodeSuccess || responseCode == HTTPStatusCodeAccepted;
+        success = success && [responseData length] > 0;
+        
+        
+        MPILogVerbose(@"Identity response code: %ld", (long)responseCode);
+        
+        [self checkResponseCodeToDisableEventLogging:[httpResponse statusCode]];
+        
+        if (success) {
+            @try {
+                NSError *serializationError = nil;
+                responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+                responseDictionary = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&serializationError];
+                
+                if (responseDictionary && !serializationError) {
+                    // Cache response if it contains a the custom max age header
+                    NSInteger maxAgeSeconds = [response.httpResponse.allHeaderFields[kMPIdentityCachingMaxAgeHeader] integerValue];
+                    if (maxAgeSeconds > 0) {
+                        NSDate *expires = [[NSDate date] dateByAddingTimeInterval:(NSTimeInterval)maxAgeSeconds];
+                        MPIdentityCachedResponse *cachedResponse = [[MPIdentityCachedResponse alloc] initWithBodyData:responseData
+                                                                                                           statusCode:responseCode
+                                                                                                              expires:expires];
+                        [MPIdentityCaching cacheIdentityResponse:cachedResponse endpoint:endpointType identityRequest:identityRequest];
+                    }
+                } else {
+                    responseDictionary = nil;
+                    success = NO;
+                    MPILogError(@"Identity response serialization error: %@", [serializationError localizedDescription]);
+                }
+            } @catch (NSException *exception) {
+                responseDictionary = nil;
+                success = NO;
+                MPILogError(@"Identity response serialization error: %@", [exception reason]);
+            }
+        }
     }
     
     MPILogVerbose(@"Identity execution time: %.2fms", ([[NSDate date] timeIntervalSince1970] - start) * 1000.0);
     
-    strongSelf.identifying = NO;
+    self.identifying = NO;
     
     [MPListenerController.sharedInstance onNetworkRequestFinished:endpointType url:url.absoluteString body:responseDictionary responseCode:responseCode];
     if (success) {

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -809,6 +809,9 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
                 responseDictionary = nil;
                 success = NO;
                 MPILogError(@"Identity response serialization error: %@", [serializationError localizedDescription]);
+            } else {
+                responseCode = cachedResponse.statusCode;
+                success = YES;
             }
         } @catch (NSException *exception) {
             responseDictionary = nil;

--- a/mParticle-Apple-SDK/Persistence/MPIdentityCaching.h
+++ b/mParticle-Apple-SDK/Persistence/MPIdentityCaching.h
@@ -1,0 +1,26 @@
+//
+//  MPIdentityCaching.h
+//  mParticle-Apple-SDK
+//
+//  Created by Ben Baron on 12/12/23.
+//
+
+#import <Foundation/Foundation.h>
+#import "MPListenerProtocol.h"
+#import "MPIdentityDTO.h"
+
+@interface MPIdentityCachedResponse : NSObject
+@property (nonnull, nonatomic, readonly) NSData *bodyData;
+@property (nonatomic, readonly) NSInteger statusCode;
+@property (nonnull, nonatomic, readonly) NSDate *expires;
+- (nonnull instancetype)initWithBodyData:(nonnull NSData *)bodyData statusCode:(NSInteger)statusCode expires:(nonnull NSDate *)expires;
+@end
+
+@interface MPIdentityCaching : NSObject
+
++ (void)cacheIdentityResponse:(nonnull MPIdentityCachedResponse *)cachedResponse endpoint:(MPEndpoint)endpoint identityRequest:(nonnull MPIdentityHTTPBaseRequest *)identityRequest;
++ (nullable MPIdentityCachedResponse *)getCachedIdentityResponseForEndpoint:(MPEndpoint)endpoint identityRequest:(nonnull MPIdentityHTTPBaseRequest *)identityRequest;
++ (void)clearAllCache;
++ (void)clearExpiredCache;
+
+@end

--- a/mParticle-Apple-SDK/Persistence/MPIdentityCaching.m
+++ b/mParticle-Apple-SDK/Persistence/MPIdentityCaching.m
@@ -46,7 +46,7 @@ static NSString *const kMPIdentityCachingExpires = @"kMPIdentityCachingExpires";
     NSData *bodyData = dictionary[kMPIdentityCachingBodyData];
     NSNumber *statusCode = dictionary[kMPIdentityCachingStatusCode];
     NSDate *expires = dictionary[kMPIdentityCachingExpires];
-    if (!bodyData || !statusCode || !expires) {
+    if (bodyData == nil || statusCode == nil || expires == nil) {
         return nil;
     }
     

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -58,6 +58,7 @@
 @property (nonatomic) BOOL allowASR;
 @property (nonatomic, nullable) MPDataPlanOptions *dataPlanOptions;
 @property (nonatomic) BOOL enableDirectRouting;
+@property (nonatomic) BOOL enableIdentityCaching;
 
 + (MPEnvironment)environment;
 + (void)setEnvironment:(MPEnvironment)environment;


### PR DESCRIPTION
 ## Summary
 - Adds caching of identify and login calls
 - Clears that cache on modify and logout calls
 - Some minor code cleanup

This is all behind a feature flag that is currently disabled

 ## Testing Plan
 - Unit tests were added
 - Tested locally:

```
1. Disable feature flag

mParticle -> Identity response code: 200
mParticle -> Identity execution time: 437.32ms
mParticle -> Identity response:
{"context":null,"matched_identities":{"email":"bbaron+abc1@mparticle.com"},"is_ephemeral":false,"mpid":"6167123318226482339","is_logged_in":true}

2. Start app fresh (idenity should save to cache)

mParticle -> Identity Caching - max age header value (in seconds): 86400
mParticle -> Identity Caching - Cached response for endpoint 2, key: 2::8f9e2eefac54a94a33bcfa00512550bf4963e21ee01060a924fc181bd55981a0, expires: 2024-01-10 21:51:30 +0000, bodyData.length: 145

3. Start app again (identity should read from cache)

mParticle -> Identity Caching - Valid cached response found for key: 2::8f9e2eefac54a94a33bcfa00512550bf4963e21ee01060a924fc181bd55981a0, expires: 2024-01-10 21:51:30 +0000, seconds left: 86357.1
mParticle -> Identity execution time: 0.36ms
mParticle -> Identity response:
{"context":null,"matched_identities":{"email":"bbaron+abc1@mparticle.com"},"is_ephemeral":false,"mpid":"6167123318226482339","is_logged_in":true}

4. Manually call identify, then modify, then identify (should save identify, should clear cache on modify, should save identify)

// First identify request
mParticle -> Identity response code: 200
mParticle -> Identity Caching - max age header value (in seconds): 86400
mParticle -> Identity Caching - Cached response for endpoint 2, key: 2::b6fb24420bffaaeded2d230e03aa287d82dbb13a9b5a04832992fa49ca605361, expires: 2024-01-10 21:55:53 +0000, bodyData.length: 145
mParticle -> Identity execution time: 235.59ms

// Modify request
mParticle -> Identity Caching - Removed all cached responses
mParticle -> Identity response code: 200
mParticle -> Identity Caching - max age header value (in seconds): 86400
mParticle -> Identity execution time: 372.21ms

// Second identify request
mParticle -> Identity response code: 200
mParticle -> Identity Caching - max age header value (in seconds): 86400
mParticle -> Identity Caching - Cached response for endpoint 2, key: 2::b6fb24420bffaaeded2d230e03aa287d82dbb13a9b5a04832992fa49ca605361, expires: 2024-01-10 21:55:54 +0000, bodyData.length: 145
mParticle -> Identity execution time: 252.73ms
```

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5974
