### PR TITLE
fix: Rename internal Swift.h header to avoid Expo conflicts

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -29,7 +29,7 @@
 #import "MPKitProtocol.h"
 #import "MPKitTestClassSideloaded.h"
 #import "MPApplication.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 @interface MParticle ()
 

--- a/UnitTests/MParticleTests.m
+++ b/UnitTests/MParticleTests.m
@@ -15,7 +15,7 @@
 #import "MPKitTestClassSideloaded.h"
 #import "MPKitTestClassNoStartImmediately.h"
 #import "MPKitConfiguration.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 #import <AppTrackingTransparency/AppTrackingTransparency.h>
 
 @interface MParticle ()

--- a/UnitTests/NSNumber+MPFormatterTests.m
+++ b/UnitTests/NSNumber+MPFormatterTests.m
@@ -8,7 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MPBaseTestCase.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 @interface NSNumber_MPFormatterTests : MPBaseTestCase
 

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -14,8 +14,8 @@
 		531BCF3A2B28A83E00F5C573 /* MPIdentityCachingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */; };
 		531BCF3B2B28A83E00F5C573 /* MPIdentityCachingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */; };
 		534CD25C29CE2877008452B3 /* NSNumber+MPFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A79B2629CDFB1F00E7489F /* NSNumber+MPFormatter.swift */; };
-		534CD25E29CE2BF1008452B3 /* Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 534CD25D29CE2BF1008452B3 /* Swift.h */; };
-		534CD25F29CE2BF1008452B3 /* Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 534CD25D29CE2BF1008452B3 /* Swift.h */; };
+		534CD25E29CE2BF1008452B3 /* MParticleSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 534CD25D29CE2BF1008452B3 /* MParticleSwift.h */; };
+		534CD25F29CE2BF1008452B3 /* MParticleSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 534CD25D29CE2BF1008452B3 /* MParticleSwift.h */; };
 		534CD26429CE2CE1008452B3 /* MPKitSecondTestClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C7029CE019E00E7489F /* MPKitSecondTestClass.m */; };
 		534CD26529CE2CE1008452B3 /* MPKitAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9F29CE019F00E7489F /* MPKitAPITests.m */; };
 		534CD26629CE2CE1008452B3 /* MPUserIdentityChangeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C7429CE019E00E7489F /* MPUserIdentityChangeTests.m */; };
@@ -542,7 +542,7 @@
 		531BCF322B28A23400F5C573 /* MPIdentityCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPIdentityCaching.h; sourceTree = "<group>"; };
 		531BCF332B28A23400F5C573 /* MPIdentityCaching.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPIdentityCaching.m; sourceTree = "<group>"; };
 		531BCF392B28A83E00F5C573 /* MPIdentityCachingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPIdentityCachingTests.m; sourceTree = "<group>"; };
-		534CD25D29CE2BF1008452B3 /* Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Swift.h; sourceTree = "<group>"; };
+		534CD25D29CE2BF1008452B3 /* MParticleSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MParticleSwift.h; sourceTree = "<group>"; };
 		534CD2AA29CE2CE1008452B3 /* mParticle-Apple-SDK-NoLocationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-Apple-SDK-NoLocationTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		53A79A7929CCCD6400E7489F /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		53A79A8329CCCD6400E7489F /* mParticle-Apple-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-Apple-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -886,7 +886,7 @@
 				53A79AD029CDFB1F00E7489F /* MPEnums.m */,
 				53A79ACF29CDFB1F00E7489F /* MPIConstants.h */,
 				53A79B6429CDFB1F00E7489F /* MPIConstants.m */,
-				534CD25D29CE2BF1008452B3 /* Swift.h */,
+				534CD25D29CE2BF1008452B3 /* MParticleSwift.h */,
 				53A79B3729CDFB1F00E7489F /* AppNotifications */,
 				53A79AF529CDFB1F00E7489F /* Consent */,
 				53A79B2E29CDFB1F00E7489F /* Custom Modules */,
@@ -1387,7 +1387,7 @@
 				53A79C1F29CDFB2100E7489F /* MPBaseProjection.h in Headers */,
 				53A79BC929CDFB2000E7489F /* MPIUserDefaults.h in Headers */,
 				53A79C1429CDFB2100E7489F /* MPEventProjection.h in Headers */,
-				534CD25E29CE2BF1008452B3 /* Swift.h in Headers */,
+				534CD25E29CE2BF1008452B3 /* MParticleSwift.h in Headers */,
 				53A79B8A29CDFB2000E7489F /* MPUpload.h in Headers */,
 				53A79BD129CDFB2000E7489F /* MPResponseConfig.h in Headers */,
 				53A79B9829CDFB2000E7489F /* MPConsumerInfo.h in Headers */,
