### PR TITLE
fix: Refactor MPUploadBuilder to attempt to eliminate rare crash in withLocation: method

### DIFF
--- a/UnitTests/MPBackendControllerTests.m
+++ b/UnitTests/MPBackendControllerTests.m
@@ -689,9 +689,9 @@
     dispatch_async(messageQueue, ^{
         MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
         
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                               session:session
-                                                                           messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                                 session:session
+                                                                             messageInfo:@{@"MessageKey1":@"MessageValue1"}];
         MPMessage *message = [messageBuilder build];
         
         MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
@@ -1397,9 +1397,9 @@
     
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     [[MParticle sharedInstance].backendController saveMessage:message updateSession:NO];
     
@@ -1418,7 +1418,7 @@
     
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeOptOut session:session messageInfo:@{kMPOptOutStatus:(@"true")}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeOptOut session:session messageInfo:@{kMPOptOutStatus:(@"true")}];
     
     MPMessage *message = [messageBuilder build];
     [[MParticle sharedInstance].backendController saveMessage:message updateSession:NO];
@@ -1437,9 +1437,9 @@
     
     NSMutableArray *unlimitedMessages = [NSMutableArray array];
     for (int i=0; i<10; i++) {
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                               session:session
-                                                                           messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                                 session:session
+                                                                             messageInfo:@{@"MessageKey1":@"MessageValue1"}];
         MPMessage *message = [messageBuilder build];
         [unlimitedMessages addObject:message];
     }
@@ -1457,9 +1457,9 @@
     
     NSMutableArray *unlimitedMessages = [NSMutableArray array];
     for (int i=0; i<10; i++) {
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                               session:session
-                                                                           messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                                 session:session
+                                                                             messageInfo:@{@"MessageKey1":@"MessageValue1"}];
         MPMessage *message = [messageBuilder build];
         [unlimitedMessages addObject:message];
     }
@@ -1474,9 +1474,9 @@
 
 - (void)testBatchAndMessageLimitsBytesPerBatch {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     NSMutableArray *unlimitedMessages = [NSMutableArray array];
@@ -1503,9 +1503,9 @@
     while (longString.length < 1000) {
         longString = [NSString stringWithFormat:@"%@%@", longString, longString];
     }
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":longString}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":longString}];
     MPMessage *message = [messageBuilder build];
     NSMutableArray *unlimitedMessages = [NSMutableArray array];
     for (int i=0; i<10; i++) {
@@ -1534,9 +1534,9 @@
     while (longString.length < length) {
         longString = [NSString stringWithFormat:@"%@%@", longString, longString];
     }
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:type
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":longString}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:type
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":longString}];
     MPMessage *message = [messageBuilder build];
     NSInteger bytesToTruncate = message.messageData.length - length;
     NSInteger bytesLongString = longString.length - bytesToTruncate;

--- a/UnitTests/MPDataModelTests.m
+++ b/UnitTests/MPDataModelTests.m
@@ -71,9 +71,9 @@
 - (void)testMessageInstance {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     XCTAssertNotNil(messageBuilder, @"Should not have been nil.");
     
     MPMessage *message = [messageBuilder build];
@@ -159,9 +159,9 @@
     
     double four = 4.0;
     double zed = 0.0;
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@(four/zed)}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@(four/zed)}];
     XCTAssertNotNil(messageBuilder, @"Should not have been nil.");
     
     MPMessage *message = [messageBuilder build];
