### PR TITLE
feat: Improve mParticle reset methods

### DIFF
--- a/UnitTests/BracketTests.mm
+++ b/UnitTests/BracketTests.mm
@@ -8,14 +8,6 @@
 
 @implementation BracketTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 mParticle::Bracket makeBracket() {
     mParticle::Bracket bracket(LONG_MAX - 3141592, 95, 97);
     return bracket;

--- a/UnitTests/HasherTests.m
+++ b/UnitTests/HasherTests.m
@@ -14,14 +14,6 @@
 
 @implementation HasherTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testHashingString {
     NSString *referenceString = @"The Quick Brown Fox Jumps Over the Lazy Dog.";
     NSString *hashedString = [MPIHasher hashString:referenceString];

--- a/UnitTests/MPAliasRequestTests.m
+++ b/UnitTests/MPAliasRequestTests.m
@@ -8,14 +8,6 @@
 
 @implementation MPAliasRequestTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testAliasInitWithMPIDs {
     MPAliasRequest *request = [MPAliasRequest requestWithSourceMPID:@1 destinationMPID:@2 startTime:[NSDate dateWithTimeIntervalSince1970:100] endTime:[NSDate dateWithTimeIntervalSince1970:200]];
     XCTAssertEqualObjects(request.sourceMPID, @1);

--- a/UnitTests/MPAliasResponseTests.m
+++ b/UnitTests/MPAliasResponseTests.m
@@ -7,14 +7,6 @@
 
 @implementation MPAliasResponseTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testAliasResponseCodeSuccess {
     MPAliasResponse *response = [[MPAliasResponse alloc] init];
     response.responseCode = 200;

--- a/UnitTests/MPAppNotificationHandlerTests.m
+++ b/UnitTests/MPAppNotificationHandlerTests.m
@@ -21,14 +21,6 @@
 
 @implementation MPAppNotificationHandlerTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 #if TARGET_OS_IOS == 1
 
 - (void)testFailedToRegisterForRemoteNotification {

--- a/UnitTests/MPBackendControllerTests.m
+++ b/UnitTests/MPBackendControllerTests.m
@@ -114,35 +114,22 @@
 - (void)setUp {
     [super setUp];
     messageQueue = [MParticle messageQueue];
-    
+        
     [MPPersistenceController setMpid:@1];
     [MParticle sharedInstance].persistenceController = [[MPPersistenceController alloc] init];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
-    stateMachine.apiKey = @"unit_test_app_key";
-    stateMachine.secret = @"unit_test_secret";
+    [MParticle sharedInstance].stateMachine.apiKey = @"unit_test_app_key";
+    [MParticle sharedInstance].stateMachine.secret = @"unit_test_secret";
     
     [MParticle sharedInstance].kitContainer = [[MPKitContainer alloc] init];
     
-    MParticle *mParticle = [MParticle sharedInstance];
-    mParticle.backendController = [[MPBackendController alloc] initWithDelegate:(id<MPBackendControllerDelegate>)mParticle];
+    [MParticle sharedInstance].backendController = [[MPBackendController alloc] initWithDelegate:(id<MPBackendControllerDelegate>)[MParticle sharedInstance]];
     self.backendController = [MParticle sharedInstance].backendController;
     [self notificationController];
 }
 
 - (void)tearDown {
     [MParticle sharedInstance].stateMachine.launchInfo = nil;
-    MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
-    [persistence deleteRecordsOlderThan:[[NSDate date] timeIntervalSince1970]];
-    NSMutableArray *sessions = [persistence fetchSessions];
-    for (MPSession *session in sessions) {
-        [persistence deleteSession:session];
-    }
-    
-    sessions = [persistence fetchSessions];
-    XCTAssertEqual(sessions.count, 0, @"Sessions have not been deleted.");
-    [persistence closeDatabase];
     [super tearDown];
 }
 

--- a/UnitTests/MPBaseTestCase.m
+++ b/UnitTests/MPBaseTestCase.m
@@ -30,14 +30,15 @@
 
 @implementation MPBaseTestCase
 
-- (void)setUp {
+- (void)setUpWithCompletionHandler:(void (^)(NSError * _Nullable))completion {
     [super setUp];
-    [[MParticle sharedInstance] reset];
-    MPNetworkCommunication.connectorFactory = [[MPTestConnectorFactory alloc] init];
+    [[MParticle sharedInstance] reset:^{
+        MPNetworkCommunication.connectorFactory = [[MPTestConnectorFactory alloc] init];
+        completion(nil);
+    }];
 }
 
 - (void)tearDown {
-    [[MParticle sharedInstance] reset];
     MPNetworkCommunication.connectorFactory = nil;
     [super tearDown];
 }

--- a/UnitTests/MPBase_Attribute_Event_ProjectionTests.m
+++ b/UnitTests/MPBase_Attribute_Event_ProjectionTests.m
@@ -10,14 +10,6 @@
 
 @implementation MPBase_Attribute_Event_ProjectionTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testBaseInstanceEvent {
     NSDictionary *configuration = @{@"action":@{@"projected_event_name":@"Projected Event"
                                                 },

--- a/UnitTests/MPCCPAConsentTests.m
+++ b/UnitTests/MPCCPAConsentTests.m
@@ -4,58 +4,50 @@
 
 static NSTimeInterval epsilon = 0.05;
 
-@interface MPCCPAConsentTests : MPBaseTestCase {
-    MPCCPAConsent *_state;
-}
+@interface MPCCPAConsentTests : MPBaseTestCase
 
 @end
 
 @implementation MPCCPAConsentTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-    _state = [[MPCCPAConsent alloc] init];
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testInit {
-    XCTAssertNotNil(_state);
+    MPCCPAConsent *state = [[MPCCPAConsent alloc] init];
+    XCTAssertNotNil(state);
 }
 
 - (void)testDefaultPropertyValues {
-    XCTAssertFalse(_state.consented);
-    XCTAssertNil(_state.document);
+    MPCCPAConsent *state = [[MPCCPAConsent alloc] init];
     
-    XCTAssertNotNil(_state.timestamp);
-    XCTAssertLessThan(-1*_state.timestamp.timeIntervalSinceNow, epsilon);
+    XCTAssertFalse(state.consented);
+    XCTAssertNil(state.document);
     
-    XCTAssertNil(_state.location);
-    XCTAssertNil(_state.hardwareId);
+    XCTAssertNotNil(state.timestamp);
+    XCTAssertLessThan(-1*state.timestamp.timeIntervalSinceNow, epsilon);
+    
+    XCTAssertNil(state.location);
+    XCTAssertNil(state.hardwareId);
 }
 
 - (void)testPropertySetters {
-    _state.consented = YES;
-    _state.document = @"foo-document-1";
+    MPCCPAConsent *state = [[MPCCPAConsent alloc] init];
+    
+    state.consented = YES;
+    state.document = @"foo-document-1";
     
     NSDate *date = [NSDate date];
-    _state.timestamp = date;
+    state.timestamp = date;
     
-    _state.location = @"foo-location-1";
-    _state.hardwareId = @"foo-hardware-id-1";
+    state.location = @"foo-location-1";
+    state.hardwareId = @"foo-hardware-id-1";
     
-    XCTAssertTrue(_state.consented);
-    XCTAssertEqualObjects(_state.document, @"foo-document-1");
-    XCTAssertEqualObjects(_state.timestamp, date);
-    XCTAssertEqualObjects(_state.location, @"foo-location-1");
-    XCTAssertEqualObjects(_state.hardwareId, @"foo-hardware-id-1");
+    XCTAssertTrue(state.consented);
+    XCTAssertEqualObjects(state.document, @"foo-document-1");
+    XCTAssertEqualObjects(state.timestamp, date);
+    XCTAssertEqualObjects(state.location, @"foo-location-1");
+    XCTAssertEqualObjects(state.hardwareId, @"foo-hardware-id-1");
     
-    _state.consented = NO;
-    XCTAssertFalse(_state.consented);
+    state.consented = NO;
+    XCTAssertFalse(state.consented);
 }
 
 @end

--- a/UnitTests/MPCommerceEventTests.m
+++ b/UnitTests/MPCommerceEventTests.m
@@ -16,14 +16,6 @@
 
 @implementation MPCommerceEventTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testProduct {
     MPProduct *product = [[MPProduct alloc] initWithName:@"DeLorean"
                                                      sku:@"OutATime"

--- a/UnitTests/MPConnectorTests.m
+++ b/UnitTests/MPConnectorTests.m
@@ -22,14 +22,6 @@
 
 @implementation MPConnectorTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testSessionIsInvalidatedWithError {
     MPConnector *connector = [[MPConnector alloc] init];
     NSURLSession *mockSession = OCMClassMock([NSURLSession class]);

--- a/UnitTests/MPConsentKitFilterTests.m
+++ b/UnitTests/MPConsentKitFilterTests.m
@@ -8,16 +8,6 @@
 
 @implementation MPConsentKitFilterTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testProperties {
     MPConsentKitFilter *filter = [[MPConsentKitFilter alloc] init];
     

--- a/UnitTests/MPConsentSerializationTests.m
+++ b/UnitTests/MPConsentSerializationTests.m
@@ -21,16 +21,6 @@ static NSTimeInterval epsilon = 0.05;
 
 @implementation MPConsentSerializationTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testServerDictionaryGDPR {
     MPConsentState *consentState = nil;
     NSDictionary *dictionary = nil;

--- a/UnitTests/MPConsentStateTests.m
+++ b/UnitTests/MPConsentStateTests.m
@@ -16,16 +16,11 @@
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
     _globalState = [[MPConsentState alloc] init];
     _state = [[MPGDPRConsent alloc] init];
     _ccpaState = [[MPCCPAConsent alloc] init];
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
 
 - (void)testInit {
     XCTAssertNotNil(_globalState);

--- a/UnitTests/MPConsumerInfoTests.m
+++ b/UnitTests/MPConsumerInfoTests.m
@@ -56,10 +56,6 @@
     consumerInfoDictionary = responseDictionary[kMPRemoteConfigConsumerInfoKey];
 }
 
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testInstance {
     MPConsumerInfo *consumerInfo = [[MPConsumerInfo alloc] init];
     

--- a/UnitTests/MPConvertJSTests.m
+++ b/UnitTests/MPConvertJSTests.m
@@ -9,16 +9,6 @@
 
 @implementation MPConvertJSTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testConvertTransaction {
     NSDictionary *json = @{
                            @"Affiliation":@"Test affiliation",

--- a/UnitTests/MPCustomModuleTests.m
+++ b/UnitTests/MPCustomModuleTests.m
@@ -95,10 +95,6 @@
     [MPPersistenceController setMpid:@1];
 }
 
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testConfiguration {
     NSData *customModuleData = [self.customModulesString dataUsingEncoding:NSUTF8StringEncoding];
     XCTAssertNotNil(customModuleData, @"Should not have been nil.");

--- a/UnitTests/MPDataModelTests.m
+++ b/UnitTests/MPDataModelTests.m
@@ -24,14 +24,8 @@
 - (void)setUp {
     [super setUp];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
-    stateMachine.apiKey = @"unit_test_app_key";
-    stateMachine.secret = @"unit_test_secret";
-}
-
-- (void)tearDown {
-    [super tearDown];
+    [MParticle sharedInstance].stateMachine.apiKey = @"unit_test_app_key";
+    [MParticle sharedInstance].stateMachine.secret = @"unit_test_secret";
 }
 
 - (void)testSessionInstance {

--- a/UnitTests/MPDataPlanFilterTests.m
+++ b/UnitTests/MPDataPlanFilterTests.m
@@ -1,16 +1,18 @@
 #import <XCTest/XCTest.h>
 #import "MPDataPlanFilter.h"
 
-MPDataPlanFilter *adapter;
-MPDataPlanFilter *noBlockAdapter;
-MPDataPlanFilter *additionalAttrsAdapter;
-
-@interface MPDataPlanFilterTests : XCTestCase
+@interface MPDataPlanFilterTests : XCTestCase {
+    MPDataPlanFilter *adapter;
+    MPDataPlanFilter *noBlockAdapter;
+    MPDataPlanFilter *additionalAttrsAdapter;
+}
 @end
 
 @implementation MPDataPlanFilterTests
 
 - (void)setUp {
+    [super setUp];
+    
     // Put setup code here. This method is called before the invocation of each test method in the class.
     NSDictionary *plan = @{@"version_document":@{@"data_points":@[@{@"match":@{@"type":@"custom_event",@"criteria":@{@"event_name":@"Email Bounces",@"custom_event_type":@"other"} }, @"validator":@{@"definition":@{@"properties":@{@"data":@{@"properties":@{@"custom_attributes":@{@"additionalProperties": @NO, @"properties":@{@"Campaign Name": @{}, @"Campaign Id": @{}}}}}}}}}]}};
     
@@ -38,11 +40,6 @@ MPDataPlanFilter *additionalAttrsAdapter;
     addAttrsDataplanOptions.blockUserIdentities = YES;
     additionalAttrsAdapter = [[MPDataPlanFilter alloc] initWithDataPlanOptions:addAttrsDataplanOptions];
 }
-
-- (void)tearDown {
-    
-}
-
 
 // No attribute custom event tests
 - (void)testNoBlockPlannedCustomEventNameType {
@@ -106,15 +103,16 @@ MPDataPlanFilter *additionalAttrsAdapter;
 
 
 
-@interface MPKDataPlanFilterCommonTests : XCTestCase
+@interface MPKDataPlanFilterCommonTests : XCTestCase {
+    MPDataPlanOptions *dataplanOptions;
+}
 @end
 
 @implementation MPKDataPlanFilterCommonTests
 
-MPDataPlanOptions *dataplanOptions;
-
-
 -(void)setUp {
+    [super setUp];
+    
     NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"sample_dataplan2" ofType:@"json"];
     NSString *jsonString = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     NSData * jsonData = [jsonString dataUsingEncoding:0];

--- a/UnitTests/MPDateFormatterTests.m
+++ b/UnitTests/MPDateFormatterTests.m
@@ -24,10 +24,6 @@
     referenceDate = [dateComponents date];
 }
 
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testDatesFromString {
     NSDate *date = [MPDateFormatter dateFromString:@"1955-11-5T01:15:00-8"];
     XCTAssertNotNil(date, @"Should not have been nil.");

--- a/UnitTests/MPDeviceTests.m
+++ b/UnitTests/MPDeviceTests.m
@@ -10,14 +10,6 @@
 
 @implementation MPDeviceTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testTelephonyRadioAccessTechnology {
 #if TARGET_OS_IOS == 1
     CTTelephonyNetworkInfo *mockTelephonyNetworkInfo = OCMPartialMock([[CTTelephonyNetworkInfo alloc] init]);

--- a/UnitTests/MPEventTests.m
+++ b/UnitTests/MPEventTests.m
@@ -24,16 +24,6 @@
 
 @implementation MPEventTests
 
-- (void)setUp {
-    [super setUp];
-    
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testInstance {
     MPEvent *event = [[MPEvent alloc] initWithName:@"Dinosaur Run" type:MPEventTypeOther];
     

--- a/UnitTests/MPForwardQueueItemTests.m
+++ b/UnitTests/MPForwardQueueItemTests.m
@@ -49,14 +49,6 @@
 
 @implementation MPForwardQueueItemTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testCommerceInstance {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Forward Queue Item Test (Ecommerce)"];
     MPProduct *product = [[MPProduct alloc] initWithName:@"Sonic Screwdriver" sku:@"SNCDRV" quantity:@1 price:@3.14];

--- a/UnitTests/MPForwardRecordTests.m
+++ b/UnitTests/MPForwardRecordTests.m
@@ -26,15 +26,6 @@
 
 @implementation MPForwardRecordTests
 
-- (void)setUp {
-    
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testInstance {
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess];
     XCTAssertTrue([execStatus success], @"Should have been true.");

--- a/UnitTests/MPGDPRConsentTests.m
+++ b/UnitTests/MPGDPRConsentTests.m
@@ -4,58 +4,50 @@
 
 static NSTimeInterval epsilon = 0.05;
 
-@interface MPGDPRConsentTests : MPBaseTestCase {
-    MPGDPRConsent *_state;
-}
+@interface MPGDPRConsentTests : MPBaseTestCase
 
 @end
 
 @implementation MPGDPRConsentTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-    _state = [[MPGDPRConsent alloc] init];
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testInit {
-    XCTAssertNotNil(_state);
+    MPGDPRConsent *state = [[MPGDPRConsent alloc] init];
+    XCTAssertNotNil(state);
 }
 
 - (void)testDefaultPropertyValues {
-    XCTAssertFalse(_state.consented);
-    XCTAssertNil(_state.document);
+    MPGDPRConsent *state = [[MPGDPRConsent alloc] init];
     
-    XCTAssertNotNil(_state.timestamp);
-    XCTAssertLessThan(-1*_state.timestamp.timeIntervalSinceNow, epsilon);
+    XCTAssertFalse(state.consented);
+    XCTAssertNil(state.document);
     
-    XCTAssertNil(_state.location);
-    XCTAssertNil(_state.hardwareId);
+    XCTAssertNotNil(state.timestamp);
+    XCTAssertLessThan(-1*state.timestamp.timeIntervalSinceNow, epsilon);
+    
+    XCTAssertNil(state.location);
+    XCTAssertNil(state.hardwareId);
 }
 
 - (void)testPropertySetters {
-    _state.consented = YES;
-    _state.document = @"foo-document-1";
+    MPGDPRConsent *state = [[MPGDPRConsent alloc] init];
+    
+    state.consented = YES;
+    state.document = @"foo-document-1";
     
     NSDate *date = [NSDate date];
-    _state.timestamp = date;
+    state.timestamp = date;
     
-    _state.location = @"foo-location-1";
-    _state.hardwareId = @"foo-hardware-id-1";
+    state.location = @"foo-location-1";
+    state.hardwareId = @"foo-hardware-id-1";
     
-    XCTAssertTrue(_state.consented);
-    XCTAssertEqualObjects(_state.document, @"foo-document-1");
-    XCTAssertEqualObjects(_state.timestamp, date);
-    XCTAssertEqualObjects(_state.location, @"foo-location-1");
-    XCTAssertEqualObjects(_state.hardwareId, @"foo-hardware-id-1");
+    XCTAssertTrue(state.consented);
+    XCTAssertEqualObjects(state.document, @"foo-document-1");
+    XCTAssertEqualObjects(state.timestamp, date);
+    XCTAssertEqualObjects(state.location, @"foo-location-1");
+    XCTAssertEqualObjects(state.hardwareId, @"foo-hardware-id-1");
     
-    _state.consented = NO;
-    XCTAssertFalse(_state.consented);
+    state.consented = NO;
+    XCTAssertFalse(state.consented);
 }
 
 @end

--- a/UnitTests/MPIUserDefaultsTests.m
+++ b/UnitTests/MPIUserDefaultsTests.m
@@ -26,10 +26,8 @@
 - (void)setUp {
     [super setUp];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
-    stateMachine.apiKey = @"unit_test_app_key";
-    stateMachine.secret = @"unit_test_secret";
+    [MParticle sharedInstance].stateMachine.apiKey = @"unit_test_app_key";
+    [MParticle sharedInstance].stateMachine.secret = @"unit_test_secret";
     
     [MParticle sharedInstance].kitContainer = [[MPKitContainer alloc] init];
     kitContainer = [MParticle sharedInstance].kitContainer;

--- a/UnitTests/MPIdentityApiRequestTests.m
+++ b/UnitTests/MPIdentityApiRequestTests.m
@@ -8,14 +8,6 @@
 
 @implementation MPIdentityApiRequestTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testSetNilIdentity {
     MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
     [request setIdentity:@"foo" identityType:MPIdentityOther];

--- a/UnitTests/MPIdentityCachingTests.m
+++ b/UnitTests/MPIdentityCachingTests.m
@@ -40,11 +40,6 @@ static NSString *const kMPIdentityCachingExpires = @"kMPIdentityCachingExpires";
     [MPIdentityCaching setCache:nil];
 }
 
-- (void)tearDown {
-    [super tearDown];
-    [MPIdentityCaching setCache:nil];
-}
-
 - (void)testGetCachedResponse {
     NSDictionary *identities = @{
         @"ios_idfv": @"abcdefg",

--- a/UnitTests/MPIdentityTests.m
+++ b/UnitTests/MPIdentityTests.m
@@ -65,14 +65,6 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 
 @implementation MPIdentityTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testConstructIdentityApiRequest {
     MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
     [request setIdentity:@"other id" identityType:MPIdentityOther];

--- a/UnitTests/MPIntegrationAttributesTest.m
+++ b/UnitTests/MPIntegrationAttributesTest.m
@@ -10,14 +10,6 @@
 
 @implementation MPIntegrationAttributesTest
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testInstance {
     NSNumber *integrationId = @(MPKitInstanceUrbanAirship);
     NSDictionary<NSString *, NSString *> *attributes = @{@"key":@"value"};

--- a/UnitTests/MPKitAPITests.m
+++ b/UnitTests/MPKitAPITests.m
@@ -79,13 +79,6 @@
     _kitApi = [[MPKitAPI alloc] initWithKitCode:@42];
 }
 
-- (void)tearDown {
-    [MParticle sharedInstance].backendController = nil;
-    [[MPIUserDefaults standardUserDefaults] resetDefaults];
-
-    [super tearDown];
-}
-
 - (void)testIntegrationAttributes {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Integration attributes"];
     MParticle *mParticle = [MParticle sharedInstance];

--- a/UnitTests/MPKitActivityTests.m
+++ b/UnitTests/MPKitActivityTests.m
@@ -20,8 +20,10 @@
 @interface MPKitContainer(Tests)
 
 - (id<MPKitProtocol>)startKit:(NSNumber *)integrationId configuration:(MPKitConfiguration *)kitConfiguration;
++ (NSMutableSet <id<MPExtensionKitProtocol>> *)kitsRegistry;
 
 @end
+
 
 #pragma mark - MPKitActivityTests
 @interface MPKitActivityTests : MPBaseTestCase
@@ -38,32 +40,23 @@
 
     _kitActivity = [[MPKitActivity alloc] init];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
-    stateMachine.apiKey = @"unit_test_app_key";
-    stateMachine.secret = @"unit_test_secret";
+    [MParticle sharedInstance].stateMachine.apiKey = @"unit_test_app_key";
+    [MParticle sharedInstance].stateMachine.secret = @"unit_test_secret";
     
     [MParticle sharedInstance].kitContainer = [[MPKitContainer alloc] init];
         
-    NSSet<id<MPExtensionProtocol>> *registeredKits = [MPKitContainer registeredKits];
-    if (!registeredKits) {
-        MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"KitTest" className:@"MPKitTestClassNoStartImmediately"];
-        [MPKitContainer registerKit:kitRegister];
-        
-        NSDictionary *configuration = @{
-                                        @"id":@42,
-                                        @"as":@{
-                                                @"appId":@"MyAppId"
-                                                }
-                                        };
-        
-        MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configuration];
-        [[[MParticle sharedInstance].kitContainer startKit:@42 configuration:kitConfiguration] start];
-    }
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"KitTest" className:@"MPKitTestClassNoStartImmediately"];
+    [MPKitContainer registerKit:kitRegister];
+    NSDictionary *configuration = @{@"id": @42, @"as": @{@"appId":@"MyAppId"}};
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configuration];
+    [[[MParticle sharedInstance].kitContainer startKit:@42 configuration:kitConfiguration] start];
 }
 
 - (void)tearDown {
     _kitActivity = nil;
+    
+    // Ensure registeredKits is empty
+    [MPKitContainer.kitsRegistry removeAllObjects];
     
     [super tearDown];
 }

--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -86,10 +86,8 @@
 - (void)setUp {
     [super setUp];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
-    stateMachine.apiKey = @"unit_test_app_key";
-    stateMachine.secret = @"unit_test_secret";
+    [MParticle sharedInstance].stateMachine.apiKey = @"unit_test_app_key";
+    [MParticle sharedInstance].stateMachine.secret = @"unit_test_secret";
     
     [MParticle sharedInstance].kitContainer = [[MPKitContainer alloc] init];
     kitContainer = [MParticle sharedInstance].kitContainer;

--- a/UnitTests/MPKitRegisterTests.m
+++ b/UnitTests/MPKitRegisterTests.m
@@ -10,14 +10,6 @@
 
 @implementation MPKitRegisterTests
 
-- (void)setUp {
-    [super setUp];    
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testInstance {
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"KitTest" className:@"MPKitTestClassNoStartImmediately"];
     XCTAssertNotNil(kitRegister, @"Should not have been nil.");

--- a/UnitTests/MPLaunchInfoTests.m
+++ b/UnitTests/MPLaunchInfoTests.m
@@ -13,14 +13,6 @@
 
 @implementation MPLaunchInfoTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testAnnotation {
     NSURL *url = [NSURL URLWithString:@"http://mparticle.com"];
     NSString *sourceApp = @"testApp";

--- a/UnitTests/MPMessageBuilderTests.m
+++ b/UnitTests/MPMessageBuilderTests.m
@@ -50,16 +50,6 @@ NSString *const kMPStateInformationKey = @"cs";
     return _session;
 }
 
-- (void)setUp {
-    [super setUp];
-    
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testBuildingMessage {
     NSDictionary *messageInfo = @{@"key1":@"value1",
                                   @"key2":@"value2",

--- a/UnitTests/MPMessageTests.m
+++ b/UnitTests/MPMessageTests.m
@@ -15,14 +15,6 @@
 
 @implementation MPMessageTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testTruncateDataProperty {
     NSDictionary *messageDictionary = @{
         @"location": @"17 Cherry Tree Lane",

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -40,14 +40,6 @@ Method originalMethod = nil; Method swizzleMethod = nil;
 
 @implementation MPNetworkCommunicationTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {    
-    [super tearDown];
-}
-
 - (void) swizzleInstanceMethodForInstancesOfClass:(Class)targetClass selector:(SEL)selector
 {
     originalMethod = class_getInstanceMethod(targetClass, selector);

--- a/UnitTests/MPNetworkOptionsTests.m
+++ b/UnitTests/MPNetworkOptionsTests.m
@@ -8,16 +8,6 @@
 
 @implementation MPNetworkOptionsTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testInit {
     MPNetworkOptions *options = [[MPNetworkOptions alloc] init];
     XCTAssertNotNil(options);

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -47,13 +47,7 @@
 - (void)setUp {
     [super setUp];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
     [MParticle sharedInstance].persistenceController = [[MPPersistenceController alloc] init];
-}
-
-- (void)tearDown {
-    
-    [super tearDown];
 }
 
 - (void)testMultiThreadedAccess {

--- a/UnitTests/MPResponseConfigTests.m
+++ b/UnitTests/MPResponseConfigTests.m
@@ -20,18 +20,6 @@
 
 @implementation MPResponseConfigTests
 
-- (void)setUp {
-    [super setUp];
-    
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-}
-
-- (void)tearDown {
-    [[MPIUserDefaults standardUserDefaults] resetDefaults];
-
-    [super tearDown];
-}
-
 - (void)testInstance {
     NSDictionary *configuration = @{kMPRemoteConfigKitsKey:[NSNull null],
                                     kMPRemoteConfigCustomModuleSettingsKey:[NSNull null],

--- a/UnitTests/MPResponseEventsTest.m
+++ b/UnitTests/MPResponseEventsTest.m
@@ -18,16 +18,6 @@
 
 @implementation MPResponseEventsTest
 
-- (void)setUp {
-    [super setUp];
-    
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testParseConfiguration {
     MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
     

--- a/UnitTests/MPStateMachineTests.m
+++ b/UnitTests/MPStateMachineTests.m
@@ -35,16 +35,6 @@
 
 @implementation MPStateMachineTests
 
-- (void)setUp {
-    [super setUp];
-    
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testOptOut {
     MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
     stateMachine.optOut = YES;

--- a/UnitTests/MPSurrogateAppDelegateTests.m
+++ b/UnitTests/MPSurrogateAppDelegateTests.m
@@ -7,14 +7,6 @@
 
 @implementation MPSurrogateAppDelegateTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testNonImplementedMethods {
     MPSurrogateAppDelegate *surrogate = [[MPSurrogateAppDelegate alloc] init];
     XCTAssertFalse([surrogate implementsSelector:@selector(isKindOfClass:)]);

--- a/UnitTests/MPURLRequestBuilderTests.m
+++ b/UnitTests/MPURLRequestBuilderTests.m
@@ -60,10 +60,8 @@
     
     [MPPersistenceController setMpid:@12];
 
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
-    stateMachine.apiKey = @"unit_test_app_key";
-    stateMachine.secret = @"unit_test_secret";
+    [MParticle sharedInstance].stateMachine.apiKey = @"unit_test_app_key";
+    [MParticle sharedInstance].stateMachine.secret = @"unit_test_secret";
 
     [MParticle sharedInstance].kitContainer = [[MPKitContainer alloc] init];
     kitContainer = [MParticle sharedInstance].kitContainer;

--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -37,8 +37,6 @@
 - (void)setUp {
     [super setUp];
     
-    [MParticle sharedInstance].stateMachine = [[MPStateMachine alloc] init];
-
     [MParticle sharedInstance].persistenceController = [[MPPersistenceController alloc] init];
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -53,12 +51,6 @@
     attributes = @{@"keyB":@"valueB"};
     integrationAttributes = [[MPIntegrationAttributes alloc] initWithIntegrationId:integrationId attributes:attributes];
     [persistence saveIntegrationAttributes:integrationAttributes];
-}
-
-- (void)tearDown {
-    [super tearDown];
-    
-    [[MParticle sharedInstance].persistenceController deleteAllIntegrationAttributes];
 }
 
 - (void)configureCustomModules {

--- a/UnitTests/MPUserAttributeChangeTests.m
+++ b/UnitTests/MPUserAttributeChangeTests.m
@@ -8,14 +8,6 @@
 
 @implementation MPUserAttributeChangeTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testInstance {
     NSArray *val2Array = @[@"item1", @"item2"];
     NSDictionary<NSString *, id> *userAttributes = @{@"key1":@"val1",

--- a/UnitTests/MPUserIdentityChangeTests.m
+++ b/UnitTests/MPUserIdentityChangeTests.m
@@ -18,16 +18,6 @@
 
 @implementation MPUserIdentityChangeTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [[MPIUserDefaults standardUserDefaults] resetDefaults];
-
-    [super tearDown];
-}
-
 - (void)testUserIdentityRequest {
     MParticle *mParticle = [MParticle sharedInstance];
     mParticle.backendController = [[MPBackendController alloc] initWithDelegate:(id<MPBackendControllerDelegate>)mParticle];

--- a/UnitTests/MPZipTests.m
+++ b/UnitTests/MPZipTests.m
@@ -74,14 +74,6 @@
 
 @implementation MPZipTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testSimpleCompressAndExpand {
     NSString *input = @"";
     for (int i=0; i<100; i++) {

--- a/UnitTests/MParticleOptionsTests.m
+++ b/UnitTests/MParticleOptionsTests.m
@@ -5,112 +5,102 @@
 
 @interface MParticleOptionsTests : MPBaseTestCase
 
-@property (nonatomic) MParticleOptions *options;
-
 @end
 
 @implementation MParticleOptionsTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    _options = nil;
-    [super tearDown];
-}
 
 - (void)testNoArgInit {
-    _options = [[MParticleOptions alloc] init];
-    XCTAssertNotNil(_options, @"Expected no-arg init to produce a non-nil options object");
+    MParticleOptions *options = [[MParticleOptions alloc] init];
+    XCTAssertNotNil(options, @"Expected no-arg init to produce a non-nil options object");
 }
 
 - (void)testKeySecretInit {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
     
-    XCTAssertNotNil(_options, @"Expected optionsWithKey to produce a non-nil options object");
+    XCTAssertNotNil(options, @"Expected optionsWithKey to produce a non-nil options object");
     
-    XCTAssertEqualObjects(_options.apiKey, @"unit_test_app_key", @"Expected key to match the one passed in");
-    XCTAssertEqualObjects(_options.apiSecret, @"unit_test_secret", @"Expected secret to match the one passed in");
+    XCTAssertEqualObjects(options.apiKey, @"unit_test_app_key", @"Expected key to match the one passed in");
+    XCTAssertEqualObjects(options.apiSecret, @"unit_test_secret", @"Expected secret to match the one passed in");
 }
 
 - (void)testDisableProxyAppDelegate {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    XCTAssertTrue(_options.proxyAppDelegate, @"Expected proxy AppDelegate to default to YES");
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    XCTAssertTrue(options.proxyAppDelegate, @"Expected proxy AppDelegate to default to YES");
     
-    _options.proxyAppDelegate = NO;
-    XCTAssertFalse(_options.proxyAppDelegate, @"Expected proxy AppDelegate to be NO after setting to NO");
+    options.proxyAppDelegate = NO;
+    XCTAssertFalse(options.proxyAppDelegate, @"Expected proxy AppDelegate to be NO after setting to NO");
 }
 
 - (void)testDisableAutoSessionTracking {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    XCTAssertTrue(_options.automaticSessionTracking, @"Expected auto session tracking to default to YES");
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    XCTAssertTrue(options.automaticSessionTracking, @"Expected auto session tracking to default to YES");
     
-    _options.automaticSessionTracking = NO;
-    XCTAssertFalse(_options.automaticSessionTracking, @"Expected auto session tracking to be NO after setting to NO");
+    options.automaticSessionTracking = NO;
+    XCTAssertFalse(options.automaticSessionTracking, @"Expected auto session tracking to be NO after setting to NO");
 }
 
 - (void)testLogLevel {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
     
-    XCTAssertEqual(_options.logLevel, MPILogLevelNone, @"Default Debug Level was incorrect");
+    XCTAssertEqual(options.logLevel, MPILogLevelNone, @"Default Debug Level was incorrect");
 }
 
 - (void)testSetLogLevel {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    _options.logLevel = MPILogLevelDebug;
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    options.logLevel = MPILogLevelDebug;
     
-    XCTAssertEqual(_options.logLevel, MPILogLevelDebug, @"Debug Level was was not set correctly");
+    XCTAssertEqual(options.logLevel, MPILogLevelDebug, @"Debug Level was was not set correctly");
 }
 
 - (void)testSetSearchAdsAttributionDefault {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
     
-    XCTAssertFalse(_options.collectSearchAdsAttribution, @"Search ads attribution shouldn't be collected by default");
+    XCTAssertFalse(options.collectSearchAdsAttribution, @"Search ads attribution shouldn't be collected by default");
 }
 
 - (void)testSetSearchAdsAttributionSet {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    _options.collectSearchAdsAttribution = YES;
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    options.collectSearchAdsAttribution = YES;
     
-    XCTAssertTrue(_options.collectSearchAdsAttribution, @"Search ads attribution was not set correctly");
+    XCTAssertTrue(options.collectSearchAdsAttribution, @"Search ads attribution was not set correctly");
 }
 
 - (void)testSetSearchAdsAttributionReset {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    _options.collectSearchAdsAttribution = NO;
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    options.collectSearchAdsAttribution = NO;
     
-    _options.collectSearchAdsAttribution = YES;
-    XCTAssertTrue(_options.collectSearchAdsAttribution, @"Search ads attribution was not set correctly");
+    options.collectSearchAdsAttribution = YES;
+    XCTAssertTrue(options.collectSearchAdsAttribution, @"Search ads attribution was not set correctly");
 }
 
 - (void)testSessionTimeout {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    XCTAssertEqual(_options.sessionTimeout, DEFAULT_SESSION_TIMEOUT, @"Session Timeout Interval default correct");
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    XCTAssertEqual(options.sessionTimeout, DEFAULT_SESSION_TIMEOUT, @"Session Timeout Interval default correct");
     
-    _options.sessionTimeout = 100.0;
-    XCTAssertEqual(_options.sessionTimeout, 100.0, @"Session Timeout Interval set correctly");
+    options.sessionTimeout = 100.0;
+    XCTAssertEqual(options.sessionTimeout, 100.0, @"Session Timeout Interval set correctly");
 }
 
 - (void)testDataBlockOptions {
-    _options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
-    XCTAssertNil(_options.dataPlanOptions.dataPlan);
-    XCTAssertFalse(_options.dataPlanOptions.blockEvents);
-    XCTAssertFalse(_options.dataPlanOptions.blockEventAttributes);
-    XCTAssertFalse(_options.dataPlanOptions.blockUserAttributes);
-    XCTAssertFalse(_options.dataPlanOptions.blockUserIdentities);
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit_test_app_key" secret:@"unit_test_secret"];
+    XCTAssertNil(options.dataPlanOptions.dataPlan);
+    XCTAssertFalse(options.dataPlanOptions.blockEvents);
+    XCTAssertFalse(options.dataPlanOptions.blockEventAttributes);
+    XCTAssertFalse(options.dataPlanOptions.blockUserAttributes);
+    XCTAssertFalse(options.dataPlanOptions.blockUserIdentities);
     
-    _options.dataPlanOptions = [[MPDataPlanOptions alloc] init];
-    _options.dataPlanOptions.dataPlan = @{};
-    _options.dataPlanOptions.blockEvents = YES;
-    _options.dataPlanOptions.blockEventAttributes = YES;
-    _options.dataPlanOptions.blockUserAttributes = YES;
-    _options.dataPlanOptions.blockUserIdentities = YES;
-    XCTAssertNotNil(_options.dataPlanOptions.dataPlan);
-    XCTAssertTrue(_options.dataPlanOptions.blockEvents);
-    XCTAssertTrue(_options.dataPlanOptions.blockEventAttributes);
-    XCTAssertTrue(_options.dataPlanOptions.blockUserAttributes);
-    XCTAssertTrue(_options.dataPlanOptions.blockUserIdentities);
+    options.dataPlanOptions = [[MPDataPlanOptions alloc] init];
+    options.dataPlanOptions.dataPlan = @{};
+    options.dataPlanOptions.blockEvents = YES;
+    options.dataPlanOptions.blockEventAttributes = YES;
+    options.dataPlanOptions.blockUserAttributes = YES;
+    options.dataPlanOptions.blockUserIdentities = YES;
+    XCTAssertNotNil(options.dataPlanOptions.dataPlan);
+    XCTAssertTrue(options.dataPlanOptions.blockEvents);
+    XCTAssertTrue(options.dataPlanOptions.blockEventAttributes);
+    XCTAssertTrue(options.dataPlanOptions.blockUserAttributes);
+    XCTAssertTrue(options.dataPlanOptions.blockUserIdentities);
 }
 
 @end

--- a/UnitTests/MParticleTests.m
+++ b/UnitTests/MParticleTests.m
@@ -63,7 +63,7 @@
     lastNotification = nil;
 }
 
-- (void)testResetInstance {
+- (void)testDeprecatedResetInstance {
     MParticle *instance = [MParticle sharedInstance];
     MParticle *instance2 = [MParticle sharedInstance];
     XCTAssertNotNil(instance);
@@ -73,6 +73,22 @@
     MParticle *instance4 = [MParticle sharedInstance];
     XCTAssertNotEqual(instance, instance3);
     XCTAssertEqual(instance3, instance4);
+}
+
+- (void)testResetInstance {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
+    MParticle *instance = [MParticle sharedInstance];
+    MParticle *instance2 = [MParticle sharedInstance];
+    XCTAssertNotNil(instance);
+    XCTAssertEqual(instance, instance2);
+    [instance reset:^{
+        MParticle *instance3 = [MParticle sharedInstance];
+        MParticle *instance4 = [MParticle sharedInstance];
+        XCTAssertNotEqual(instance, instance3);
+        XCTAssertEqual(instance3, instance4);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
 - (void)testOptOut {

--- a/UnitTests/NSNumber+MPFormatterTests.m
+++ b/UnitTests/NSNumber+MPFormatterTests.m
@@ -16,16 +16,6 @@
 
 @implementation NSNumber_MPFormatterTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testFormatZero {
     NSNumber *number = @(0);
     NSNumber *formattedNumber = [number formatWithNonScientificNotation];

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -720,12 +720,14 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 - (BOOL)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler;
 
 /**
- This method will permanently remove ALL MParticle data from the device, including MParticle UserDefaults and Database, it will also halt any further upload or download behavior that may be prepared
+ DEPRECATED: This method will permanently remove ALL MParticle data from the device, including MParticle UserDefaults and Database, it will also halt any further upload or download behavior that may be prepared
+ 
+ NOTE: This method is less comprehensive than the new `reset:` method. It resets less state and is called within a `dispatch_sync()` which has the potential to deadlock in rare cases.
 
  If you have any reference to the MParticle instance, you must remove your reference by setting it to "nil", in order to avoid any unexpected behavior
  The SDK will be shut down and [MParticle sharedInstance] will return a new instance without apiKey or secretKey. MParticle can be restarted by calling MParticle.startWithOptions
  */
-- (void)reset;
+- (void)reset DEPRECATED_MSG_ATTRIBUTE("replace calls to `reset` with `reset:` and a completion handler");
 
 /**
  This method will permanently remove ALL MParticle data from the device, including MParticle UserDefaults and Database, it will also halt any further upload or download behavior that may be prepared

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -826,12 +826,12 @@ static NSString *const kMPStateKey = @"state";
 }
 
 - (void)reset:(void (^)(void))completion {
-    [MParticle executeOnMessageSync:^{
+    [MParticle executeOnMessage:^{
         [self.kitContainer flushSerializedKits];
         [self.kitContainer removeAllSideloadedKits];
         [[MPIUserDefaults standardUserDefaults] resetDefaults];
         [self.persistenceController resetDatabase];
-        [MParticle executeOnMainSync:^{
+        [MParticle executeOnMain:^{
             [self.backendController unproxyOriginalAppDelegate];
             [MParticle setSharedInstance:nil];
             if (completion) {
@@ -842,7 +842,12 @@ static NSString *const kMPStateKey = @"state";
 }
 
 - (void)reset {
-    [self reset:nil];
+    [MParticle executeOnMessageSync:^{
+        [[MPIUserDefaults standardUserDefaults] resetDefaults];
+        [[MParticle sharedInstance].persistenceController resetDatabase];
+        [[MParticle sharedInstance].backendController unproxyOriginalAppDelegate];
+        [MParticle setSharedInstance:nil];
+    }];
 }
 
 #pragma mark Basic tracking


### PR DESCRIPTION
 ## Summary
 This looks big because of all the test cleanup, but the only real changes are in the `mParticle.m/h` files and are minimal
 
 - Revert old `reset` method to it's original implementation and mark it deprecated
 - Update new `reset:` method to use async dispatch to prevent potential for deadlocks
 - Clean up tests and ensure use of new reset method

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - All tests pass and performed E2E test to confirm workspace switching still works as expected

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6229
