### PR TITLE
fix: Remove deprecated iAd framework

### DIFF
--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -25,7 +25,9 @@
 #import "MPKitContainer.h"
 #import "MPUserAttributeChange.h"
 #import "MPUserIdentityChange.h"
+#if TARGET_OS_IOS == 1
 #import "MPSearchAdsAttribution.h"
+#endif
 #import "MPURLRequestBuilder.h"
 #import "MPArchivist.h"
 #import "MPListenerController.h"
@@ -1554,12 +1556,16 @@ static BOOL skipNextUpload = NO;
             });
         };
         
+#if TARGET_OS_IOS == 1
         if (MParticle.sharedInstance.collectSearchAdsAttribution) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SEARCH_ADS_ATTRIBUTION_GLOBAL_TIMEOUT_SECONDS * NSEC_PER_SEC)), [MParticle messageQueue], searchAdsCompletion);
             [stateMachine.searchAttribution requestAttributionDetailsWithBlock:searchAdsCompletion requestsCompleted:0];
         } else {
             searchAdsCompletion();
         }
+#else
+        searchAdsCompletion();
+#endif
         
         [self processPendingArchivedMessages];
         

--- a/mParticle-Apple-SDK/Utils/MPApplication.m
+++ b/mParticle-Apple-SDK/Utils/MPApplication.m
@@ -6,7 +6,6 @@
 #import "MPIUserDefaults.h"
 #import <UIKit/UIKit.h>
 #import "MPStateMachine.h"
-#import "MPSearchAdsAttribution.h"
 #import <libkern/OSAtomic.h>
 #import "mParticle.h"
 

--- a/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.h
+++ b/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.h
@@ -1,7 +1,9 @@
 #import <Foundation/Foundation.h>
 
+#if TARGET_OS_IOS == 1
 @interface MPSearchAdsAttribution : NSObject
 
 - (void)requestAttributionDetailsWithBlock:(void (^ _Nonnull)(void))completionHandler requestsCompleted:(int)requestsCompleted;
 
 @end
+#endif

--- a/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
+++ b/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
@@ -5,7 +5,6 @@
 #import "MPILogger.h"
 
 #if TARGET_OS_IOS == 1
-#import <iAd/ADClient.h>
 #import <AdServices/AAAttribution.h>
 #endif
 
@@ -21,24 +20,11 @@
 - (void)requestAttributionDetailsWithBlock:(void (^ _Nonnull)(void))completionHandler requestsCompleted:(int)requestsCompleted {
     NSError *error;
     if (@available(iOS 14.3, *)) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        Class MPClientClass = NSClassFromString(@"AAAttribution");
-        if (!MPClientClass) {
-            completionHandler();
-            return;
-        }
-        SEL attributionTokenSelector = NSSelectorFromString(@"attributionTokenWithError:");
-        if (![MPClientClass respondsToSelector:attributionTokenSelector]) {
-            completionHandler();
-            return;
-        }
-        NSString *attributionToken = [MPClientClass performSelector:attributionTokenSelector withObject:error];
+        NSString *attributionToken = [AAAttribution attributionTokenWithError:&error];
         if (!attributionToken) {
             completionHandler();
             return;
         }
-#pragma clang diagnostic pop
         
         if (attributionToken) {
             NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://api-adservices.apple.com/api/v1/"]];
@@ -88,61 +74,6 @@
                 }];
             });
         }
