### PR TITLE
fix: Prevent Database Growth When ATT Status Denied

### DIFF
--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -394,7 +394,9 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 }
 
 - (void)checkResponseCodeToDisableEventLogging:(NSInteger)responseCode {
-    if (responseCode == HTTPStatusCodeBadRequest || responseCode == HTTPStatusCodeUnauthorized || responseCode == HTTPStatusCodeForbidden) {
+    NSNumber *currentStatus = [MParticle sharedInstance].stateMachine.attAuthorizationStatus;
+
+    if (responseCode == HTTPStatusCodeBadRequest || responseCode == HTTPStatusCodeUnauthorized || responseCode == HTTPStatusCodeForbidden || currentStatus.integerValue == MPATTAuthorizationStatusDenied) {
         [MPStateMachine setCanWriteMessagesToDB:NO];
         MPILogError(@"API Key appears to be invalid based on server response, disabling event logging to prevent excessive local database growth");
     } else {

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -1047,6 +1047,13 @@ static NSString *const kMPStateKey = @"state";
         if (attStatusTimestampMillis != nil) {
             [MParticle sharedInstance].stateMachine.attAuthorizationTimestamp = attStatusTimestampMillis;
         }
+        
+        if (status == MPATTAuthorizationStatusDenied) {
+            [MPStateMachine setCanWriteMessagesToDB:NO];
+            MPILogError(@"ATT Status is denied, disabling event logging to prevent excessive local database growth");
+        } else {
+            [MPStateMachine setCanWriteMessagesToDB:YES];
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
 - This change ensures that we never grow the database when ATT Status has been set to denied. Any Messages or Uploads already saved will remain until uploaded or [service provides an invalid code](https://github.com/mParticle/mparticle-apple-sdk/blob/efb81cd0241225dfbbfdeb7a262464adeea38cf8/mParticle-Apple-SDK/Network/MPNetworkCommunication.m#L579) 

 ## Testing Plan
 - Tested locally to confirm Denied ATT status blocks saving to the DB

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5654
