### PR TITLE
fix: Type hinting MPIdentityApiRequest.identities

### DIFF
--- a/UnitTests/MPIdentityApiRequestTests.m
+++ b/UnitTests/MPIdentityApiRequestTests.m
@@ -6,6 +6,10 @@
 
 @end
 
+@interface MPIdentityApiRequest ()
+@property (nonatomic) NSMutableDictionary<NSNumber*, NSObject*> *mutableIdentities;
+@end
+
 @implementation MPIdentityApiRequestTests
 
 - (void)testSetNilIdentity {
@@ -24,7 +28,7 @@
     XCTAssertEqualObjects([NSNull null], [request.identities objectForKey:@(MPIdentityOther)]);
 }
 
-- (void)testsetIdentity {
+- (void)testSetIdentity {
     MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
     [request setIdentity:@"foo" identityType:MPIdentityOther];
     XCTAssertEqualObjects(@"foo", [request.identities objectForKey:@(MPIdentityOther)]);
@@ -47,6 +51,30 @@
     request.email = nil;
     XCTAssertNotEqualObjects(request.email, [NSNull null]);
     XCTAssertNotEqualObjects(request.customerId, [NSNull null]);
+}
+
+- (void)testSetEmail {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    XCTAssertNil(request.email);
+    request.email = @"test@test.com";
+    XCTAssertEqualObjects(@"test@test.com", request.email);
+    XCTAssertEqualObjects(@"test@test.com", request.mutableIdentities[@(MPIdentityEmail)]);
+    
+    request.email = nil;
+    XCTAssertNil(request.email);
+    XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityEmail)], [NSNull null]);
+}
+
+- (void)testSetCustomerId {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    XCTAssertNil(request.customerId);
+    request.customerId = @"some id";
+    XCTAssertEqualObjects(@"some id", request.customerId);
+    XCTAssertEqualObjects(@"some id", request.mutableIdentities[@(MPIdentityCustomerId)]);
+    
+    request.customerId = nil;
+    XCTAssertNil(request.customerId);
+    XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityCustomerId)], [NSNull null]);
 }
 
 @end

--- a/UnitTests/MPSwiftTests.swift
+++ b/UnitTests/MPSwiftTests.swift
@@ -64,4 +64,19 @@ class mParticle_Swift_SDKTests: XCTestCase {
         XCTAssertNotNil(MPIdentityErrorResponseCode(rawValue: 500))
         XCTAssertNotNil(MPIdentityErrorResponseCode(rawValue: 502))
     }
+    
+    func testMPIdentityApiRequestIdentitiesInterop() {
+        let request = MPIdentityApiRequest()
+        request.setIdentity("test id", identityType: .customerId)
+        request.setIdentity("test@test.com", identityType: .email)
+                
+        var identities = [NSNumber: NSObject]()
+        identities[NSNumber(value: MPIdentity.customerId.rawValue)] = NSString(string: "test id")
+        identities[NSNumber(value: MPIdentity.email.rawValue)] = NSString(string: "test@test.com")
+        XCTAssertEqual(identities, request.identities);
+        
+        request.email = nil
+        identities[NSNumber(value: MPIdentity.email.rawValue)] = NSNull()
+        XCTAssertEqual(identities, request.identities);
+    }
 }

--- a/mParticle-Apple-SDK/Identity/FilteredMPIdentityApiRequest.m
+++ b/mParticle-Apple-SDK/Identity/FilteredMPIdentityApiRequest.m
@@ -37,7 +37,7 @@
 }
 
 - (NSDictionary<NSNumber *,NSString *> *)userIdentities {
-    NSDictionary<NSNumber *, NSString *> *unfilteredUserIdentities = self.request.identities;
+    NSDictionary<NSNumber *, NSObject *> *unfilteredUserIdentities = self.request.identities;
     NSMutableDictionary *filteredUserIdentities = [NSMutableDictionary dictionary];
     
     for (NSNumber* key in unfilteredUserIdentities) {

--- a/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
@@ -11,7 +11,7 @@
 #import "MPIdentityDTO.h"
 
 @interface MPIdentityApiRequest ()
-@property (nonatomic) NSMutableDictionary<NSNumber*, NSString*> *mutableIdentities;
+@property (nonatomic) NSMutableDictionary<NSNumber*, NSObject*> *mutableIdentities;
 @end
 
 @implementation MPIdentityApiRequest
@@ -50,11 +50,11 @@
 }
 
 - (NSString *)email {
-    NSString *result = _mutableIdentities[@(MPIdentityEmail)];
-    if ([result isEqual:[NSNull null]]) {
-        result = nil;
+    NSObject *result = _mutableIdentities[@(MPIdentityEmail)];
+    if ([result isKindOfClass:[NSString class]]) {
+        return (NSString *)result;
     }
-    return result;
+    return nil;
 }
 
 - (void)setEmail:(NSString *)email {
@@ -62,18 +62,18 @@
 }
 
 - (NSString *)customerId {
-    NSString *result = _mutableIdentities[@(MPIdentityCustomerId)];
-    if ([result isEqual:[NSNull null]]) {
-        result = nil;
+    NSObject *result = _mutableIdentities[@(MPIdentityCustomerId)];
+    if ([result isKindOfClass:[NSString class]]) {
+        return (NSString *)result;
     }
-    return result;
+    return nil;
 }
 
 - (void)setCustomerId:(NSString *)customerId {
     [self setIdentity:customerId identityType:MPIdentityCustomerId];
 }
 
-- (NSDictionary<NSNumber*, NSString*> *)identities {
+- (NSDictionary<NSNumber*, NSObject*> *)identities {
     return [_mutableIdentities copy];
 }
 

--- a/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
+++ b/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSString *email;
 @property (nonatomic, strong, nullable) NSString *customerId;
-@property (nonatomic, strong, nullable, readonly) NSDictionary<NSNumber*, NSString*> *identities;
+@property (nonatomic, strong, nullable, readonly) NSDictionary<NSNumber*, NSObject*> *identities;
 
 @end
 


### PR DESCRIPTION
 ## Summary
 Fix crash when accessing the `-[MPIdentityApiRequest identity]` property from Swift due to incorrect type hinting

 We had it hinted as `<NSNumber*, NSString*>` but then we also stored `NSNull` objects in some cases. That was fine with Objective-C since it ignores the type hints at runtime, but Swift doesn't and crashes if any NSNull objects are present when accessing the `identities` property.

 Note this doesn't actually change the underlying behavior of this property in any way, it just now is correctly type hinted as `<NSNumber*, NSObject*>` to include the possibility of `NSNull`.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - First reproduced the crash, then confirmed that I can now access the property from Swift without crashing. Also added unit tests to confirm both the core behavior and the Swift interop, explicitly accessing the property from Swift when it contains an NSNull object.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6338