@@ -193,9 +193,9 @@
 - (void)testUploadInstance {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO,
@@ -235,9 +235,9 @@
 - (void)testBreadcrumbInstance {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     MPBreadcrumb *breadcrumb = [[MPBreadcrumb alloc] initWithSessionUUID:session.uuid
@@ -283,9 +283,9 @@
 - (void)testMessageEncoding {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     XCTAssertNotNil(message, @"Should not have been nil.");
@@ -298,9 +298,9 @@
 - (void)testBreadcrumbEncoding {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     MPBreadcrumb *breadcrumb = [[MPBreadcrumb alloc] initWithSessionUUID:session.uuid

--- a/UnitTests/MPMessageBuilderTests.m
+++ b/UnitTests/MPMessageBuilderTests.m
@@ -65,9 +65,9 @@ NSString *const kMPStateInformationKey = @"cs";
                                   @"key2":@"value2",
                                   @"key3":@"value3"};
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:self.session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:self.session
+                                                                         messageInfo:messageInfo];
     
     XCTAssertNotNil(messageBuilder, @"Message builder should not have been nil.");
     XCTAssertEqualObjects(messageBuilder.messageType, @"e", @"Message type not being set properly.");
@@ -86,7 +86,7 @@ NSString *const kMPStateInformationKey = @"cs";
     XCTAssertTrue(containsDictionary, @"Message info dictionary is not contained in the message's dictionary.");
     
     NSTimeInterval timestamp = messageBuilder.timestamp;
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     XCTAssertNotEqual(messageBuilder.timestamp, timestamp, @"Timestamp is not being updated.");
     
     MPMessage *message = [messageBuilder build];
@@ -94,9 +94,9 @@ NSString *const kMPStateInformationKey = @"cs";
     XCTAssertTrue([message isKindOfClass:[MPMessage class]], @"Returning the wrong kind of class instance.");
     XCTAssertNotNil(message.messageData, @"MPMessage has no data.");
     
-    messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                         session:nil
-                                                     messageInfo:messageInfo];
+    messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                           session:nil
+                                                       messageInfo:messageInfo];
     
     XCTAssertNotNil(messageBuilder, @"Message builder should not have been nil.");
     
@@ -109,9 +109,9 @@ NSString *const kMPStateInformationKey = @"cs";
                                   @"key2":@"value2",
                                   @"key3":@"value3"};
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:self.session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:self.session
+                                                                         messageInfo:messageInfo];
     
     XCTAssertNil(messageBuilder.messageInfo[kMPStateInformationKey]);
 }
@@ -121,9 +121,9 @@ NSString *const kMPStateInformationKey = @"cs";
                                   @"key2":@"value2",
                                   @"key3":@"value3"};
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:self.session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:self.session
+                                                                         messageInfo:messageInfo];
     
     XCTAssertNotNil(messageBuilder, @"Message builder should not have been nil.");
     XCTAssertEqualObjects(messageBuilder.messageType, @"e", @"Message type not being set properly.");
@@ -142,7 +142,7 @@ NSString *const kMPStateInformationKey = @"cs";
     XCTAssertTrue(containsDictionary, @"Message info dictionary is not contained in the message's dictionary.");
     
     NSTimeInterval timestamp = messageBuilder.timestamp;
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     XCTAssertNotEqual(messageBuilder.timestamp, timestamp, @"Timestamp is not being updated.");
     
     MPMessage *message = [messageBuilder build];
@@ -150,9 +150,9 @@ NSString *const kMPStateInformationKey = @"cs";
     XCTAssertTrue([message isKindOfClass:[MPMessage class]], @"Returning the wrong kind of class instance.");
     XCTAssertNotNil(message.messageData, @"MPMessage has no data.");
     
-    messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                         session:nil
-                                                     messageInfo:messageInfo];
+    messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                           session:nil
+                                                       messageInfo:messageInfo];
     
     XCTAssertNotNil(messageBuilder, @"Message builder should not have been nil.");
     
@@ -211,9 +211,9 @@ NSString *const kMPStateInformationKey = @"cs";
     transactionAttributes.transactionId = @"42";
     commerceEvent.transactionAttributes = transactionAttributes;
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeCommerceEvent
-                                                                           session:self.session
-                                                                     messageInfo:commerceEvent.customAttributes];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeCommerceEvent
+                                                                             session:self.session
+                                                                         messageInfo:commerceEvent.customAttributes];
     
     XCTAssertNotNil(messageBuilder, @"Message builder should not have been nil.");
     XCTAssertEqualObjects(messageBuilder.messageType, @"cm", @"Incorrect message type.");
@@ -235,9 +235,9 @@ NSString *const kMPStateInformationKey = @"cs";
     
     MPCommerceEvent *commerceEvent = [[MPCommerceEvent alloc] initWithPromotionContainer:promotionContainer];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeCommerceEvent
