### PR TITLE
Update mParticle-Apple-SDK.podspec for privacy manifest

### DIFF
--- a/mParticle-Apple-SDK.podspec
+++ b/mParticle-Apple-SDK.podspec
@@ -32,12 +32,14 @@ Pod::Spec.new do |s|
         ss.public_header_files = 'mParticle-Apple-SDK/Include/*.h'
         ss.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         ss.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp,swift}'
+        ss.resource_bundles = {'mParticle-Privacy' => ['PrivacyInfo.xcprivacy']}
     end
     
     s.subspec 'mParticleNoLocation' do |ss|
         ss.public_header_files = 'mParticle-Apple-SDK/Include/*.h'
         ss.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         ss.source_files         = 'mParticle-Apple-SDK/**/*.{h,m,mm,cpp,swift}'
+        ss.resource_bundles = {'mParticle-Privacy' => ['PrivacyInfo.xcprivacy']}
         ss.pod_target_xcconfig  = {
             'GCC_PREPROCESSOR_DEFINITIONS' => 'MPARTICLE_LOCATION_DISABLE=1',
             'OTHER_SWIFT_FLAGS' => '-D MPARTICLE_LOCATION_DISABLE'


### PR DESCRIPTION
 ## Summary
 - Update with suggestion from this [issue](https://github.com/mParticle/mparticle-apple-sdk/issues/269) to ensure that cocaopods users are correctly receiving the privacy manifest.

 ## Testing Plan
 - unit tests ran and pod lib lint

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://github.com/mParticle/mparticle-apple-sdk/issues/269
