### PR TITLE
fix: Rare arithmetic overflow crash in MPIHasher

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPIHasher.swift
+++ b/mParticle-Apple-SDK/Utils/MPIHasher.swift
@@ -30,7 +30,7 @@ import Foundation
        
         var hash: Int32 = 0
         for byte in dataToHash {
-            hash = ((hash << 5) &- hash) + Int32(byte);
+            hash = ((hash << 5) &- hash) &+ Int32(byte);
         }
         
         return String(hash)


### PR DESCRIPTION
 ## Summary
There is an extremely rare case where a specific string could cause an overflow error when calling `MPIHasher.hashString()` due to not using the overflow addition operator. I've changed the code from a regular addition to overflow addition which matches the original Objective-C logic and was the intended behavior.

 ## Testing Plan
Due to the nature of this hash function I was unable to write a unit test to reproduce the bug, but I reproduced it manually by setting `var hash: Int32 = Int32.max` to confirm that it was hypothetically possible and that switching to the overflow addition operator fixes the issue.

<img width="783" alt="Screenshot 2024-01-16 at 2 09 06 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/350423/0b401e8c-35c3-43af-b716-a6ab6f4228b0">

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6076