-                                                                           session:self.session
-                                                                     messageInfo:commerceEvent.customAttributes];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeCommerceEvent
+                                                                             session:self.session
+                                                                         messageInfo:commerceEvent.customAttributes];
     
     XCTAssertNotNil(messageBuilder, @"Message builder should not have been nil.");
     XCTAssertEqualObjects(messageBuilder.messageType, @"cm", @"Incorrect message type.");
@@ -284,9 +284,9 @@ NSString *const kMPStateInformationKey = @"cs";
     // Add a new user attribute
     MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:userAttributes key:@"meal_restrictions" value:@"Peanuts"];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeUserAttributeChange
-                                                                           session:self.session
-                                                               userAttributeChange:userAttributeChange];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeUserAttributeChange
+                                                                             session:self.session
+                                                                 userAttributeChange:userAttributeChange];
     XCTAssertNotNil(messageBuilder);
     MPMessage *message = [messageBuilder build];
     XCTAssertNotNil(message);
@@ -303,9 +303,9 @@ NSString *const kMPStateInformationKey = @"cs";
     userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:userAttributes key:@"membership_status" value:nil];
     userAttributeChange.deleted = YES;
     
-    messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeUserAttributeChange
-                                                         session:self.session
-                                             userAttributeChange:userAttributeChange];
+    messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeUserAttributeChange
+                                                           session:self.session
+                                               userAttributeChange:userAttributeChange];
 
     XCTAssertNotNil(messageBuilder);
     message = [messageBuilder build];
@@ -323,9 +323,9 @@ NSString *const kMPStateInformationKey = @"cs";
     NSArray<NSString *> *seatPreference = @[@"Window", @"Aisle"];
     userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:userAttributes key:@"seat_preference" value:seatPreference];
     
-    messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeUserAttributeChange
-                                                         session:self.session
-                                             userAttributeChange:userAttributeChange];
+    messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeUserAttributeChange
+                                                           session:self.session
+                                               userAttributeChange:userAttributeChange];
 
     XCTAssertNotNil(messageBuilder);
     message = [messageBuilder build];
@@ -342,9 +342,9 @@ NSString *const kMPStateInformationKey = @"cs";
     // User attribute tag
     userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:userAttributes key:@"VIP" value:[NSNull null]];
     
-    messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeUserAttributeChange
-                                                         session:self.session
-                                             userAttributeChange:userAttributeChange];
+    messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeUserAttributeChange
+                                                           session:self.session
+                                               userAttributeChange:userAttributeChange];
 
     XCTAssertNotNil(messageBuilder);
     message = [messageBuilder build];
@@ -381,9 +381,9 @@ NSString *const kMPStateInformationKey = @"cs";
                                   @"key3":@"value3"};
     
     [MPPersistenceController setMpid:@1];
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:nil
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:nil
+                                                                         messageInfo:messageInfo];
     MPMessage *message = [messageBuilder build];
     
     XCTAssertEqualObjects([MPPersistenceController mpId], message.userId);
@@ -396,9 +396,9 @@ NSString *const kMPStateInformationKey = @"cs";
     
     [MPPersistenceController setMpid:@1];
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:@0];
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     MPMessage *message = [messageBuilder build];
     
     XCTAssertEqualObjects([MPPersistenceController mpId], message.userId);

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -85,9 +85,9 @@
                                   @"key2":@"value2",
                                   @"key3":@"value3"};
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:nil
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:nil
+                                                                         messageInfo:messageInfo];
     
     [persistence saveMessage:[messageBuilder build]];
     MPDatabaseMigrationController *migrationController = [[MPDatabaseMigrationController alloc] initWithDatabaseVersions:@[@1,@28,@28]];
@@ -100,9 +100,9 @@
                                   @"key2":@"value2",
                                   @"key3":@"value3"};
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:nil
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:nil
+                                                                         messageInfo:messageInfo];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:@123 sessionId:nil messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
     __block BOOL tested = NO;
@@ -122,9 +122,9 @@
                                   @"key3":@"value3"};
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:@123];
     session.sessionId = 11;
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
     [persistence saveMessage:[messageBuilder build]];
     MPDatabaseMigrationController *migrationController = [[MPDatabaseMigrationController alloc] initWithDatabaseVersions:@[@1,@28,@29]];
