### PR TITLE
fix: Correct threading around user notification log

### DIFF
--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1960,39 +1960,41 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)logUserNotification:(MParticleUserNotification *)userNotification {
-    NSMutableDictionary *messageInfo = [@{kMPPushNotificationStateKey:userNotification.state,
-                                          kMPPushMessageProviderKey:kMPPushMessageProviderValue,
-                                          kMPPushMessageTypeKey:userNotification.type}
-                                        mutableCopy];
-    
-    NSString *tokenString = [MPIUserDefaults stringFromDeviceToken:[MPNotificationController deviceToken]];
-    if (tokenString) {
-        messageInfo[kMPDeviceTokenKey] = tokenString;
-    }
-                             
-    if (userNotification.redactedUserNotificationString) {
-        messageInfo[kMPPushMessagePayloadKey] = userNotification.redactedUserNotificationString;
-    }
-    
-    if (userNotification.actionTitle) {
-        messageInfo[kMPPushNotificationActionTitleKey] = userNotification.actionTitle;
-    }
+    [MParticle executeOnMessage:^{
+        NSMutableDictionary *messageInfo = [@{kMPPushNotificationStateKey:userNotification.state,
+                                              kMPPushMessageProviderKey:kMPPushMessageProviderValue,
+                                              kMPPushMessageTypeKey:userNotification.type}
+                                            mutableCopy];
+        
+        NSString *tokenString = [MPIUserDefaults stringFromDeviceToken:[MPNotificationController deviceToken]];
+        if (tokenString) {
+            messageInfo[kMPDeviceTokenKey] = tokenString;
+        }
+                                 
+        if (userNotification.redactedUserNotificationString) {
+            messageInfo[kMPPushMessagePayloadKey] = userNotification.redactedUserNotificationString;
+        }
+        
+        if (userNotification.actionTitle) {
+            messageInfo[kMPPushNotificationActionTitleKey] = userNotification.actionTitle;
+        }
 
-    if (userNotification.actionIdentifier) {
-        messageInfo[kMPPushNotificationActionIdentifierKey] = userNotification.actionIdentifier;
-    }
+        if (userNotification.actionIdentifier) {
+            messageInfo[kMPPushNotificationActionIdentifierKey] = userNotification.actionIdentifier;
+        }
     
-    if (userNotification.behavior > 0) {
-        messageInfo[kMPPushNotificationBehaviorKey] = @(userNotification.behavior);
-    }
+        if (userNotification.behavior > 0) {
+            messageInfo[kMPPushNotificationBehaviorKey] = @(userNotification.behavior);
+        }
     
-    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypePushNotification session:_session messageInfo:messageInfo];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypePushNotification session:self.session messageInfo:messageInfo];
 #ifndef MPARTICLE_LOCATION_DISABLE
-    [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
+        [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
-    MPMessage *message = [messageBuilder build];
+        MPMessage *message = [messageBuilder build];
     
-    [self saveMessage:message updateSession:(_session != nil)];
+        [self saveMessage:message updateSession:(self.session != nil)];
+    }];
 }
 
 #endif


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fix occasion timing crash around log notification

1.  App goes to background for a long time (not killed)
2. User receives and taps notification
3. App opens and at the same, concurrently, time attempts to
 a. on main queue, log user notification with _session property in https://github.com/mParticle/mparticle-apple-sdk/blob/d604e598b74503ff6f675c0989a014a0f266f21d/mParticle-Apple-SDK/MPBackendController.m#L1986 
 b. on internal message queue, end old session and begin a new one in https://github.com/mParticle/mparticle-apple-sdk/blob/d604e598b74503ff6f675c0989a014a0f266f21d/mParticle-Apple-SDK/MPBackendController.m#L2200 

The read on main queue in logUserNotification: method is done without synchronisation, resulting in occasional crashes on notification interactions.

 ## Testing Plan
 - Tested using sample app while manually triggering logNotification

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6192
