### PR TITLE
feat: Add Audience Support Reverts(#171)"

### DIFF
--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -3,6 +3,7 @@
 #import "MPSession.h"
 #import "MPMessage.h"
 #import "MPUpload.h"
+#import "MPAudience.h"
 #import "MPIConstants.h"
 #import "MPMessageBuilder.h"
 #import "MPIntegrationAttributes.h"
@@ -554,6 +555,28 @@
     [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
 }
 
+- (void)testAudiences {
+    [MPPersistenceController setMpid:@2];
+    
+    NSDictionary *audienceDictionary = @{@"id":@2,
+                                        @"n":@"External Name 101",
+                                        @"c":@[@{@"ct":@1395014265365,
+                                                 @"a":@"add"
+                                                 },
+                                               @{@"ct":@1395100665367,
+                                                 @"a":@"drop"
+                                                 },
+                                               @{@"ct":@1395187065367,
+                                                 @"a":@"add"
+                                                 }
+                                               ],
+                                        @"s":@[@"aaa", @"bbb", @"ccc"]
+                                        };
+    
+    MPAudience *audience = [[MPAudience alloc] initWithDictionary:audienceDictionary];
+    XCTAssertTrue([audience.name isEqualToString:@"External Name 101"]);
+    XCTAssertTrue(audience.audienceId.intValue == 2);
+}
 - (void)testFetchIntegrationAttributesForKit {
     NSNumber *integrationId = nil;
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -515,6 +515,10 @@
 		53B33E8B2A4606CD00CC8A19 /* MPSideloadedKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */; };
 		53FDD1BD2AE871AF003D5FA1 /* MPIHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */; };
 		53FDD1BE2AE871AF003D5FA1 /* MPIHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */; };