@@ -148,9 +148,9 @@
     
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:@123];
     session.sessionId = 11;
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:@123 sessionId:@11 messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
     __block BOOL tested = NO;
@@ -206,9 +206,9 @@
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     [persistence saveSession:session];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     [persistence saveMessage:message];
     
@@ -245,9 +245,9 @@
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     [persistence saveSession:session];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     [persistence saveMessage:message];
     
@@ -283,9 +283,9 @@
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     [persistence saveSession:session];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     [persistence saveMessage:message];
     
@@ -320,9 +320,9 @@
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     [persistence saveSession:session];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     [persistence saveMessage:message];
     
@@ -353,9 +353,9 @@
 - (void)testUpload {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO,
@@ -400,9 +400,9 @@
 
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                            session:session
+                                                                        messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO,
@@ -446,9 +446,9 @@
 
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO,
@@ -493,9 +493,9 @@
     
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:@"test" dataPlanVersion:@(1)];
@@ -521,7 +521,7 @@
     
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeOptOut session:session messageInfo:@{kMPOptOutStatus:(@"true")}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeOptOut session:session messageInfo:@{kMPOptOutStatus:(@"true")}];
     
     MPMessage *message = [messageBuilder build];
     
@@ -715,7 +715,7 @@
     XCTAssertEqualObjects(forwardRecord, fetchedForwardRecord);
     
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent session:session messageInfo:@{}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent session:session messageInfo:@{}];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -740,9 +740,9 @@
     }
     [MPPersistenceController setMpid:@1];
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":longString}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":longString}];
     MPMessage *message = [messageBuilder build];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
@@ -772,9 +772,9 @@
     }
     [MPPersistenceController setMpid:@1];
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeCrashReport
-                                                                           session:session
-                                                                       messageInfo:@{@"MessageKey1":longString}];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeCrashReport
+                                                                             session:session
+                                                                         messageInfo:@{@"MessageKey1":longString}];
     MPMessage *message = [messageBuilder build];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;

--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -131,11 +131,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -205,11 +205,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:nil
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:nil
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:[MPPersistenceController mpId]
@@ -283,11 +283,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -365,11 +365,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -444,11 +444,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -526,11 +526,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -611,11 +611,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
@@ -692,11 +692,11 @@
     
     [self configureCustomModules];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                           session:session
-                                                                       messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                                                             session:session
+                                                                         messageInfo:messageInfo];
     
-    messageBuilder = [messageBuilder withTimestamp:[[NSDate date] timeIntervalSince1970]];
+    [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -260,13 +260,14 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
             messageInfo[kMPAttributesKey] = sessionAttributesDictionary;
         }
         
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeSessionEnd session:session messageInfo:messageInfo];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeSessionEnd session:session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-        messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+        [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
-        message = [[messageBuilder withTimestamp:session.endTime] build];
+        [messageBuilder timestamp:session.endTime];
+        message = [messageBuilder build];
         
         [self saveMessage:message updateSession:NO];
         MPILogVerbose(@"Session Ended: %@", session.uuid);
@@ -304,11 +305,11 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
         return;
     }
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeUserAttributeChange
-                                                                           session:self.session
-                                                               userAttributeChange:userAttributeChange];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeUserAttributeChange
+                                                                             session:self.session
+                                                                 userAttributeChange:userAttributeChange];
     if (userAttributeChange.timestamp) {
-        [messageBuilder withTimestamp:[userAttributeChange.timestamp timeIntervalSince1970]];
+        [messageBuilder timestamp:[userAttributeChange.timestamp timeIntervalSince1970]];
     }
     
     MPMessage *message = [messageBuilder build];
@@ -321,11 +322,11 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
         return;
     }
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeUserIdentityChange
-                                                                           session:self.session
-                                                                userIdentityChange:userIdentityChange];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeUserIdentityChange
+                                                                             session:self.session
+                                                                  userIdentityChange:userIdentityChange];
     if (userIdentityChange.timestamp) {
-        [messageBuilder withTimestamp:[userIdentityChange.timestamp timeIntervalSince1970]];
+        [messageBuilder timestamp:[userIdentityChange.timestamp timeIntervalSince1970]];
     }
     
     MPMessage *message = [messageBuilder build];