@@ -1494,7 +1494,7 @@
 				53A79D3A29CE23F700E7489F /* MPBaseProjection.h in Headers */,
 				53A79D3B29CE23F700E7489F /* MPIUserDefaults.h in Headers */,
 				53A79D3C29CE23F700E7489F /* MPEventProjection.h in Headers */,
-				534CD25F29CE2BF1008452B3 /* Swift.h in Headers */,
+				534CD25F29CE2BF1008452B3 /* MParticleSwift.h in Headers */,
 				53A79D3D29CE23F700E7489F /* MPUpload.h in Headers */,
 				53A79D3E29CE23F700E7489F /* MPResponseConfig.h in Headers */,
 				53A79D3F29CE23F700E7489F /* MPConsumerInfo.h in Headers */,

--- a/mParticle-Apple-SDK/Ecommerce/MPProduct.m
+++ b/mParticle-Apple-SDK/Ecommerce/MPProduct.m
@@ -1,5 +1,5 @@
 #import "MPProduct.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 #import "MPIConstants.h"
 #import "NSDictionary+MPCaseInsensitive.h"
 #import "MPILogger.h"

--- a/mParticle-Apple-SDK/Ecommerce/MPPromotion.m
+++ b/mParticle-Apple-SDK/Ecommerce/MPPromotion.m
@@ -1,7 +1,7 @@
 #import "MPPromotion.h"
 #import "MPIConstants.h"
 #import "NSDictionary+MPCaseInsensitive.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 // Internal keys
 NSString *const kMPPMAction = @"an";

--- a/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes.m
+++ b/mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes.m
@@ -1,5 +1,5 @@
 #import "MPTransactionAttributes.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 #import "NSDictionary+MPCaseInsensitive.h"
 #import "MPILogger.h"
 #import "mParticle.h"

--- a/mParticle-Apple-SDK/Identity/FilteredMParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/FilteredMParticleUser.m
@@ -3,7 +3,7 @@
 #import "MParticleUser.h"
 #import "MPKitConfiguration.h"
 #import "MPDataPlanFilter.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 @interface MParticle ()
 

--- a/mParticle-Apple-SDK/Kits/MPEventProjection.mm
+++ b/mParticle-Apple-SDK/Kits/MPEventProjection.mm
@@ -1,6 +1,6 @@
 #import "MPEventProjection.h"
 #import "MPAttributeProjection.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 #import <vector>
 
 @implementation MPProjectionMatch

--- a/mParticle-Apple-SDK/Kits/MPKitConfiguration.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitConfiguration.mm
@@ -6,7 +6,7 @@
 #import "MPConsentSerialization.h"
 #import "mParticle.h"
 #import "MPEnums.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 #import <vector>
 
 @interface MPKitConfiguration()

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -1,5 +1,5 @@
 #import "MPKitContainer.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 #import "MPKitExecStatus.h"
 #import "MPEnums.h"
 #import "MPStateMachine.h"

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -34,7 +34,7 @@
 #import "MParticleWebView.h"
 #import "MPDevice.h"
 #import "MPIdentityCaching.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE

--- a/mParticle-Apple-SDK/MParticleSwift.h
+++ b/mParticle-Apple-SDK/MParticleSwift.h
@@ -1,5 +1,5 @@
 //
-//  Swift.h
+//  MParticleSwift.h
 //  mParticle-Apple-SDK
 //
 //  Created by Ben Baron on 3/24/23.

--- a/mParticle-Apple-SDK/Utils/MPIUserDefaults.m
+++ b/mParticle-Apple-SDK/Utils/MPIUserDefaults.m
@@ -7,7 +7,7 @@
 #import "MPArchivist.h"
 #import "MPStateMachine.h"
 #import "MPKitContainer.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 @interface MParticle ()
 

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.m
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.m
@@ -20,7 +20,7 @@
 #import <UIKit/UIKit.h>
 #import "MPForwardQueueParameters.h"
 #import "MPDataPlanFilter.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -23,7 +23,7 @@
 #import "MParticleWebView.h"
 #import "MPDataPlanFilter.h"
 #import "MPResponseConfig.h"
-#import "Swift.h"
+#import "MParticleSwift.h"
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE


### PR DESCRIPTION
 ## Summary
 We have an internal header called `Swift.h` used as a wrapper import. Due to it being project level (aka internal), it was thought the generic file name would not cause issues, but due to the way Expo does builds, it conflicts with their own `Swift.h` header.

This change renames that internal header and updates all imports statements.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested local build in Xcode
 - Manually updated Expo test app dependency to use this change and confirmed successful build and run `npx expo run:ios`

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6578
