### PR TITLE
feat: Update Audience Logic

### DIFF
--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -548,25 +548,7 @@
 }
 
 - (void)testAudiences {
-    [MPPersistenceController setMpid:@2];
-    
-    NSDictionary *audienceDictionary = @{@"id":@2,
-                                        @"n":@"External Name 101",
-                                        @"c":@[@{@"ct":@1395014265365,
-                                                 @"a":@"add"
-                                                 },
-                                               @{@"ct":@1395100665367,
-                                                 @"a":@"drop"
-                                                 },
-                                               @{@"ct":@1395187065367,
-                                                 @"a":@"add"
-                                                 }
-                                               ],
-                                        @"s":@[@"aaa", @"bbb", @"ccc"]
-                                        };
-    
-    MPAudience *audience = [[MPAudience alloc] initWithDictionary:audienceDictionary];
-    XCTAssertTrue([audience.name isEqualToString:@"External Name 101"]);
+    MPAudience *audience = [[MPAudience alloc] initWithAudienceId:@2];
     XCTAssertTrue(audience.audienceId.intValue == 2);
 }
 - (void)testFetchIntegrationAttributesForKit {

--- a/mParticle-Apple-SDK/Identity/MPAudience.m
+++ b/mParticle-Apple-SDK/Identity/MPAudience.m
@@ -8,30 +8,17 @@
 #import "MPAudience.h"
 
 // Internal keys
-NSString * const kMPAudienceListKey = @"m";
-NSString * const kMPAudienceIdKey = @"id";
-NSString * const kMPAudienceNameKey = @"n";
-NSString * const kMPAudienceMembershipListKey = @"c";
-NSString * const kMPAudienceMembershipListChangeActionKey = @"a";
-NSString * const kMPAudienceMembershipListChangeActionAddValue = @"add";
-NSString * const kMPAudienceMembershipListChangeActionDropValue = @"drop";
+NSString * const kMPAudienceMembershipKey = @"audience_memberships";
+NSString * const kMPAudienceIdKey = @"audience_id";
 
 @implementation MPAudience
 
-- (instancetype)initWithAudienceId:(NSNumber *)audienceId andName:(NSString *)name {
+- (instancetype)initWithAudienceId:(NSNumber *)audienceId {
     self = [super init];
     if (self) {
         _audienceId = audienceId;
-        _name = name;
     }
     return self;
-}
-
-- (instancetype)initWithDictionary:(NSDictionary *)audienceDictionary {
-    NSNumber *audienceId = audienceDictionary[kMPAudienceIdKey];
-    NSString *audienceName = audienceDictionary[kMPAudienceNameKey];
-
-    return [self initWithAudienceId:audienceId andName:audienceName];
 }
 
 @end

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -449,7 +449,7 @@
 }
 
 #pragma mark - User Segments
-- (void)getUserAudiencesWithCompletionHandler:(void (^)(NSArray<MPAudience *> *currentAudiences, NSArray<MPAudience *> *pastAudiences, NSError * _Nullable error))completionHandler {
+- (void)getUserAudiencesWithCompletionHandler:(void (^)(NSArray<MPAudience *> *currentAudiences, NSError * _Nullable error))completionHandler {
     dispatch_async([MParticle messageQueue], ^{
         [self.backendController fetchAudiencesWithCompletionHandler:completionHandler];
     });

--- a/mParticle-Apple-SDK/Include/MPAudience.h
+++ b/mParticle-Apple-SDK/Include/MPAudience.h
@@ -16,23 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(readonly, strong, nonnull) NSNumber *audienceId;
 
-/**
- The date when this user was first seen by the SDK
- */
-@property(readonly, strong, nonnull) NSString *name;
+- (instancetype)initWithAudienceId:(NSNumber *)audienceId;
 
-- (instancetype)initWithAudienceId:(NSNumber *)audienceId andName:(NSString *)name;
-
-- (instancetype)initWithDictionary:(NSDictionary *)audienceDictionary;
 
 @end
 
-extern NSString * _Nonnull const kMPAudienceListKey;
+extern NSString * _Nonnull const kMPAudienceMembershipKey;
 extern NSString * _Nonnull const kMPAudienceIdKey;
-extern NSString * _Nonnull const kMPAudienceNameKey;
-extern NSString * _Nonnull const kMPAudienceMembershipListKey;
-extern NSString * _Nonnull const kMPAudienceMembershipListChangeActionKey;
-extern NSString * _Nonnull const kMPAudienceMembershipListChangeActionAddValue;
-extern NSString * _Nonnull const kMPAudienceMembershipListChangeActionDropValue;
 
 NS_ASSUME_NONNULL_END

--- a/mParticle-Apple-SDK/Include/MParticleUser.h
+++ b/mParticle-Apple-SDK/Include/MParticleUser.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  Retrieves user audiences from mParticle's servers and returns the result as two arrays of MPAudience objects
  @param completionHandler A block to be called when the results are available.
  */
-- (void)getUserAudiencesWithCompletionHandler:(void (^)(NSArray<MPAudience *> *currentAudiences, NSArray<MPAudience *> *pastAudiences, NSError * _Nullable error))completionHandler;
+- (void)getUserAudiencesWithCompletionHandler:(void (^)(NSArray<MPAudience *> *currentAudiences, NSError * _Nullable error))completionHandler;
 
 #pragma mark - Consent State
 /**

--- a/mParticle-Apple-SDK/MPBackendController.h
+++ b/mParticle-Apple-SDK/MPBackendController.h
@@ -80,7 +80,7 @@ extern const NSInteger kInvalidKey;
 + (BOOL)checkAttribute:(nonnull NSDictionary *)attributesDictionary key:(nonnull NSString *)key value:(nonnull id)value error:(out NSError *__autoreleasing _Nullable * _Nullable)error;
 - (nullable MPEvent *)eventWithName:(nonnull NSString *)eventName;
 + (nullable NSString *)execStatusDescription:(MPExecStatus)execStatus;
-- (MPExecStatus)fetchAudiencesWithCompletionHandler:(void (^ _Nonnull)(NSArray * _Nullable currentAudiences, NSArray * _Nullable pastAudiences, NSError * _Nullable error))completionHandler;
+- (MPExecStatus)fetchAudiencesWithCompletionHandler:(void (^ _Nonnull)(NSArray * _Nullable currentAudiences, NSError * _Nullable error))completionHandler;
 - (nullable NSNumber *)incrementSessionAttribute:(nonnull MPSession *)session key:(nonnull NSString *)key byValue:(nonnull NSNumber *)value;
 - (nullable NSNumber *)incrementUserAttribute:(nonnull NSString *)key byValue:(nonnull NSNumber *)value;
 - (void)leaveBreadcrumb:(nonnull MPEvent *)event completionHandler:(void (^ _Nonnull)(MPEvent * _Nonnull event, MPExecStatus execStatus))completionHandler;

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1068,18 +1068,18 @@ static BOOL skipNextUpload = NO;
     return event;
 }
 
-- (MPExecStatus)fetchAudiencesWithCompletionHandler:(void (^ _Nonnull)(NSArray * _Nullable currentAudiences, NSArray * _Nullable pastAudiences, NSError * _Nullable error))completionHandler {
+- (MPExecStatus)fetchAudiencesWithCompletionHandler:(void (^ _Nonnull)(NSArray * _Nullable currentAudiences, NSError * _Nullable error))completionHandler {
     
     NSAssert(completionHandler != nil, @"completionHandler cannot be nil.");
         
-    [self.networkCommunication requestAudiencesWithCompletionHandler:^(BOOL success, NSArray *currentAudiences, NSArray *pastAudiences, NSError *error) {
+    [self.networkCommunication requestAudiencesWithCompletionHandler:^(BOOL success, NSArray *currentAudiences, NSError *error) {
         if (!error) {
-            MPILogVerbose(@"Audiences Request Succesful: /nCurrent Audiences: %@/nPast Audiences: %@", currentAudiences, pastAudiences);
+            MPILogVerbose(@"Audiences Request Succesful: /nCurrent Audiences: %@", currentAudiences);
         } else {
             MPILogError(@"Audience request failed with error: %@", error)
         }
         
-        completionHandler(currentAudiences, pastAudiences, error);
+        completionHandler(currentAudiences, error);
     }];
     
     return MPExecStatusSuccess;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
@@ -18,7 +18,7 @@ typedef NS_ENUM(NSInteger, MPNetworkError) {
     MPNetworkErrorDelayedSegments
 };
 
-typedef void(^ _Nonnull MPAudienceResponseHandler)(BOOL success, NSArray<MPAudience *> * _Nullable currentAudience, NSArray<MPAudience *> * _Nullable pastAudience, NSError * _Nullable error);
+typedef void(^ _Nonnull MPAudienceResponseHandler)(BOOL success, NSArray<MPAudience *> * _Nullable currentAudience, NSError * _Nullable error);
 typedef void(^ _Nonnull MPUploadsCompletionHandler)(void);
 
 typedef void (^MPIdentityApiManagerCallback)(MPIdentityHTTPBaseSuccessResponse *_Nullable httpResponse, NSError *_Nullable error);

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -565,7 +565,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     NSHTTPURLResponse *httpResponse = response.httpResponse;
     __strong MPNetworkCommunication *strongSelf = weakSelf;
     if (!strongSelf) {
-        completionHandler(NO, nil, nil, nil);
+        completionHandler(NO, nil, nil);
         return;
     }
     
@@ -577,12 +577,11 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     }
     
     if (!data) {
-        completionHandler(NO, nil, nil, nil);
+        completionHandler(NO, nil, nil);
         return;
     }
     
     NSMutableArray<MPAudience *> *currentAudiences = nil;
-    NSMutableArray<MPAudience *> *pastAudiences = nil;
     BOOL success = NO;
     
     NSArray *audiencesList = nil;
@@ -603,24 +602,15 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         }
         
         if (success) {
-            audiencesList = audiencesDictionary[kMPAudienceListKey];
+            audiencesList = audiencesDictionary[kMPAudienceMembershipKey];
         }
         
         if (audiencesList.count > 0) {
             currentAudiences = [[NSMutableArray alloc] init];
-            pastAudiences = [[NSMutableArray alloc] init];
             
             for (NSDictionary *audienceDictionary in audiencesList) {
-                MPAudience *audience = [[MPAudience alloc] initWithDictionary:audienceDictionary];
-                
-                if (audience) {
-                    if ([audienceDictionary[kMPAudienceMembershipListKey][0][kMPAudienceMembershipListChangeActionKey] isEqualToString:kMPAudienceMembershipListChangeActionAddValue]) {
-                        [currentAudiences addObject:audience];
-                    }
-                    if ([audienceDictionary[kMPAudienceMembershipListKey][0][kMPAudienceMembershipListChangeActionKey] isEqualToString:kMPAudienceMembershipListChangeActionDropValue]) {
-                        [pastAudiences addObject:audience];
-                    }
-                }
+                MPAudience *audience = [[MPAudience alloc] initWithAudienceId:audienceDictionary[kMPAudienceIdKey]];
+                [currentAudiences addObject:audience];
             }
             
             MPILogVerbose(@"Audiences Response Code: %ld", (long)responseCode);
@@ -633,9 +623,6 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         currentAudiences = nil;
     }
     
-    if (pastAudiences.count == 0) {
-        pastAudiences = nil;
-    }
     NSError *audienceError = nil;
 
     if (responseCode == HTTPStatusCodeForbidden) {
@@ -644,7 +631,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
                                        userInfo:@{@"message":@"Audiences not enabled for this org."}];
     }
     
-    completionHandler(success, currentAudiences, pastAudiences, audienceError);
+    completionHandler(success, currentAudiences, audienceError);
 }
 
 - (BOOL)performMessageUpload:(MPUpload *)upload {


### PR DESCRIPTION
## Summary
 - Add methods to the public API to retrieve audience IDs associated with the current user

 ## Testing Plan
 - Tested locally with hard coded data.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6150