@@ -399,13 +400,13 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
         if (isInstallOrUpgrade && MParticle.sharedInstance.automaticSessionTracking) {
             [self beginSession];
         }
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeAppStateTransition session:self.session messageInfo:messageInfo];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeAppStateTransition session:self.session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-        messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+        [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
-        messageBuilder = [messageBuilder withStateTransition:YES previousSession:nil];
+        [messageBuilder stateTransition:YES previousSession:nil];
         MPMessage *message = [messageBuilder build];
         
         [self saveMessage:message updateSession:YES];
@@ -928,13 +929,14 @@ static BOOL skipNextUpload = NO;
                 
         messageInfo[kMPPreviousSessionLengthKey] = @(previousSessionLength);
         
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeSessionStart session:_session messageInfo:messageInfo];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeSessionStart session:_session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-        messageBuilder = [messageBuilder withLocation:stateMachine.location];
+        [messageBuilder location:stateMachine.location];
 #endif
 #endif
-        MPMessage *message = [[messageBuilder withTimestamp:_session.startTime] build];
+        [messageBuilder timestamp:_session.startTime];
+        MPMessage *message = [messageBuilder build];
         
         [self saveMessage:message updateSession:YES];
         
@@ -1169,9 +1171,9 @@ static BOOL skipNextUpload = NO;
     
     NSDictionary *messageInfo = [event breadcrumbDictionaryRepresentation];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:event.messageType session:self.session messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:event.messageType session:self.session messageInfo:messageInfo];
     if (event.timestamp) {
-        [messageBuilder withTimestamp:[event.timestamp timeIntervalSince1970]];
+        [messageBuilder timestamp:[event.timestamp timeIntervalSince1970]];
     }
     MPMessage *message = [messageBuilder build];
     
@@ -1232,10 +1234,10 @@ static BOOL skipNextUpload = NO;
         [messageInfo addEntriesFromDictionary:appImageInfo];
     }
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeCrashReport session:self.session messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeCrashReport session:self.session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-    messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+    [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
     MPMessage *errorMessage = [messageBuilder build];
@@ -1299,7 +1301,7 @@ static BOOL skipNextUpload = NO;
         }
     }
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeCrashReport session:crashSession messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeCrashReport session:crashSession messageInfo:messageInfo];
     MPMessage *crashMessage = [messageBuilder build];
     
     NSInteger maxBytes = [MPPersistenceController maxBytesPerEvent:crashMessage.messageType];
@@ -1330,13 +1332,13 @@ static BOOL skipNextUpload = NO;
     if ([event isKindOfClass:[MPEvent class]] || [event isKindOfClass:[MPCommerceEvent class]]) {
         NSDictionary<NSString *, id> *messageInfo = [event dictionaryRepresentation];
             
-            MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:event.messageType session:self.session messageInfo:messageInfo];
+            MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:event.messageType session:self.session messageInfo:messageInfo];
             if (event.timestamp) {
-                [messageBuilder withTimestamp:[event.timestamp timeIntervalSince1970]];
+                [messageBuilder timestamp:[event.timestamp timeIntervalSince1970]];
             }
         #if TARGET_OS_IOS == 1
         #ifndef MPARTICLE_LOCATION_DISABLE
-            messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+            [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
         #endif
         #endif
             MPMessage *message = [messageBuilder build];
@@ -1385,10 +1387,10 @@ static BOOL skipNextUpload = NO;
     
     NSDictionary *messageInfo = [networkPerformance dictionaryRepresentation];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeNetworkPerformance session:self.session messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeNetworkPerformance session:self.session messageInfo:messageInfo];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-    messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+    [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
     MPMessage *message = [messageBuilder build];
@@ -1417,13 +1419,13 @@ static BOOL skipNextUpload = NO;
     
     NSDictionary *messageInfo = [event screenDictionaryRepresentation];
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:event.messageType session:self.session messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:event.messageType session:self.session messageInfo:messageInfo];
     if (event.timestamp) {
-        [messageBuilder withTimestamp:[event.timestamp timeIntervalSince1970]];
+        [messageBuilder timestamp:[event.timestamp timeIntervalSince1970]];
     }
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-    messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+    [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
     MPMessage *message = [messageBuilder build];
@@ -1450,10 +1452,10 @@ static BOOL skipNextUpload = NO;
         
         [MParticle sharedInstance].stateMachine.optOut = optOutStatus;
         
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeOptOut session:self.session messageInfo:@{kMPOptOutStatus:(optOutStatus ? @"true" : @"false")}];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeOptOut session:self.session messageInfo:@{kMPOptOutStatus:(optOutStatus ? @"true" : @"false")}];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-        messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+        [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
         MPMessage *message = [messageBuilder build];
@@ -1534,7 +1536,7 @@ static BOOL skipNextUpload = NO;
             [self beginSessionWithIsManual:!MParticle.sharedInstance.automaticSessionTracking date:date];
         }
         
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeFirstRun session:self.session messageInfo:nil];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeFirstRun session:self.session messageInfo:nil];
                 
         [self processOpenSessionsEndingCurrent:NO completionHandler:^(void) {}];
         [self waitForKitsAndUploadWithCompletionHandler:nil];
