### PR TITLE
fix: Record PushRegistration Correctly in UI

### DIFF
--- a/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.m
+++ b/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.m
@@ -105,7 +105,7 @@
                                                           event:nil
                                                      parameters:queueParameters
                                                     messageType:MPMessageTypePushRegistration
-                                                       userInfo:nil
+                                                       userInfo:@{@"state":@1}
          ];
     });
 }


### PR DESCRIPTION
## Summary
 - The push registration notification was not passing the correct userinfo. This made the UI read it as an unregister rather than a register

 ## Testing Plan
 - Tested in a sample app and confirmed end to end

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6516
