### PR TITLE
feat: Add Option to Disable Certificate Pinning

### DIFF
--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -137,6 +137,8 @@ Defaults to false. If set true the aliasHost above with overwrite the subdirecto
 @property (nonatomic) NSArray<NSData *> *certificates;
 
 @property (nonatomic) BOOL pinningDisabledInDevelopment;
+
+@property (nonatomic) BOOL pinningDisabled;
 /**
 Defaults to false. Prevents the eventsHost above from overwriting the alias endpoint.
 */

--- a/mParticle-Apple-SDK/Network/MPConnector.m
+++ b/mParticle-Apple-SDK/Network/MPConnector.m
@@ -138,7 +138,7 @@ static NSArray *mpStoredCertificates = nil;
                 }
             }
             
-            BOOL shouldDisablePinning = networkOptions.pinningDisabledInDevelopment && [MParticle sharedInstance].environment == MPEnvironmentDevelopment;
+            BOOL shouldDisablePinning = (networkOptions.pinningDisabledInDevelopment && [MParticle sharedInstance].environment == MPEnvironmentDevelopment) || networkOptions.pinningDisabled;
             if (trustChallenge || shouldDisablePinning) {
                 NSURLCredential *urlCredential = [NSURLCredential credentialForTrust:trustRef];
                 completionHandler(NSURLSessionAuthChallengeUseCredential, urlCredential);

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -139,6 +139,7 @@ static NSString *const kMPStateKey = @"state";
     self = [super init];
     if (self) {
         _pinningDisabledInDevelopment = NO;
+        _pinningDisabled = NO;
         _overridesConfigSubdirectory = NO;
         _overridesEventsSubdirectory = NO;
         _overridesIdentitySubdirectory = NO;
@@ -163,6 +164,7 @@ static NSString *const kMPStateKey = @"state";
     [description appendFormat:@"  overridesAliasSubdirectory: %s\n", _overridesAliasSubdirectory ? "true" : "false"];
     [description appendFormat:@"  certificates: %@\n", _certificates];
     [description appendFormat:@"  pinningDisabledInDevelopment: %s\n", _pinningDisabledInDevelopment ? "true" : "false"];
+    [description appendFormat:@"  pinningDisabled: %s\n", _pinningDisabled ? "true" : "false"];
     [description appendFormat:@"  eventsOnly: %s\n", _eventsOnly ? "true" : "false"];
     [description appendString:@"}"];
     return description;


### PR DESCRIPTION
## Summary
 - Added an option to disable certificate pinning, even in production.

 ## Testing Plan
 - Tested in sample app
 First Fresh app in development
 
<img width="556" alt="Screenshot 2024-06-25 at 1 11 40 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/c263c0e6-391c-44a7-8c17-65ce5c33d996">

Second sabotaged certs

<img width="604" alt="Screenshot 2024-06-25 at 1 12 38 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/72395e4b-96a3-4e30-b772-10d547a98837">

Third used existing disabled in development to successfully upload

<img width="1039" alt="Screenshot 2024-06-25 at 1 13 23 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/2f81759e-23b2-4208-a84d-6490ea131d27">
<img width="709" alt="Screenshot 2024-06-25 at 1 13 53 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/5fc0b894-743a-4e48-a9d6-1499fb9fc706">

Fourth switched to Production to confirm it failed with bad certs as expected

<img width="1130" alt="Screenshot 2024-06-25 at 1 15 37 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/ccbc8ad9-a94a-402a-8d92-f162ef803d97">

Fifth tested change by enabling 'disabledPinning' in production

<img width="1483" alt="Screenshot 2024-06-25 at 1 16 15 PM" src="https://github.com/mParticle/mparticle-apple-sdk/assets/33703490/3d422355-8f06-44f8-bb47-7ecd66bf022f">

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6408
