### PR TITLE
feat: Switch workspaces without restarting app

### DIFF
--- a/UnitTests/MPKitSecondTestClass.m
+++ b/UnitTests/MPKitSecondTestClass.m
@@ -20,7 +20,7 @@
     return @314;
 }
 
-- (void)deinit {
+- (void)stop {
     
 }
 

--- a/UnitTests/MPKitSecondTestClassNoStartImmediately.m
+++ b/UnitTests/MPKitSecondTestClassNoStartImmediately.m
@@ -20,7 +20,7 @@
     return @314;
 }
 
-- (void)deinit {
+- (void)stop {
     
 }
 

--- a/UnitTests/MPKitTestClass.m
+++ b/UnitTests/MPKitTestClass.m
@@ -18,7 +18,7 @@
     return @42;
 }
 
-- (void)deinit {
+- (void)stop {
     
 }
 

--- a/UnitTests/MPKitTestClassNoStartImmediately.h
+++ b/UnitTests/MPKitTestClassNoStartImmediately.h
@@ -13,3 +13,6 @@
 + (nonnull NSNumber *)kitCode;
 
 @end
+
+@interface MPKitTestClassNoStartImmediatelyWithStop: MPKitTestClassNoStartImmediately
+@end

--- a/UnitTests/MPKitTestClassSideloaded.m
+++ b/UnitTests/MPKitTestClassSideloaded.m
@@ -18,6 +18,10 @@
     return YES;
 }
 
+- (id)providerKitInstance {
+    return self;
+}
+
 - (nonnull MPKitExecStatus *)didFinishLaunchingWithConfiguration:(nonnull NSDictionary *)configuration {
     return [[MPKitExecStatus alloc] initWithSDKCode:self.sideloadedKitCode returnCode:MPKitReturnCodeSuccess];
 }

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -50,7 +50,7 @@
 
 #pragma mark Kit lifecycle
 - (void)start;
-- (void)deinit;
+- (void)stop;
 
 #pragma mark Application
 - (nonnull MPKitExecStatus *)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler;

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -617,12 +617,34 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 
 /**
  Starts the SDK with your API key and secret and installation type.
- It is required that you use either this method or `start` to authorize the SDK before
+ It is required that you use either this method to authorize the SDK before
  using the other API methods. The apiKey and secret that are passed in to this method
- will override the api_key and api_secret parameters of the (optional) MParticleConfig.plist.
+ will override the `api_key` and `api_secret` parameters of the (optional) MParticleConfig.plist.
  @param options SDK startup options
  */
 - (void)startWithOptions:(MParticleOptions *)options;
+
+/**
+ Switches the SDK to a new API key and secret.
+ 
+ Will first attempt to upload any batches that have not been sent to mParticle,
+ then all SDK state including user defaults, database, etc will be completely reset.
+ After that, `startWithOptions` will be called with the new key and secret
+ and the SDK will initialize again as if it is a new app launch.
+ 
+ Any kits that do not implement the `stop` method will be deactivated and will
+ not receive any events until the app is restarted. Any kits that were not used by the
+ previous workspace will continue to be available even if they don't implement `stop`.
+ Any sideloaded kits will need new instances passed in via `options.sideloadedKits`.
+ It is recommended to implement the `stop` in all sideloaded kits, though if it is not
+ implemented then the old instances will still not receive any new events.
+ 
+ The apiKey and secret that are passed in to this method will override the `api_key`
+ and `api_secret` parameters of the (optional) MParticleConfig.plist.
+ 
+ @param options SDK startup options
+ */
+- (void)switchWorkspaceWithOptions:(MParticleOptions *)options;
 
 #pragma mark - Application notifications
 #if TARGET_OS_IOS == 1
@@ -704,6 +726,16 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  The SDK will be shut down and [MParticle sharedInstance] will return a new instance without apiKey or secretKey. MParticle can be restarted by calling MParticle.startWithOptions
  */
 - (void)reset;
+
+/**
+ This method will permanently remove ALL MParticle data from the device, including MParticle UserDefaults and Database, it will also halt any further upload or download behavior that may be prepared
+
+ If you have any reference to the MParticle instance, you must remove your reference by setting it to "nil", in order to avoid any unexpected behavior
+ The SDK will be shut down and [MParticle sharedInstance] will return a new instance without apiKey or secretKey. MParticle can be restarted by calling MParticle.startWithOptions
+ 
+ @param completion A block to execute on the main thread after the SDK is completely reset
+ */
+- (void)reset:(nullable void (^)(void))completion;
 
 #pragma mark - Basic Tracking
 /**

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -21,6 +21,9 @@
 + (BOOL)registerKit:(nonnull id<MPExtensionKitProtocol>)kitRegister;
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;
 
+- (void)flushSerializedKits;
+- (void)removeAllSideloadedKits;
+- (void)removeKitsFromRegistryInvalidForWorkspaceSwitch;
 - (nullable NSArray<id<MPExtensionKitProtocol>> *)activeKitsRegistry;
 - (nullable NSArray<NSNumber *> *)configuredKitsRegistry;
 - (void)configureKits:(nullable NSArray<NSDictionary *> *)kitsConfiguration;

--- a/mParticle-Apple-SDK/Kits/MPKitRegister.m
+++ b/mParticle-Apple-SDK/Kits/MPKitRegister.m
@@ -62,4 +62,26 @@
     return description;
 }
 
+- (NSUInteger)hash {
+    return _code.hash ^ _className.hash ^ _name.hash;
+}
+
+- (BOOL)isEqual:(id)other
+{
+    if (other == self) {
+        return YES;
+    } else if (![super isEqual:other]) {
+        return NO;
+    } else {
+        MPKitRegister *otherRegister = other;
+        return [_code isEqualToNumber:otherRegister.code]
+            && [_className isEqualToString:otherRegister.className]
+            && [_name isEqualToString:otherRegister.name];
+    }
+}
+
+- (void)setWrapperInstance:(id<MPKitProtocol>)wrapperInstance {
+    _wrapperInstance = wrapperInstance;
+}
+
 @end

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -497,6 +497,7 @@ The reason for this is that when an iOS app is first launched, the app delegate 
 */
 static id unproxiedAppDelegateReference = nil;
 
+// NOTE: This can only be called from the main thread
 - (void)unproxyOriginalAppDelegate {
     if (!originalAppDelegateProxied && appDelegateProxy) {
         return;


### PR DESCRIPTION
 ## Summary
This new feature enables customers to switch to a new workspace while the app is running. It works by uploading any waiting events, completely resetting the internal data/state of the SDK, stopping/uninitializing any kits that support that (none do yet, but the logic is there to handle it), removing any kits that don't support reinitialization to prevent events forwarding to the wrong accounts, removing all sideloaded kits as new instances will be passed in again via the new MParticleOptions object, and then starts the SDK up fresh using the new API key.

NOTE: A change was made to MPKitProtocol to rename `deinit` to `stop` to prevent conflicts with Swift since it uses `deinit` rather than `dealloc` to deinitialize classes. No kits were using the `deinit` method in the protocol, so while this is technically a public API breaking change, it should have zero impact.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Full E2E testing was performed to confirm that waiting events are uploaded, all new events go to the new workspace, and kits are properly handled.
 - New unit tests were added to confirm all behavior
 - Old unit tests confirm existing behavior still works as they use the MParticle reset method which has been updated as part of this change

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6088
