### PR TITLE
ci: Use latest checkout action, macOS, and Xcode

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -4,10 +4,13 @@ on: [pull_request]
 
 jobs:
   pod-lint:
-    runs-on: macos-12
+    runs-on: macOS-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
         
       - name: Update xcodeproj gem
         run: sudo gem install xcodeproj
@@ -22,10 +25,13 @@ jobs:
         run: git checkout *.podspec
 
   carthage-build:
-    runs-on: macos-12
+    runs-on: macOS-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Build with Carthage
         run: ./Scripts/carthage.sh build --no-skip-current || true
@@ -37,13 +43,16 @@ jobs:
         run: ls 2>&1 | grep .framework.zip
 
   compile-extension:
-    runs-on: macos-12
+    runs-on: macOS-13
     defaults:
       run:
         working-directory: ./Example
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Update CocoaPods repo
         run: pod repo update
@@ -55,10 +64,13 @@ jobs:
         run: xcodebuild -allowProvisioningUpdates -workspace mParticleExample.xcworkspace -scheme mParticleExample_Extension -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest'
 
   run-analyzer:
-    runs-on: macos-12
+    runs-on: macOS-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Run static analyzer
         run: |

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -11,16 +11,16 @@ on:
 jobs:
   run-ios-tests:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macOS-13
     steps:
       - name: "Checkout Cross Platform Tests"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: "true"
           repository: mParticle/crossplatform-sdk-tests
           fetch-depth: 1
       - name: "Checkout iOS SDK"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           path: .sdks/apple

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -12,7 +12,7 @@ jobs:
   native-unit-tests:
     strategy:
       matrix:
-        xcode: ["15.0"]
+        xcode: ["15.2"]
         platform: [iOS, tvOS]
         scheme: [mParticle-Apple-SDK, mParticle-Apple-SDK-NoLocation]
         include:
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -16,11 +16,11 @@ jobs:
 
   create-release-branch:
     name: Create release branch
-    runs-on: macOS-12
+    runs-on: macOS-13
     needs: confirm-main-branch
     steps:
       - name: Checkout development branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -33,14 +33,17 @@ jobs:
 
   release:
     name: Perform release
-    runs-on: macOS-12
+    runs-on: macOS-13
     needs: create-release-branch
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Validate environment
         env:
@@ -66,7 +69,7 @@ jobs:
           git config user.name "mParticle Automation"
 
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}
@@ -152,10 +155,10 @@ jobs:
   sync-repository:
     name: Finalize release
     needs: release
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}


### PR DESCRIPTION
 ## Summary
 - Update all CI to use macOS-13 runners and Xcode 15.2
 - Update all checkout actions to v4 as v3 uses a deprecated version of node

 ## Testing Plan
 - The actions that run in this PR will test most of the changes, final test will happen when we cut the next release as it's not really possible to fully test the release action without running it, but my previous PR fixed building on Xcode 15, so it should work (release build scripts run locally to test Xcode 15.2 support)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/6171