@@ -1944,7 +1946,7 @@ static BOOL skipNextUpload = NO;
             messageInfo[kMPDeviceTokenTypeKey] = [MParticle sharedInstance].stateMachine.deviceTokenType;
         }
         
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypePushRegistration session:self.session messageInfo:messageInfo];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypePushRegistration session:self.session messageInfo:messageInfo];
         MPMessage *message = [messageBuilder build];
         
         [self saveMessage:message updateSession:YES];
@@ -1984,9 +1986,9 @@ static BOOL skipNextUpload = NO;
         messageInfo[kMPPushNotificationBehaviorKey] = @(userNotification.behavior);
     }
     
-    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypePushNotification session:_session messageInfo:messageInfo];
+    MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypePushNotification session:_session messageInfo:messageInfo];
 #ifndef MPARTICLE_LOCATION_DISABLE
-    messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+    [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
     MPMessage *message = [messageBuilder build];
     
@@ -2109,15 +2111,15 @@ static BOOL skipNextUpload = NO;
         [self setPreviousSessionSuccessfullyClosed:@YES];
         [self cleanUp];
                 
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeAppStateTransition 
-                                                                               session:self.session
-                                                                           messageInfo:@{kMPAppStateTransitionType: kMPASTBackgroundKey}];
-#if TARGET_OS_IOS == 1
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeAppStateTransition
+                                                                                 session:self.session
+                                                                             messageInfo:@{kMPAppStateTransitionType: kMPASTBackgroundKey}];
+    #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
         if ([MPLocationManager trackingLocation] && ![MParticle sharedInstance].stateMachine.locationManager.backgroundLocationTracking) {
             [[MParticle sharedInstance].stateMachine.locationManager.locationManager stopUpdatingLocation];
         }
-        messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+        [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
         MPMessage *message = [messageBuilder build];
@@ -2235,12 +2237,12 @@ static BOOL skipNextUpload = NO;
             messageDictionary[kMPAppForePreviousForegroundTime] = self.previousForegroundTime;
             isLaunch = NO;
         }
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeAppStateTransition session:self.session messageInfo:messageDictionary];
+        MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeAppStateTransition session:self.session messageInfo:messageDictionary];
         self.previousForegroundTime = MPCurrentEpochInMilliseconds;
-        messageBuilder = [messageBuilder withStateTransition:isLaunch previousSession:nil];
+        [messageBuilder stateTransition:isLaunch previousSession:nil];
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-        messageBuilder = [messageBuilder withLocation:[MParticle sharedInstance].stateMachine.location];
+        [messageBuilder location:[MParticle sharedInstance].stateMachine.location];
 #endif
 #endif
         MPMessage *message = [messageBuilder build];

--- a/mParticle-Apple-SDK/Utils/MPMessageBuilder.h
+++ b/mParticle-Apple-SDK/Utils/MPMessageBuilder.h
@@ -13,12 +13,7 @@
 @class MPUserIdentityChange;
 @class MPMessage;
 
-@interface MPMessageBuilder : NSObject {
-@protected
-    NSMutableDictionary<NSString *, id> *messageDictionary;
-    NSString *uuid;
-    MPMessageType messageTypeValue;
-}
+@interface MPMessageBuilder : NSObject
 
 @property (nonatomic, strong, readonly, nonnull) NSString *messageType;
 @property (nonatomic, strong, readonly, nullable) MPSession *session;
