### PR TITLE
fix: Remove unnecessary badge number functionality

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPApplication.h
+++ b/mParticle-Apple-SDK/Utils/MPApplication.h
@@ -24,16 +24,11 @@ extern NSString * _Nonnull const kMPApplicationInformationKey;
 @property (nonatomic, strong, readonly, nullable) NSString *version __attribute__((const));
 @property (nonatomic, readonly) MPEnvironment environment __attribute__((const));
 
-#if TARGET_OS_IOS == 1
-@property (nonatomic, strong, readonly, nullable) NSNumber *badgeNumber;
-#endif
-
 + (nullable NSString *)appStoreReceipt;
 + (void)markInitialLaunchTime;
 + (void)updateLastUseDate:(nonnull NSDate *)date;
 + (void)updateLaunchCountsAndDates;
 + (void)updateStoredVersionAndBuildNumbers;
-+ (void)updateBadgeNumber;
 + (nonnull NSDictionary *)appImageInfo;
 + (nullable UIApplication *)sharedUIApplication;
 - (nonnull NSDictionary<NSString *, id> *)dictionaryRepresentation;

--- a/mParticle-Apple-SDK/Utils/MPApplication.m
+++ b/mParticle-Apple-SDK/Utils/MPApplication.m
@@ -28,7 +28,6 @@ NSString *const kMPAppLastUseDateKey = @"lud";
 NSString *const kMPAppStoredVersionKey = @"asv";
 NSString *const kMPAppStoredBuildKey = @"asb";
 NSString *const kMPAppEnvironmentKey = @"env";
-NSString *const kMPAppBadgeNumberKey = @"bn";
 NSString *const kMPAppStoreReceiptKey = @"asr";
 NSString *const kMPAppImageBaseAddressKey = @"iba";
 NSString *const kMPAppImageSizeKey = @"is";
@@ -68,10 +67,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 @interface MParticle ()
 
 @property (nonatomic, strong, readonly) MPStateMachine *stateMachine;
-
-#if TARGET_OS_IOS == 1
-@property (nonatomic, strong, readwrite, nullable) NSNumber *badgeNumber;
-#endif
 
 @end
 
@@ -298,24 +293,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     return nil;
 }
 
-#if TARGET_OS_IOS == 1
-- (NSNumber *)badgeNumber {
-    if (![MPStateMachine isAppExtension]) {
-        MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
-        NSNumber *badgeNumber = userDefaults[kMPAppBadgeNumberKey];
-        return badgeNumber.integerValue != 0 ? badgeNumber : nil;
-    }
-    return nil;
-}
-
-- (void)setBadgeNumber:(NSNumber * _Nullable)badgeNumber {
-    if (![MPStateMachine isAppExtension]) {
-        MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
-        userDefaults[kMPAppBadgeNumberKey] = badgeNumber;
-    }
-}
-#endif
-
 - (NSDictionary *)searchAdsAttribution {
     return MParticle.sharedInstance.stateMachine.searchAdsInfo;
 }
@@ -384,20 +361,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     MPApplication *application = [[MPApplication alloc] init];
     application.storedVersion = application.version;
     application.storedBuild = application.build;
-}
-
-+ (void)updateBadgeNumber {
-#if TARGET_OS_IOS == 1
-    if ([NSThread isMainThread]) {
-        MPApplication *application = [[MPApplication alloc] init];
-        application.badgeNumber = @([MPApplication sharedUIApplication].applicationIconBadgeNumber);
-    } else {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            MPApplication *application = [[MPApplication alloc] init];
-            application.badgeNumber = @([MPApplication sharedUIApplication].applicationIconBadgeNumber);
-        });
-    }
-#endif
 }
 
 + (NSDictionary *)appImageInfo {
@@ -509,13 +472,6 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
     if ([MParticle sharedInstance].stateMachine.allowASR && [MPApplication appStoreReceipt]) {
         applicationInfo[kMPAppStoreReceiptKey] = [MPApplication appStoreReceipt];
     }
-    
-#if TARGET_OS_IOS == 1
-    NSNumber *badgeNumber = self.badgeNumber;
-    if (badgeNumber != nil) {
-        applicationInfo[kMPAppBadgeNumberKey] = badgeNumber;
-    }
-#endif
     
     appInfo = (NSDictionary *)applicationInfo;
     

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.m
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.m
@@ -137,7 +137,6 @@ static BOOL runningInBackground = NO;
             
             [MPApplication markInitialLaunchTime];
             [MPApplication updateLaunchCountsAndDates];
-            [MPApplication updateBadgeNumber];
         });
     }
     
@@ -260,12 +259,11 @@ static BOOL runningInBackground = NO;
 - (void)handleApplicationDidEnterBackground:(NSNotification *)notification {
     [MPApplication updateLastUseDate:_launchDate];
     _backgrounded = YES;
-
+    
     __weak MPStateMachine *weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong MPStateMachine *strongSelf = weakSelf;
         strongSelf.launchInfo = nil;
-        [MPApplication updateBadgeNumber];
     });
 }
 
@@ -275,7 +273,6 @@ static BOOL runningInBackground = NO;
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong MPStateMachine *strongSelf = weakSelf;
         strongSelf->_backgrounded = NO;
-        [MPApplication updateBadgeNumber];
     });
 }
 


### PR DESCRIPTION
 ## Summary
 We received a report of freezing causing due to retrieving the badge number count. While this appears to be an Apple bug, we not longer have any need for that information, so we've removed it entirely to prevent the potential freeze.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Performed SDK smoke test using a test app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6416
