### PR TITLE
fix: Forwarding ATT status to kits

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -2302,6 +2302,10 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                 } else if (selector == @selector(shouldDelayMParticleUpload)) {
                     [kitRegister.wrapperInstance shouldDelayMParticleUpload];
                     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code returnCode:MPKitReturnCodeSuccess];
+                } else if (selector == @selector(setATTStatus:withATTStatusTimestampMillis:)) {
+                    MPATTAuthorizationStatus status = (MPATTAuthorizationStatus)[parameters[0] unsignedIntValue];
+                    NSNumber *timestamp = [parameters[1] isKindOfClass:[NSNumber class]] ? (NSNumber*)parameters[1] : nil;
+                    execStatus = [kitRegister.wrapperInstance setATTStatus:status withATTStatusTimestampMillis:timestamp];
                 } else if (parameters.count == 3) {
                     typedef MPKitExecStatus *(*send_type)(id, SEL, id, id, id);
                     send_type func = (send_type)objc_msgSend;

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -1119,6 +1119,19 @@ static NSString *const kMPStateKey = @"state";
             [MParticle sharedInstance].stateMachine.attAuthorizationTimestamp = attStatusTimestampMillis;
         }
     }
+    
+    // Forward to kits
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSNumber *parameter0 = @(status);
+        NSObject *parameter1 = attStatusTimestampMillis ?: [NSNull null];
+        MPForwardQueueParameters *parameters = [[MPForwardQueueParameters alloc] initWithParameters:@[parameter0, parameter1]];
+        [[MParticle sharedInstance].kitContainer forwardSDKCall:@selector(setATTStatus:withATTStatusTimestampMillis:)
+                                                          event:nil
+                                                     parameters:parameters
+                                                    messageType:MPMessageTypeUnknown
+                                                       userInfo:nil
+         ];
+    });
 }
 
 #pragma mark Attribution


### PR DESCRIPTION
 ## Summary
 - We already had an optional protocol method for this but weren't actually forwarding when set on mParticle object. This adds that forwarding as it's necessary for the latest Braze SDK update and iOS 17 app tracking stuff.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - E2E tested to see that the kit correctly received the status, tested with both an NSNumber and nil for the timestamp.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6409