+		D33C8B332B8510C20012EDFD /* MPAudience.h in Headers */ = {isa = PBXBuildFile; fileRef = D33C8B312B8510C20012EDFD /* MPAudience.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D33C8B342B8510C20012EDFD /* MPAudience.h in Headers */ = {isa = PBXBuildFile; fileRef = D33C8B312B8510C20012EDFD /* MPAudience.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D33C8B352B8510C20012EDFD /* MPAudience.m in Sources */ = {isa = PBXBuildFile; fileRef = D33C8B322B8510C20012EDFD /* MPAudience.m */; };
+		D33C8B362B8510C20012EDFD /* MPAudience.m in Sources */ = {isa = PBXBuildFile; fileRef = D33C8B322B8510C20012EDFD /* MPAudience.m */; };
 		D3724C192AE02AF60074CD67 /* mParticle_Apple_SDK_NoLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = D3724C182AE02AF60074CD67 /* mParticle_Apple_SDK_NoLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D3B3E2072AE029AE001AB58C /* mParticle_Apple_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = D3B3E2062AE028EC001AB58C /* mParticle_Apple_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -807,6 +811,8 @@
 		53A79DC629CE23F700E7489F /* mParticle_Apple_SDK_NoLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_SDK_NoLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPSideloadedKit.swift; sourceTree = "<group>"; };
 		53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPIHasher.swift; sourceTree = "<group>"; };
+		D33C8B312B8510C20012EDFD /* MPAudience.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPAudience.h; sourceTree = "<group>"; };
+		D33C8B322B8510C20012EDFD /* MPAudience.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPAudience.m; sourceTree = "<group>"; };
 		D3724C182AE02AF60074CD67 /* mParticle_Apple_SDK_NoLocation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Apple_SDK_NoLocation.h; sourceTree = "<group>"; };
 		D3B3E2062AE028EC001AB58C /* mParticle_Apple_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Apple_SDK.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -910,6 +916,7 @@
 				53A79A9929CDFB1E00E7489F /* MPAliasResponse.m */,
 				53A79A9A29CDFB1E00E7489F /* MParticleUser.m */,
 				53A79A9B29CDFB1E00E7489F /* FilteredMPIdentityApiRequest.m */,
+				D33C8B322B8510C20012EDFD /* MPAudience.m */,
 				53A79A9C29CDFB1E00E7489F /* MPAliasRequest.m */,
 				53A79A9D29CDFB1E00E7489F /* MPIdentityDTO.m */,
 				53A79A9E29CDFB1E00E7489F /* MPIdentityApiManager.h */,
@@ -1207,6 +1214,7 @@
 				53A79C4029CDFB4800E7489F /* MPConsentState.h */,
 				53A79C4129CDFB4800E7489F /* MPKitRegister.h */,
 				53A79C4229CDFB4800E7489F /* MPProduct+Dictionary.h */,
+				D33C8B312B8510C20012EDFD /* MPAudience.h */,
 				53A79C4329CDFB4800E7489F /* MPProduct.h */,
 				53A79C4429CDFB4800E7489F /* MPTransactionAttributes+Dictionary.h */,
 			);
@@ -1358,6 +1366,7 @@
 				53A79C5629CDFB4800E7489F /* MParticleUser.h in Headers */,
 				53A79C5529CDFB4800E7489F /* NSDictionary+MPCaseInsensitive.h in Headers */,
 				53A79C5129CDFB4800E7489F /* MPCommerceEventInstruction.h in Headers */,
+				D33C8B332B8510C20012EDFD /* MPAudience.h in Headers */,
 				53A79C6629CDFB4800E7489F /* MPTransactionAttributes+Dictionary.h in Headers */,
 				53A79BE629CDFB2000E7489F /* MPArchivist.h in Headers */,
 				53A79BDC29CDFB2000E7489F /* MPLaunchInfo.h in Headers */,
@@ -1466,6 +1475,7 @@
 				53A79D2129CE23F700E7489F /* NSDictionary+MPCaseInsensitive.h in Headers */,
 				53A79D2229CE23F700E7489F /* MPCommerceEventInstruction.h in Headers */,
 				53A79D2329CE23F700E7489F /* MPTransactionAttributes+Dictionary.h in Headers */,
+				D33C8B342B8510C20012EDFD /* MPAudience.h in Headers */,
 				53A79D2429CE23F700E7489F /* MPArchivist.h in Headers */,
 				53A79D2529CE23F700E7489F /* MPLaunchInfo.h in Headers */,
 				53A79D2629CE23F700E7489F /* MPConvertJS.h in Headers */,
@@ -1841,6 +1851,7 @@
 				53A79C1629CDFB2100E7489F /* MPEventProjection.mm in Sources */,
 				53A79C2029CDFB2100E7489F /* MPListenerController.m in Sources */,
 				53A79C0E29CDFB2100E7489F /* MPKitContainer.mm in Sources */,
+				D33C8B352B8510C20012EDFD /* MPAudience.m in Sources */,
 				53A79BD729CDFB2000E7489F /* MPUploadBuilder.m in Sources */,
 				53A79C1129CDFB2100E7489F /* MPBaseProjection.m in Sources */,
 				53A79B7329CDFB2000E7489F /* MPLocationManager.m in Sources */,
@@ -2006,6 +2017,7 @@
 				53A79DB729CE23F700E7489F /* MPEventProjection.mm in Sources */,
 				53A79DB829CE23F700E7489F /* MPListenerController.m in Sources */,
 				53A79DB929CE23F700E7489F /* MPKitContainer.mm in Sources */,
+				D33C8B362B8510C20012EDFD /* MPAudience.m in Sources */,
 				53A79DBA29CE23F700E7489F /* MPUploadBuilder.m in Sources */,
 				53A79DBC29CE23F700E7489F /* MPBaseProjection.m in Sources */,
 				53A79DBD29CE23F700E7489F /* MPLocationManager.m in Sources */,

--- a/mParticle-Apple-SDK/Identity/MPAudience.m
+++ b/mParticle-Apple-SDK/Identity/MPAudience.m
@@ -1,0 +1,37 @@
+//
+//  MPAudience.m
+//  mParticle-Apple-SDK
+//
+//  Created by Brandon Stalnaker on 2/20/24.
+//
+
+#import "MPAudience.h"
+
+// Internal keys
+NSString * const kMPAudienceListKey = @"m";
+NSString * const kMPAudienceIdKey = @"id";
+NSString * const kMPAudienceNameKey = @"n";
+NSString * const kMPAudienceMembershipListKey = @"c";
+NSString * const kMPAudienceMembershipListChangeActionKey = @"a";
+NSString * const kMPAudienceMembershipListChangeActionAddValue = @"add";
+NSString * const kMPAudienceMembershipListChangeActionDropValue = @"drop";
+
+@implementation MPAudience
+
+- (instancetype)initWithAudienceId:(NSNumber *)audienceId andName:(NSString *)name {
+    self = [super init];
+    if (self) {
+        _audienceId = audienceId;
+        _name = name;
+    }
+    return self;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)audienceDictionary {
+    NSNumber *audienceId = audienceDictionary[kMPAudienceIdKey];
+    NSString *audienceName = audienceDictionary[kMPAudienceNameKey];
+
+    return [self initWithAudienceId:audienceId andName:audienceName];
+}
+
+@end

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -8,6 +8,7 @@
 #import "MPKitContainer.h"
 #import "MPILogger.h"
 #import "mParticle.h"
+#import "MPAudience.h"
 #import "MPPersistenceController.h"
 #import "MPIUserDefaults.h"
 #import "MPDataPlanFilter.h"
@@ -444,6 +445,13 @@
                                        }
                                    }
                            }];