@@ -29,28 +24,26 @@
 
 + (NSString *_Nullable)stringForMessageType:(MPMessageType)type;
 + (MPMessageType)messageTypeForString:(NSString *_Nonnull)string;
-+ (nonnull MPMessageBuilder *)newBuilderWithMessageType:(MPMessageType)messageType
-                                                session:(nullable MPSession *)session
-                                            messageInfo:(nullable NSDictionary<NSString *, id> *)messageInfo;
-+ (nonnull MPMessageBuilder *)newBuilderWithMessageType:(MPMessageType)messageType
-                                                session:(nonnull MPSession *)session
-                                    userAttributeChange:(nonnull MPUserAttributeChange *)userAttributeChange;
-+ (nonnull MPMessageBuilder *)newBuilderWithMessageType:(MPMessageType)messageType
-                                                session:(nonnull MPSession *)session
-                                     userIdentityChange:(nonnull MPUserIdentityChange *)userIdentityChange;
-- (nonnull instancetype)initWithMessageType:(MPMessageType)messageType
+- (nullable instancetype)initWithMessageType:(MPMessageType)messageType
                                     session:(nullable MPSession *)session;
-- (nonnull instancetype)initWithMessageType:(MPMessageType)messageType
+- (nullable instancetype)initWithMessageType:(MPMessageType)messageType
                                     session:(nullable MPSession *)session
                                 messageInfo:(nullable NSDictionary<NSString *, id> *)messageInfo;
-- (nonnull MPMessageBuilder *)withLaunchInfo:(nonnull NSDictionary *)launchInfo;
-- (nonnull MPMessageBuilder *)withTimestamp:(NSTimeInterval)timestamp;
-- (nonnull MPMessageBuilder *)withStateTransition:(BOOL)sessionFinalized previousSession:(nullable MPSession *)previousSession;
+- (nullable instancetype)initWithMessageType:(MPMessageType)messageType
+                                     session:(nullable MPSession *)session
+                          userIdentityChange:(nonnull MPUserIdentityChange *)userIdentityChange;
+- (nullable instancetype)initWithMessageType:(MPMessageType)messageType
+                                     session:(nonnull MPSession *)session
+                         userAttributeChange:(nonnull MPUserAttributeChange *)userAttributeChange;
+
+- (void)launchInfo:(nonnull NSDictionary *)launchInfo;
+- (void)timestamp:(NSTimeInterval)timestamp;
+- (void)stateTransition:(BOOL)sessionFinalized previousSession:(nullable MPSession *)previousSession;
 - (nonnull MPMessage *)build;
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
-- (nonnull MPMessageBuilder *)withLocation:(nonnull CLLocation *)location;
+- (void)location:(nonnull CLLocation *)location;
 #endif
 #endif
 


### PR DESCRIPTION
 ## Summary
closes https://github.com/mParticle/mparticle-apple-sdk/issues/256

After some investigation, it looks like the crash is happening due to memory corruption, specifically of the `messageDictionary` object in the `MPMessageBuilder` class, but only when the `withLocation:` method is called. It seems that the pointer referenced invalid memory... It's unclear whether the root cause it in the SDK code or external code clobbering that memory, but in an attempt to resolve the issue I've refactored the `MPMessageBuilder` class in the following ways:

- Make the `messageDictionary` object a (strong) property instead of an instance variable in case there's some kind of compiler issue preventing it from being properly strongly retained
- Simplify class by removing the `new` class methods and just using init methods instead
- Fixed incorrect marking of init methods as nonnull to nullable since they can return nil and in some cases explicitly do
- Simplified other methods to no longer return self as it was not used much and hypothetically (though unlikely to impossible) the overwriting of the original reference could cause the memory to be released in between calling the methods and writing back over the reference. I don't think this is likely an actual issue but since we can't reproduce this problem I tried to change everything that could even remotely possibly cause a memory issue.


 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - We have extensive tests against `MPMessageBuilder` and they are all still passing
 - Manually E2E tested to confirm messages were properly built and uploaded to the live stream

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6174
