### PR TITLE
feat: Add max persistence age override option

### DIFF
--- a/UnitTests/MPBaseTestCase.m
+++ b/UnitTests/MPBaseTestCase.m
@@ -12,6 +12,10 @@
 #import "MPConnectorProtocol.h"
 #import "MPConnectorFactoryProtocol.h"
 
+@interface MParticle (Tests)
+@property (nonatomic, strong) MPPersistenceController *persistenceController;
+@end
+
 @interface MPTestConnectorFactory : NSObject <MPConnectorFactoryProtocol>
 
 @property (nonatomic) NSMutableArray *mockConnectors;
@@ -32,7 +36,13 @@
 
 - (void)setUpWithCompletionHandler:(void (^)(NSError * _Nullable))completion {
     [super setUp];
-    [[MParticle sharedInstance] reset:^{
+    MParticle *instance = [MParticle sharedInstance];
+    if (!instance.persistenceController) {
+        // Ensure we have a persistence controller to reset the db etc
+        instance.persistenceController = [[MPPersistenceController alloc] init];
+    }
+    
+    [instance reset:^{
         MPNetworkCommunication.connectorFactory = [[MPTestConnectorFactory alloc] init];
         completion(nil);
     }];

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -386,6 +386,19 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 @property (nonatomic, strong, readwrite, nullable) NSNumber *configMaxAgeSeconds;
 
 /**
+ Set a maximum threshold for stored events, batches, and sessions, in seconds.
+ 
+ By default, data is persisted for 90 days before being deleted to minimize data loss, however
+ this can lead to excessive storage usage on some users' devices. This is exacerbated if you log
+ a large number of events, or events with a lot of data (attributes, etc).
+ 
+ You can set this to any value greater than 0 seconds, so if you have storage usage concerns, set a lower
+ value such as 48 hours or 1 week. Or alternatively, if you have data loss concerns, you can set this to an even
+ longer value than the default.
+ */
+@property (nonatomic, strong, nullable) NSNumber *persistenceMaxAgeSeconds;
+
+/**
  Set an array of instances of kit (MPKitProtocol wrapped in MPSideloadedKit) objects to be "sideloaded".
  
  The difference between these kits and mParticle UI enabled kits is that they do not receive a server side configuration and are always activated.
@@ -606,6 +619,12 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  @see MParticleOptions
  */
 @property (nonatomic, readonly, nullable) NSNumber *configMaxAgeSeconds;
+
+/**
+ Maximum threshold for stored events, batches, and sessions, in seconds.
+ @see MParticleOptions
+ */
+@property (nonatomic, readonly, nullable) NSNumber *persistenceMaxAgeSeconds;
 
 #pragma mark - Initialization
 

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1317,12 +1317,6 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)logBaseEvent:(MPBaseEvent *)event completionHandler:(void (^)(MPBaseEvent *event, MPExecStatus execStatus))completionHandler {
-    if (![MPStateMachine canWriteMessagesToDB]) {
-        MPILogError(@"Not saving message for event to prevent excessive local database growth because API Key appears to be invalid based on server response");
-        completionHandler(event, MPExecStatusFail);
-        return;
-    }
-    
     [MPListenerController.sharedInstance onAPICalled:_cmd parameter1:event];
     
     if (event.shouldBeginSession) {
@@ -1578,11 +1572,6 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)saveMessage:(MPMessage *)message updateSession:(BOOL)updateSession {
-    if (![MPStateMachine canWriteMessagesToDB]) {
-        MPILogError(@"Not saving message for event to prevent excessive local database growth because API Key appears to be invalid based on server response");
-        return;
-    }
-    
     NSTimeInterval lastEventTimestamp = message.timestamp ?: [[NSDate date] timeIntervalSince1970];
     if (MPStateMachine.runningInBackground) {
         self.timeOfLastEventInBackground = lastEventTimestamp;

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -2089,9 +2089,15 @@ static BOOL skipNextUpload = NO;
 
 - (void)cleanUp {
     NSTimeInterval currentTime = [[NSDate date] timeIntervalSince1970];
+    [self cleanUp:currentTime];
+}
+
+- (void)cleanUp:(NSTimeInterval)currentTime {
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     if (nextCleanUpTime < currentTime) {
-        [persistence deleteRecordsOlderThan:(currentTime - NINETY_DAYS)];
+        NSNumber *persistanceMaxAgeSeconds = [MParticle sharedInstance].persistenceMaxAgeSeconds;
+        NSTimeInterval maxAgeSeconds = persistanceMaxAgeSeconds ? persistanceMaxAgeSeconds.doubleValue : NINETY_DAYS;
+        [persistence deleteRecordsOlderThan:(currentTime - maxAgeSeconds)];
         nextCleanUpTime = currentTime + TWENTY_FOUR_HOURS;
     }
     [persistence purgeMemory];

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -2085,7 +2085,7 @@ static BOOL skipNextUpload = NO;
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     if (nextCleanUpTime < currentTime) {
         NSNumber *persistanceMaxAgeSeconds = [MParticle sharedInstance].persistenceMaxAgeSeconds;
-        NSTimeInterval maxAgeSeconds = persistanceMaxAgeSeconds ? persistanceMaxAgeSeconds.doubleValue : NINETY_DAYS;
+        NSTimeInterval maxAgeSeconds = persistanceMaxAgeSeconds == nil ? NINETY_DAYS : persistanceMaxAgeSeconds.doubleValue;
         [persistence deleteRecordsOlderThan:(currentTime - maxAgeSeconds)];
         nextCleanUpTime = currentTime + TWENTY_FOUR_HOURS;
     }

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -403,15 +403,6 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     return maxAge;
 }
 
-- (void)checkResponseCodeToDisableEventLogging:(NSInteger)responseCode {
-    if (responseCode == HTTPStatusCodeBadRequest || responseCode == HTTPStatusCodeUnauthorized || responseCode == HTTPStatusCodeForbidden) {
-        [MPStateMachine setCanWriteMessagesToDB:NO];
-        MPILogError(@"API Key appears to be invalid based on server response, disabling event logging to prevent excessive local database growth");
-    } else {
-        [MPStateMachine setCanWriteMessagesToDB:YES];
-    }
-}
-
 #pragma mark Public methods
 - (NSObject<MPConnectorProtocol> *_Nonnull)makeConnector {
     if (MPNetworkCommunication.connectorFactory) {
@@ -463,9 +454,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     
     NSInteger responseCode = [httpResponse statusCode];
     MPILogVerbose(@"Config Response Code: %ld, Execution Time: %.2fms", (long)responseCode, ([[NSDate date] timeIntervalSince1970] - start) * 1000.0);
-    
-    [self checkResponseCodeToDisableEventLogging:responseCode];
-    
+        
     if (responseCode == HTTPStatusCodeNotModified) {
         MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
         [userDefaults setConfiguration:[userDefaults getConfiguration] eTag:userDefaults[kMPHTTPETagHeaderKey] requestTimestamp:[[NSDate date] timeIntervalSince1970] currentAge:ageString maxAge:maxAge];
@@ -875,9 +864,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         
         
         MPILogVerbose(@"Identity response code: %ld", (long)responseCode);
-        
-        [self checkResponseCodeToDisableEventLogging:[httpResponse statusCode]];
-        
+                
         if (success) {
             @try {
                 NSError *serializationError = nil;

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -1557,10 +1557,6 @@ const int MaxBreadcrumbs = 50;
 }
 
 - (void)saveMessage:(MPMessage *)message {
-    if (![MPStateMachine canWriteMessagesToDB]) {
-        MPILogError(@"Not saving message for event to prevent excessive local database growth because API Key appears to be invalid based on server response");
-        return;
-    }
     if (!message.shouldUploadEvent) {
         MPILogDebug(@"Not saving message for event because shouldUploadEvent was set to NO, message id: %lld, type: %@", message.messageId, message.messageType);
         return;

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -66,8 +66,6 @@
 + (BOOL)runningInBackground;
 + (void)setRunningInBackground:(BOOL)background;
 + (BOOL)isAppExtension;
-+ (BOOL)canWriteMessagesToDB;
-+ (void)setCanWriteMessagesToDB:(BOOL)canWriteMessagesToDB;
 - (void)configureCustomModules:(nullable NSArray<NSDictionary *> *)customModuleSettings;
 - (void)configureRampPercentage:(nullable NSNumber *)rampPercentage;
 - (void)configureTriggers:(nullable NSDictionary *)triggerDictionary;

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.m
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.m
@@ -33,7 +33,6 @@ static NSString *const kMPStateKey = @"state";
 
 static MPEnvironment runningEnvironment = MPEnvironmentAutoDetect;
 static BOOL runningInBackground = NO;
-static BOOL _canWriteMessagesToDB = YES;
 
 @interface MParticle ()
 + (dispatch_queue_t)messageQueue;
@@ -346,18 +345,6 @@ static BOOL _canWriteMessagesToDB = YES;
 #else
     return NO;
 #endif
-}
-
-+ (BOOL)canWriteMessagesToDB {
-    @synchronized(self) {
-        return _canWriteMessagesToDB;
-    }
-}
-
-+ (void)setCanWriteMessagesToDB:(BOOL)canWriteMessagesToDB {
-    @synchronized(self) {
-        _canWriteMessagesToDB = canWriteMessagesToDB;
-    }
 }
 
 #pragma mark Public accessors

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -258,6 +258,14 @@ static NSString *const kMPStateKey = @"state";
     }
 }
 
+- (void)setPersistenceMaxAgeSeconds:(NSNumber *)persistenceMaxAgeSeconds {
+    if (persistenceMaxAgeSeconds != nil && [persistenceMaxAgeSeconds doubleValue] <= 0) {
+        MPILogWarning(@"Persistence Max Age must be a positive number, disregarding value.");
+    } else {
+        _persistenceMaxAgeSeconds = persistenceMaxAgeSeconds;
+    }
+}
+
 @end
 
 @interface MPBackendController ()
@@ -489,6 +497,10 @@ static NSString *const kMPStateKey = @"state";
 
 - (NSNumber *)configMaxAgeSeconds {
     return self.options.configMaxAgeSeconds;
+}
+
+- (NSNumber *)persistenceMaxAgeSeconds {
+    return self.options.persistenceMaxAgeSeconds;
 }
 
 #pragma mark Initialization


### PR DESCRIPTION
 ## Summary
 To prevent excessive database size for customers that do a lot of event logging, it's now possible to set a max persistence age for batches/sessions/uploads. This was already happening, but it defaulted to 90 days. Depending on the amount of events logged and whether a user blocks mParticle uploads or has poor internet connectivity, that could be way too long. Also, some customers may not be interested in events that happened so long ago.

With the new `persistenceMaxAgeSeconds` property in `MParticleOptions`, it's now possible to override that with any positive value.

Also, I reverted an older change that would attempt to detect when API keys were no longer valid to prevent excessive database growth because may cause false positives. For customers that are concerned about this, they can set a lower persistence max age.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - I added unit tests to confirm that the persistence deletion mechanism was actually working (it was), as well as tests to confirm setting a max age works (it does). I also smoke tested in a test app.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6209