+    });
+}
+
+#pragma mark - User Segments
+- (void)getUserAudiencesWithCompletionHandler:(void (^)(NSArray<MPAudience *> *currentAudiences, NSArray<MPAudience *> *pastAudiences, NSError * _Nullable error))completionHandler {
+    dispatch_async([MParticle messageQueue], ^{
+        [self.backendController fetchAudiencesWithCompletionHandler:completionHandler];
     });
 }
 

--- a/mParticle-Apple-SDK/Include/MPAudience.h
+++ b/mParticle-Apple-SDK/Include/MPAudience.h
@@ -1,0 +1,38 @@
+//
+//  MPAudience.h
+//  mParticle-Apple-SDK
+//
+//  Created by Brandon Stalnaker on 2/20/24.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MPAudience : NSObject
+
+/**
+ The mParticle id associated with this user (MPID)
+ */
+@property(readonly, strong, nonnull) NSNumber *audienceId;
+
+/**
+ The date when this user was first seen by the SDK
+ */
+@property(readonly, strong, nonnull) NSString *name;
+
+- (instancetype)initWithAudienceId:(NSNumber *)audienceId andName:(NSString *)name;
+
+- (instancetype)initWithDictionary:(NSDictionary *)audienceDictionary;
+
+@end
+
+extern NSString * _Nonnull const kMPAudienceListKey;
+extern NSString * _Nonnull const kMPAudienceIdKey;
+extern NSString * _Nonnull const kMPAudienceNameKey;
+extern NSString * _Nonnull const kMPAudienceMembershipListKey;
+extern NSString * _Nonnull const kMPAudienceMembershipListChangeActionKey;
+extern NSString * _Nonnull const kMPAudienceMembershipListChangeActionAddValue;
+extern NSString * _Nonnull const kMPAudienceMembershipListChangeActionDropValue;
+
+NS_ASSUME_NONNULL_END

--- a/mParticle-Apple-SDK/Include/MParticleUser.h
+++ b/mParticle-Apple-SDK/Include/MParticleUser.h
@@ -4,6 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "MPAudience.h"
 #import "MPEnums.h"
 #import "MPConsentState.h"
 
@@ -88,6 +89,13 @@ NS_ASSUME_NONNULL_BEGIN
  @param key The user attribute key
  */
 - (void)removeUserAttribute:(NSString *)key;