-    } else {
-#if TARGET_OS_IOS == 1 && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_3
-        if (![MPStateMachine isAppExtension]) {
-            Class MPClientClass = NSClassFromString(@"ADClient");
-            if (!MPClientClass) {
-                completionHandler();
-                return;
-            }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-            SEL sharedClientSelector = NSSelectorFromString(@"sharedClient");
-            if (![MPClientClass respondsToSelector:sharedClientSelector]) {
-                completionHandler();
-                return;
-            }
-            
-            id MPClientSharedInstance = [MPClientClass performSelector:sharedClientSelector];
-            if (!MPClientSharedInstance) {
-                completionHandler();
-                return;
-            }
-            
-            SEL requestDetailsSelector = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
-            if (![MPClientSharedInstance respondsToSelector:requestDetailsSelector]) {
-                completionHandler();
-                return;
-            }
-            
-            [MPClientSharedInstance performSelector:requestDetailsSelector withObject:^(NSDictionary *attributionDetails, NSError *error) {
-                dispatch_async([MParticle messageQueue], ^{
-                    
-                    if (attributionDetails && !error) {
-                        [MParticle sharedInstance].stateMachine.searchAdsInfo = [[attributionDetails mutableCopy] copy];
-                        completionHandler();
-                    }
-                    else if (error.code == 1 /* ADClientErrorLimitAdTracking */) {
-                        completionHandler();
-                    }
-                    else if ((requestsCompleted + 1) > SEARCH_ADS_ATTRIBUTION_MAX_RETRIES) {
-                        completionHandler();
-                    } else {
-                        // Per Apple docs, "Handle any errors you receive and re-poll for data, if required"
-                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SEARCH_ADS_ATTRIBUTION_DELAY_BEFORE_RETRY * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                            [self requestAttributionDetailsWithBlock:completionHandler requestsCompleted:(requestsCompleted + 1)];
-                        });
-                    }
-                });
-            }];
-#pragma clang diagnostic pop
-        } else {
-            completionHandler();
-        }
-#else
-        completionHandler();
-#endif
     }
 }
 

--- a/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
+++ b/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
@@ -17,7 +17,6 @@
 
 @implementation MPSearchAdsAttribution 
 
-
 - (void)requestAttributionDetailsWithBlock:(void (^ _Nonnull)(void))completionHandler requestsCompleted:(int)requestsCompleted {
     NSError *error;
     if (@available(iOS 14.3, *)) {

--- a/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
+++ b/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
@@ -1,12 +1,12 @@
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IOS == 1
 #import "MPSearchAdsAttribution.h"
 #import "mParticle.h"
 #import "MPStateMachine.h"
 #import "MPIConstants.h"
 #import "MPILogger.h"
-
-#if TARGET_OS_IOS == 1
 #import <AdServices/AAAttribution.h>
-#endif
 
 @interface MParticle ()
 
@@ -16,6 +16,7 @@
 @end
 
 @implementation MPSearchAdsAttribution 
+
 
 - (void)requestAttributionDetailsWithBlock:(void (^ _Nonnull)(void))completionHandler requestsCompleted:(int)requestsCompleted {
     NSError *error;
@@ -78,3 +79,4 @@
 }
 
 @end
+#endif

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -52,7 +52,9 @@
 @property (nonatomic) NSNumber * _Nullable attAuthorizationStatus;
 @property (nonatomic) NSNumber * _Nullable attAuthorizationTimestamp;
 @property (nonatomic, strong, nonnull) NSNumber *aliasMaxWindow;
+#if TARGET_OS_IOS == 1
 @property (nonatomic, strong, nonnull) MPSearchAdsAttribution *searchAttribution;
+#endif
 @property (nonatomic, strong, nonnull) NSDictionary *searchAdsInfo;
 @property (nonatomic) BOOL automaticSessionTracking;
 @property (nonatomic) BOOL allowASR;

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.m
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.m
@@ -14,7 +14,9 @@
 #import "MPLocationManager.h"
 #endif
 #import "MPKitContainer.h"
+#if TARGET_OS_IOS == 1
 #import "MPSearchAdsAttribution.h"
+#endif
 #import <UIKit/UIKit.h>
 #import "MPForwardQueueParameters.h"
 #import "MPDataPlanFilter.h"
@@ -102,7 +104,9 @@ static BOOL runningInBackground = NO;
         _launchDate = [NSDate date];
         _launchOptions = nil;
         _logLevel = MPILogLevelNone;
+#if TARGET_OS_IOS == 1
         _searchAttribution = [[MPSearchAdsAttribution alloc] init];
+#endif
         
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         


### PR DESCRIPTION
 ## Summary
 - Remove deprecated and no longer functional iAd framework code
 - Replace unnecessary reflection with direct calls to AdServices framework (this is already guarded by the `if (@available(14.3` check, so we can just call the method directly
 - Fixed incorrect passing of error pointer instead of memory address which had been obfuscated by the use of reflection

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Smoke test in iOS and tvOS test app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6525
