### PR TITLE
ci: Increase timeout on unit test expectations

### DIFF
--- a/UnitTests/MPBackendControllerTests.m
+++ b/UnitTests/MPBackendControllerTests.m
@@ -24,8 +24,6 @@
 #import <CoreLocation/CoreLocation.h>
 #endif
 
-#define BACKEND_TESTS_EXPECTATIONS_TIMEOUT 10
-
 @interface MPMessage ()
 
 @property (nonatomic, strong, readwrite, nonnull) NSData *messageData;
@@ -222,7 +220,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testEndSession {
@@ -282,7 +280,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testAutomaticSessionEnd {
@@ -363,7 +361,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testSessionStartTimestamp {
@@ -719,7 +717,7 @@
         }];
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testDidBecomeActiveWithAppLink {
@@ -1036,7 +1034,7 @@
         XCTAssertEqual(execStatus, MPExecStatusSuccess);
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
     NSDictionary *attributes = [self.backendController userAttributesForUserId:[MPPersistenceController mpId]];
     XCTAssertEqual(attributes.count, 1);
     NSString *value = attributes[@"foo tag 1"];
@@ -1054,7 +1052,7 @@
         XCTAssertEqualObjects(value, [NSNull null]);
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testSetUserAttributeKits {
@@ -1299,7 +1297,7 @@
         XCTAssertEqualObjects(userIdentity[@"n"], @(MPUserIdentityCustomerId));
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testIncrementUserAttribute {
@@ -1322,7 +1320,7 @@
         XCTAssertNil(userAttributeValue);
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testSetLocation {
@@ -1359,7 +1357,7 @@
     
     [expectation fulfill];
     
-    [self waitForExpectationsWithTimeout:BACKEND_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 #endif
 #endif
 }

--- a/UnitTests/MPBaseTestCase.h
+++ b/UnitTests/MPBaseTestCase.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+#define DEFAULT_TIMEOUT 15
+
 @interface MPBaseTestCase : XCTestCase
 
 - (id)attemptSecureEncodingwithClass:(Class)cls Object:(id)object;

--- a/UnitTests/MPForwardQueueItemTests.m
+++ b/UnitTests/MPForwardQueueItemTests.m
@@ -9,8 +9,6 @@
 #import "MPForwardQueueParameters.h"
 #import "MPBaseTestCase.h"
 
-#define FORWARD_QUEUE_ITEM_TESTS_EXPECTATIONS_TIMEOUT 10
-
 #pragma mark
 @interface MPKitMockTest : NSObject <MPKitProtocol>
 
@@ -69,7 +67,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:FORWARD_QUEUE_ITEM_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testEventInstance {
@@ -91,7 +89,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:FORWARD_QUEUE_ITEM_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInvalidInstances {
@@ -133,7 +131,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:FORWARD_QUEUE_ITEM_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 @end

--- a/UnitTests/MPKitAPITests.m
+++ b/UnitTests/MPKitAPITests.m
@@ -92,7 +92,7 @@
         XCTAssertEqualObjects(value, @"Test value");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (nonnull MPKitExecStatus *)didFinishLaunchingWithConfiguration:(nonnull NSDictionary *)configuration {
@@ -193,7 +193,7 @@
         XCTAssertEqualObjects(attributes[@"better data"], @"ABC", @"Kit api is filtering user attributes when it shouldn't");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUserAttributeManuallySet {
@@ -237,7 +237,7 @@
         XCTAssertEqualObjects(attributes[@"better data"], @"ABC", @"Kit api is filtering user attributes when it shouldn't");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 @synthesize started;

--- a/UnitTests/MPKitActivityTests.m
+++ b/UnitTests/MPKitActivityTests.m
@@ -78,7 +78,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testKitAlreadyStarted {

--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -291,7 +291,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testIsDisabledByBracketConfiguration {

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -246,7 +246,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [networkCommunication upload:uploads completionHandler:^{
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadsArrayZipSucceedWithATTNotDetermined {
@@ -417,7 +417,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [networkCommunication upload:uploads completionHandler:^{
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadSuccessDeletion {
@@ -459,7 +459,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
         [mockInstance verify];
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadInvalidDeletion {
@@ -497,7 +497,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [networkCommunication upload:uploads completionHandler:^{
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testRequestConfigWithDefaultMaxAge {

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -18,8 +18,6 @@
 #import "MPStateMachine.h"
 #import "MPKitFilter.h"
 
-#define DATABASE_TESTS_EXPECTATIONS_TIMEOUT 1
-
 @interface MParticle ()
 
 + (dispatch_queue_t)messageQueue;
@@ -70,7 +68,7 @@
         [expectation fulfill];
     });
     workBlock();
-    [self waitForExpectationsWithTimeout:0.11 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testMigrateMessagesWithNullSessions {
@@ -385,7 +383,7 @@
     
     [expectation fulfill];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadWithDataPlan {
@@ -432,7 +430,7 @@
     
     [expectation fulfill];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadWithDataPlanNoVersion {
@@ -478,7 +476,7 @@
     
     [expectation fulfill];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadWithOptOut {
@@ -506,7 +504,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUploadWithOptOutMessage {
@@ -545,7 +543,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testFetchIntegrationAttributesForKit {
@@ -688,7 +686,7 @@
         
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testForwardRecord {

--- a/UnitTests/MPResponseConfigTests.m
+++ b/UnitTests/MPResponseConfigTests.m
@@ -45,7 +45,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testUpdateCustomModuleSettingsOnRestore {
@@ -96,7 +96,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testResponseConfigEncoding {
@@ -132,7 +132,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testShouldDeleteDueToMaxConfigAge {
@@ -157,7 +157,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testDeleteDueToMaxConfigAge {
@@ -186,7 +186,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 

--- a/UnitTests/MPStateMachineTests.m
+++ b/UnitTests/MPStateMachineTests.m
@@ -157,7 +157,7 @@
     
     [stateMachine handleApplicationWillTerminate:nil];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testRamping {
@@ -214,7 +214,7 @@
     });
 
 
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 #endif
 #endif
 }

--- a/UnitTests/MPURLRequestBuilderTests.m
+++ b/UnitTests/MPURLRequestBuilderTests.m
@@ -116,7 +116,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testDisableCollectUserAgent {
@@ -144,7 +144,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testHMACSha256Encode {

--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -185,7 +185,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInstanceWithoutSession {
@@ -259,7 +259,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInstanceWithDataPlanId {
@@ -340,7 +340,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInstanceWithDataPlanVersion {
@@ -422,7 +422,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInstanceWithAdvertiserIdInSessionNoAttStatus {
@@ -502,7 +502,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInstanceWithAdvertiserIdInSessionAuthorizedAttStatus {
@@ -587,7 +587,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInstanceWithAdvertiserIdInSessionDeniedAttStatus {
@@ -672,7 +672,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (MPUploadBuilder *)createTestUploadBuilder {
@@ -761,7 +761,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testNoBatchMutation {
@@ -792,7 +792,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testBatchBlocking {

--- a/UnitTests/MParticleTests.m
+++ b/UnitTests/MParticleTests.m
@@ -1092,6 +1092,11 @@
     [mockBackend verifyWithDelay:5];
 }
 
+#pragma mark Workspace Switching Tests
+
+#define WORKSPACE_SWITCHING_TIMEOUT 60
+#define WORKSPACE_SWITCHING_DELAY (int64_t)(10 * NSEC_PER_SEC)
+
 - (void)testSwitchWorkspaceOptions {
     XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
 
@@ -1099,18 +1104,18 @@
     XCTAssertNotNil(instance);
     XCTAssertNil(instance.options);
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
         MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key1" secret:@"unit-test-secret1"];
         [instance startWithOptions:options1];
         XCTAssertNotNil(instance.options);
         XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
         XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
             MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key2" secret:@"unit-test-secret2"];
             [instance switchWorkspaceWithOptions:options2];
             
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
                 MParticle *instance3 = [MParticle sharedInstance];
                 MParticle *instance4 = [MParticle sharedInstance];
                 XCTAssertNotNil(instance.options);
@@ -1128,7 +1133,7 @@
         });
     });
 
-    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
 }
 
 - (void)testSwitchWorkspaceSideloadedKits {
@@ -1141,7 +1146,7 @@
     
     [[MParticle sharedInstance] startWithOptions:options1];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
         XCTAssertEqual(MPKitContainer.registeredKits.count, 1);
         XCTAssertEqualObjects(MPKitContainer.registeredKits.anyObject.wrapperInstance, kitTestSideloaded1);
        
@@ -1152,7 +1157,7 @@
         
         [[MParticle sharedInstance] switchWorkspaceWithOptions:options2];
         
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
             XCTAssertEqual(MPKitContainer.registeredKits.count, 1);
             XCTAssertEqualObjects(MPKitContainer.registeredKits.anyObject.wrapperInstance, kitTestSideloaded2);
             
@@ -1160,7 +1165,7 @@
             MParticleOptions *options3 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
             [[MParticle sharedInstance] switchWorkspaceWithOptions:options3];
             
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
                 XCTAssertEqual(MPKitContainer.registeredKits.count, 0);
                 
                 [expectation fulfill];
@@ -1168,7 +1173,7 @@
         });
     });
     
-    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:(WORKSPACE_SWITCHING_TIMEOUT) handler:nil];
 }
 
 // Kits without configurations should NOT be removed from the registry even if they implement `stop` becuase it means they weren't used by the previous workspace
@@ -1183,17 +1188,17 @@
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     [[MParticle sharedInstance] startWithOptions:options];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
         XCTAssertEqual(MPKitContainer.registeredKits.count, 2);
         [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
        
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
             XCTAssertEqual(MPKitContainer.registeredKits.count, 2);
             [expectation fulfill];
         });
     });
     
-    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
 }
 
 // Kits with configurations that don't implement `stop` should be removed from the registry because they can't be cleanly restarted
@@ -1207,7 +1212,7 @@
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     [[MParticle sharedInstance] startWithOptions:options];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
         registerNoStop.wrapperInstance = [[MPKitTestClassNoStartImmediately alloc] init];
         [MParticle sharedInstance].kitContainer.kitConfigurations[@42] = [[MPKitConfiguration alloc] init];
         
@@ -1215,13 +1220,13 @@
                 
         [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
        
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
             XCTAssertEqual(MPKitContainer.registeredKits.count, 0);
             [expectation fulfill];
         });
     });
     
-    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
 }
 
 // Kits with configurations that implement `stop` shouldn't be removed from the registry because they can be cleanly restarted
@@ -1235,7 +1240,7 @@
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     [[MParticle sharedInstance] startWithOptions:options];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
         registerWithStop.wrapperInstance = [[MPKitTestClassNoStartImmediatelyWithStop alloc] init];
         [MParticle sharedInstance].kitContainer.kitConfigurations[@43] = [[MPKitConfiguration alloc] init];
         
@@ -1243,13 +1248,13 @@
                 
         [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
        
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
             XCTAssertEqual(MPKitContainer.registeredKits.count, 1);
             [expectation fulfill];
         });
     });
     
-    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
 }
 
 @end

--- a/UnitTests/MParticleTests.m
+++ b/UnitTests/MParticleTests.m
@@ -88,7 +88,7 @@
         XCTAssertEqual(instance3, instance4);
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testOptOut {
@@ -122,7 +122,7 @@
         XCTAssertNotNil(session, "Not Opted Out but nil current session");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testInitStartsSessionSync {
@@ -163,7 +163,7 @@
         XCTAssertNil(session, "No auto tracking but non-nil current session");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testNoAutoTrackingManualSession {
@@ -179,7 +179,7 @@
         XCTAssertNotNil(session, "No auto tracking called begin but nil current session");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testNoAutoTrackingManualEndSession {
@@ -197,7 +197,7 @@
         XCTAssertNil(session, "No auto tracking called begin/end but non-nil current session");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 #if TARGET_OS_IOS == 1
@@ -220,7 +220,7 @@
         XCTAssertNil(session, "Auto tracking but non-nil current session after content-available push");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testEventStartSession {
@@ -240,7 +240,7 @@
         XCTAssertNotNil(session, "Auto tracking but nil current session after an event logged with startSession = YES");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testEventNoStartSession {
@@ -261,7 +261,7 @@
         XCTAssertNil(session, "Auto tracking but non-nil current session after an event logged with startSession = YES");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testEventStartSessionManual {
@@ -281,7 +281,7 @@
         XCTAssertNotNil(session, "No auto tracking but nil current session after an event logged with startSession = YES");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testEventNoStartSessionManual {
@@ -302,7 +302,7 @@
         XCTAssertNil(session, "No auto tracking but non-nil current session after an event logged with startSession = YES");
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 #endif
@@ -320,7 +320,7 @@
         XCTAssertEqual(-6881666186511944082, sessionID.integerValue);
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testOptionsConsentStateInitialNil {
@@ -346,7 +346,7 @@
         XCTAssert(storedConsentState.ccpaConsentState.consented);
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testOptionsConsentStateInitialSet {
@@ -384,7 +384,7 @@
         XCTAssertFalse(storedConsentState.ccpaConsentState.consented);
         [expectation fulfill];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)handleTestSessionStart:(NSNotification *)notification {
@@ -676,7 +676,7 @@
     testNotificationHandler = block;
     MParticle *instance = [MParticle sharedInstance];
     [instance startWithOptions:[MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"]];
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
     testNotificationHandler = nil;
 }
 
@@ -699,7 +699,7 @@
     dispatch_async([MParticle messageQueue], ^{
         [[MParticle sharedInstance].backendController endSession];
     });
-    [self waitForExpectationsWithTimeout:10 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
     testNotificationHandler = nil;
 }
 
@@ -1128,7 +1128,7 @@
         });
     });
 
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 - (void)testSwitchWorkspaceSideloadedKits {
@@ -1168,7 +1168,7 @@
         });
     });
     
-    [self waitForExpectationsWithTimeout:5 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 // Kits without configurations should NOT be removed from the registry even if they implement `stop` becuase it means they weren't used by the previous workspace
@@ -1193,7 +1193,7 @@
         });
     });
     
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 // Kits with configurations that don't implement `stop` should be removed from the registry because they can't be cleanly restarted
@@ -1221,7 +1221,7 @@
         });
     });
     
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 // Kits with configurations that implement `stop` shouldn't be removed from the registry because they can be cleanly restarted
@@ -1249,7 +1249,7 @@
         });
     });
     
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 @end


### PR DESCRIPTION
 ## Summary
 After doing some digging it appears that the errors and other failed tests related to the kit registry were a red herring. What it appears was happening was that on a slow CI runner if one of the tests with chained calls to dispatch_after would time out, it would move on to the next tests but then a few seconds later it would finish which interfered with the data of other tests. The timing was set pretty tight, or rather plenty of time on a fast MacBook Pro, but tight on a slow CI runner. I've increased all timeouts to 15 seconds, which should be more than enough time for all runners to complete.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tests ran fine locally, but they always did... I'll be running them multiple times via this PR to confirm it succeeds every time.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6230