+
+#pragma mark - User Audiences
+/**
+ Retrieves user audiences from mParticle's servers and returns the result as two arrays of MPAudience objects
+ @param completionHandler A block to be called when the results are available.
+ */
+- (void)getUserAudiencesWithCompletionHandler:(void (^)(NSArray<MPAudience *> *currentAudiences, NSArray<MPAudience *> *pastAudiences, NSError * _Nullable error))completionHandler;
 
 #pragma mark - Consent State
 /**

--- a/mParticle-Apple-SDK/MPBackendController.h
+++ b/mParticle-Apple-SDK/MPBackendController.h
@@ -80,6 +80,7 @@ extern const NSInteger kInvalidKey;
 + (BOOL)checkAttribute:(nonnull NSDictionary *)attributesDictionary key:(nonnull NSString *)key value:(nonnull id)value error:(out NSError *__autoreleasing _Nullable * _Nullable)error;
 - (nullable MPEvent *)eventWithName:(nonnull NSString *)eventName;
 + (nullable NSString *)execStatusDescription:(MPExecStatus)execStatus;
+- (MPExecStatus)fetchAudiencesWithCompletionHandler:(void (^ _Nonnull)(NSArray * _Nullable currentAudiences, NSArray * _Nullable pastAudiences, NSError * _Nullable error))completionHandler;
 - (nullable NSNumber *)incrementSessionAttribute:(nonnull MPSession *)session key:(nonnull NSString *)key byValue:(nonnull NSNumber *)value;
 - (nullable NSNumber *)incrementUserAttribute:(nonnull NSString *)key byValue:(nonnull NSNumber *)value;
 - (void)leaveBreadcrumb:(nonnull MPEvent *)event completionHandler:(void (^ _Nonnull)(MPEvent * _Nonnull event, MPExecStatus execStatus))completionHandler;

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -9,6 +9,7 @@
 #import "MPIUserDefaults.h"
 #import "MPBreadcrumb.h"
 #import "MPUpload.h"
+#import "MPAudience.h"
 #import "MPApplication.h"
 #import "MPCustomModule.h"
 #import "MPMessageBuilder.h"
@@ -1064,11 +1065,28 @@ static BOOL skipNextUpload = NO;
     return event;
 }
 
+- (MPExecStatus)fetchAudiencesWithCompletionHandler:(void (^ _Nonnull)(NSArray * _Nullable currentAudiences, NSArray * _Nullable pastAudiences, NSError * _Nullable error))completionHandler {
+    
+    NSAssert(completionHandler != nil, @"completionHandler cannot be nil.");
+        
+    [self.networkCommunication requestAudiencesWithCompletionHandler:^(BOOL success, NSArray *currentAudiences, NSArray *pastAudiences, NSError *error) {
+        if (!error) {
+            MPILogVerbose(@"Audiences Request Succesful: /nCurrent Audiences: %@/nPast Audiences: %@", currentAudiences, pastAudiences);
+        } else {
+            MPILogError(@"Audience request failed with error: %@", error)
+        }
+        
+        completionHandler(currentAudiences, pastAudiences, error);
+    }];
+    
+    return MPExecStatusSuccess;
+}
+
 + (NSString *)execStatusDescription:(MPExecStatus)execStatus {
     static NSArray *execStatusDescriptions;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        execStatusDescriptions = @[@"Success", @"Fail", @"Missing Parameter", @"Feature Disabled Remotely", @"Feature Enabled Remotely", 
+        execStatusDescriptions = @[@"Success", @"Fail", @"Missing Parameter", @"Feature Disabled Remotely", @"Feature Enabled Remotely",
                                    @"User Opted Out of Tracking", @"Data Already Being Fetched", @"Invalid Data Type", @"Data is Being Uploaded",
                                    @"Server is Busy", @"Item Not Found", @"Feature is Disabled in Settings", @"There is no network connectivity"];
     });

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
@@ -2,6 +2,7 @@
 
 @class MPSession;
 @class MPUpload;
+@class MPAudience;
 @class MPIdentityApiRequest;
 @class MPIdentityHTTPSuccessResponse;
 @class MPIdentityHTTPBaseSuccessResponse;
@@ -17,6 +18,7 @@ typedef NS_ENUM(NSInteger, MPNetworkError) {
     MPNetworkErrorDelayedSegments
 };
 
+typedef void(^ _Nonnull MPAudienceResponseHandler)(BOOL success, NSArray<MPAudience *> * _Nullable currentAudience, NSArray<MPAudience *> * _Nullable pastAudience, NSError * _Nullable error);
 typedef void(^ _Nonnull MPUploadsCompletionHandler)(void);
 
 typedef void (^MPIdentityApiManagerCallback)(MPIdentityHTTPBaseSuccessResponse *_Nullable httpResponse, NSError *_Nullable error);
@@ -30,6 +32,7 @@ typedef void(^ _Nonnull MPConfigCompletionHandler)(BOOL success);
 
 - (NSObject<MPConnectorProtocol> *_Nonnull)makeConnector;
 - (void)requestConfig:(nullable NSObject<MPConnectorProtocol> *)connector withCompletionHandler:(MPConfigCompletionHandler)completionHandler;
+- (void)requestAudiencesWithCompletionHandler:(MPAudienceResponseHandler)completionHandler;
 - (void)upload:(nonnull NSArray<MPUpload *> *)uploads completionHandler:(MPUploadsCompletionHandler)completionHandler;
 
 - (void)identify:(MPIdentityApiRequest *_Nonnull)identifyRequest completion:(nullable MPIdentityApiManagerCallback)completion;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -7,6 +7,7 @@
 #import "MPUpload.h"
 #import "MPDevice.h"
 #import "MPApplication.h"
+#import "MPAudience.h"
 #import "MPIConstants.h"
 #import "MPZip.h"
 #import "MPURLRequestBuilder.h"
@@ -45,6 +46,8 @@ NSString *const kMPConfigVersion = @"v4";
 NSString *const kMPConfigURL = @"/config";
 NSString *const kMPEventsVersion = @"v2";
 NSString *const kMPEventsURL = @"/events";
+NSString *const kMPAudienceVersion = @"v1";
+NSString *const kMPAudienceURL = @"/audience";
 NSString *const kMPIdentityVersion = @"v1";
 NSString *const kMPIdentityURL = @"";
 NSString *const kMPIdentityKey = @"identity";
@@ -82,6 +85,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 @interface MPNetworkCommunication()
 
+@property (nonatomic, strong, readonly) MPURL *audienceURL;
 @property (nonatomic, strong, readonly) MPURL *configURL;
 @property (nonatomic, strong, readonly) MPURL *eventURL;
 @property (nonatomic, strong, readonly) MPURL *identifyURL;
@@ -208,6 +212,31 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         _eventURL = [[MPURL alloc] initWithURL:modifiedURL defaultURL:defaultURL];
     }
     return _eventURL;
+}
+
+- (MPURL *)audienceURL {
+    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
+    
+    NSString *eventHost = [MParticle sharedInstance].networkOptions.eventsHost ?: self.defaultEventHost;
+    NSString *audienceURLFormat = [urlFormat stringByAppendingString:@"?mpID=%@"];
+    NSString *urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, self.defaultEventHost, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController mpId]];
+    NSURL *defaultURL = [NSURL URLWithString:urlString];
+
+    if ([MParticle sharedInstance].networkOptions.overridesEventsSubdirectory) {
+        audienceURLFormat = [urlFormatOverride stringByAppendingString:@"?mpID=%@"];
+        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController mpId]];
+    } else {
+        audienceURLFormat = [urlFormat stringByAppendingString:@"?mpID=%@"];
+        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController mpId]];
+    }
+    
+    NSURL *modifiedURL = [NSURL URLWithString:urlString];
+    MPURL *audienceURL;
+    if (modifiedURL && defaultURL) {
+        audienceURL = [[MPURL alloc] initWithURL:modifiedURL defaultURL:defaultURL];
+    }
+    
+    return audienceURL;
 }
 
 - (MPURL *)identifyURL {
@@ -506,7 +535,109 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     }
 }
 
-- (BOOL)performMessageUpload:(MPUpload *)upload {    
+- (void)requestAudiencesWithCompletionHandler:(MPAudienceResponseHandler)completionHandler {
+    __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    
+    if (![MPStateMachine isAppExtension]) {
+        backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
+    
+    __weak MPNetworkCommunication *weakSelf = self;
+    NSObject<MPConnectorProtocol> *connector = [self makeConnector];
+
+    NSObject<MPConnectorResponseProtocol> *response = [connector responseFromGetRequestToURL:self.audienceURL];
+    NSData *data = response.data;
+    NSHTTPURLResponse *httpResponse = response.httpResponse;
+    __strong MPNetworkCommunication *strongSelf = weakSelf;
+    if (!strongSelf) {
+        completionHandler(NO, nil, nil, nil);
+        return;
+    }
+    
+    if (![MPStateMachine isAppExtension]) {
+        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+            [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+        }
+    }
+    
+    if (!data) {
+        completionHandler(NO, nil, nil, nil);
+        return;
+    }
+    
+    NSMutableArray<MPAudience *> *currentAudiences = nil;
+    NSMutableArray<MPAudience *> *pastAudiences = nil;
+    BOOL success = NO;
+    
+    NSArray *audiencesList = nil;
+    NSInteger responseCode = [httpResponse statusCode];
+    success = (responseCode == HTTPStatusCodeSuccess || responseCode == HTTPStatusCodeAccepted) && [data length] > 0;
+    
+    if (success) {
+        NSError *serializationError = nil;
+        NSDictionary *audiencesDictionary = nil;
+        
+        @try {
+            audiencesDictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:&serializationError];
+            success = serializationError == nil;
+        } @catch (NSException *exception) {
+            audiencesDictionary = nil;
+            success = NO;
+            MPILogError(@"Audiences Error: %@", [exception reason]);
+        }
+        
+        if (success) {
+            audiencesList = audiencesDictionary[kMPAudienceListKey];
+        }
+        
+        if (audiencesList.count > 0) {
+            currentAudiences = [[NSMutableArray alloc] init];
+            pastAudiences = [[NSMutableArray alloc] init];
+            
+            for (NSDictionary *audienceDictionary in audiencesList) {
+                MPAudience *audience = [[MPAudience alloc] initWithDictionary:audienceDictionary];
+                
+                if (audience) {
+                    if ([audienceDictionary[kMPAudienceMembershipListKey][0][kMPAudienceMembershipListChangeActionKey] isEqualToString:kMPAudienceMembershipListChangeActionAddValue]) {
+                        [currentAudiences addObject:audience];
+                    }
+                    if ([audienceDictionary[kMPAudienceMembershipListKey][0][kMPAudienceMembershipListChangeActionKey] isEqualToString:kMPAudienceMembershipListChangeActionDropValue]) {
+                        [pastAudiences addObject:audience];
+                    }
+                }
+            }
+            
+            MPILogVerbose(@"Audiences Response Code: %ld", (long)responseCode);
+        } else {
+            MPILogWarning(@"Audiences Error - Response Code: %ld", (long)responseCode);
+        }
+    }
+    
+    if (currentAudiences.count == 0) {
+        currentAudiences = nil;
+    }
+    
+    if (pastAudiences.count == 0) {
+        pastAudiences = nil;
+    }
+    NSError *audienceError = nil;
+
+    if (responseCode == HTTPStatusCodeForbidden) {
+        audienceError = [NSError errorWithDomain:@"mParticle Audiences"
+                                           code:responseCode
+                                       userInfo:@{@"message":@"Audiences not enabled for this org."}];
+    }
+    
+    completionHandler(success, currentAudiences, pastAudiences, audienceError);
+}
+
+- (BOOL)performMessageUpload:(MPUpload *)upload {
     NSDate *minUploadDate = [MParticle.sharedInstance.stateMachine minUploadDateForUploadType:MPUploadTypeMessage];
     if ([minUploadDate compare:[NSDate date]] == NSOrderedDescending) {
         return YES;  //stop upload loop

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -745,29 +745,6 @@ const int MaxBreadcrumbs = 50;
     }
 }
 
-- (void)deleteSegments {
-    sqlite3_stmt *preparedStatement;
-    string sqlStatement = "DELETE FROM segment_memberships";
-    
-    if (sqlite3_prepare_v2(mParticleDB, sqlStatement.c_str(), (int)sqlStatement.size(), &preparedStatement, NULL) == SQLITE_OK) {
-        if (sqlite3_step(preparedStatement) != SQLITE_DONE) {
-            MPILogError(@"Error while deleting segment memberships: %s", sqlite3_errmsg(mParticleDB));
-        }
-    }
-    
-    sqlite3_finalize(preparedStatement);
-    
-    sqlStatement = "DELETE FROM segments";
-    
-    if (sqlite3_prepare_v2(mParticleDB, sqlStatement.c_str(), (int)sqlStatement.size(), &preparedStatement, NULL) == SQLITE_OK) {
-        if (sqlite3_step(preparedStatement) != SQLITE_DONE) {
-            MPILogError(@"Error while deleting segments: %s", sqlite3_errmsg(mParticleDB));
-        }
-    }
-    
-    sqlite3_finalize(preparedStatement);
-}
-
 - (void)deleteAllSessionsExcept:(nullable MPSession *)session {
     // Delete sessions
     sqlite3_stmt *preparedStatement;
@@ -1318,8 +1295,6 @@ const int MaxBreadcrumbs = 50;
                                  @"previous_session",
                                  @"messages",
                                  @"breadcrumbs",
-                                 @"segments",
-                                 @"segment_memberships",
                                  @"cookies",
                                  @"consumer_info"
                                  ];


### PR DESCRIPTION
## Summary
 - This reverts commit 1c04262a6144bd292d364873ca1701b0a3793136 and exposes a method to allow our users to request what audiences a user is part of.


 ## Testing Plan
 - Tested using QA endpoints

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5993
