### PR TITLE
feat: Workspace switching redux

### DIFF
--- a/UnitTests/MPBackendControllerTests.m
+++ b/UnitTests/MPBackendControllerTests.m
@@ -522,7 +522,7 @@
     XCTAssertTrue(eventFound, @"Message for logEvent is not being saved.");
 
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     XCTAssertNotNil(uploadBuilder, @"Upload builder should not have been nil.");
     
     [uploadBuilder withUserAttributes:[self.backendController userAttributesForUserId:[MPPersistenceController mpId]] deletedUserAttributes:nil];
@@ -600,7 +600,7 @@
     XCTAssertNil([MParticle sharedInstance].identity.currentUser.identities[@(MPIdentityIOSAdvertiserId)]);
 
 
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     XCTAssertNotNil(uploadBuilder, @"Upload builder should not have been nil.");
     
     [uploadBuilder withUserAttributes:[self.backendController userAttributesForUserId:mpid] deletedUserAttributes:nil];
@@ -690,7 +690,7 @@
         NSMutableDictionary *dataPlanIdDictionary =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:self->_session.sessionId]];
         NSMutableDictionary *dataPlanVersionDictionary =  [dataPlanIdDictionary objectForKey:@"test"];
         NSArray *persistedMessages =  [dataPlanVersionDictionary objectForKey:[NSNumber numberWithInt:1]];
-        MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:persistedMessages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+        MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:persistedMessages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
         XCTAssertNotNil(uploadBuilder, @"Upload builder should not have been nil.");
         
         if (!uploadBuilder) {

--- a/UnitTests/MPBackendControllerTests.m
+++ b/UnitTests/MPBackendControllerTests.m
@@ -522,7 +522,7 @@
     XCTAssertTrue(eventFound, @"Message for logEvent is not being saved.");
 
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     XCTAssertNotNil(uploadBuilder, @"Upload builder should not have been nil.");
     
     [uploadBuilder withUserAttributes:[self.backendController userAttributesForUserId:[MPPersistenceController mpId]] deletedUserAttributes:nil];
@@ -600,7 +600,7 @@
     XCTAssertNil([MParticle sharedInstance].identity.currentUser.identities[@(MPIdentityIOSAdvertiserId)]);
 
 
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:mpid sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:messages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     XCTAssertNotNil(uploadBuilder, @"Upload builder should not have been nil.");
     
     [uploadBuilder withUserAttributes:[self.backendController userAttributesForUserId:mpid] deletedUserAttributes:nil];
@@ -690,7 +690,7 @@
         NSMutableDictionary *dataPlanIdDictionary =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:self->_session.sessionId]];
         NSMutableDictionary *dataPlanVersionDictionary =  [dataPlanIdDictionary objectForKey:@"test"];
         NSArray *persistedMessages =  [dataPlanVersionDictionary objectForKey:[NSNumber numberWithInt:1]];
-        MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:persistedMessages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
+        MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:[NSNumber numberWithLong:self->_session.sessionId] messages:persistedMessages sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
         XCTAssertNotNil(uploadBuilder, @"Upload builder should not have been nil.");
         
         if (!uploadBuilder) {

--- a/UnitTests/MPConnectorTests.m
+++ b/UnitTests/MPConnectorTests.m
@@ -90,7 +90,7 @@
     MPURL *mpURL = [[MPURL alloc] initWithURL:customURL defaultURL:defaultURL];
 
     id mockRequestBuilder = OCMClassMock([MPURLRequestBuilder class]);
-    NSObject<MPConnectorResponseProtocol> *connectorResponse = [connector responseFromPostRequestToURL:mpURL message:nil serializedParams:nil];
+    NSObject<MPConnectorResponseProtocol> *connectorResponse = [connector responseFromPostRequestToURL:mpURL message:nil serializedParams:nil secret:nil];
     
     OCMVerify([mockRequestBuilder newBuilderWithURL:mpURL message:nil httpMethod:kMPHTTPMethodPost]);
     XCTAssertNotNil(connectorResponse);

--- a/UnitTests/MPDataModelTests.m
+++ b/UnitTests/MPDataModelTests.m
@@ -199,7 +199,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     XCTAssertNotNil(upload, @"Should not have been nil.");
     
     NSString *description = [upload description];

--- a/UnitTests/MPDataModelTests.m
+++ b/UnitTests/MPDataModelTests.m
@@ -199,7 +199,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     XCTAssertNotNil(upload, @"Should not have been nil.");
     
     NSString *description = [upload description];

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -303,7 +303,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
 
 - (void)testUploadsArrayZipFail {
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     OCMStub([mockZip compressedDataFromData:OCMOCK_ANY]).andReturn(nil);
@@ -318,7 +318,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusNotDetermined withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -335,7 +335,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusRestricted withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -352,7 +352,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusDenied withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -369,7 +369,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusAuthorized withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -411,7 +411,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
     [[[mockNetworkCommunication stub] andReturn:mockConnector] makeConnector];
     
-    MPUpload *messageUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *messageUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     BOOL actualShouldStop = [networkCommunication performMessageUpload:messageUpload];
     XCTAssertEqual(shouldStop, actualShouldStop, @"Return code assertion: %d", returnCode);
@@ -446,7 +446,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
     [[[mockNetworkCommunication stub] andReturn:mockConnector] makeConnector];
     
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     BOOL actualShouldStop = [networkCommunication performAliasUpload:aliasUpload];
@@ -473,8 +473,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     MParticle *instance = [MParticle sharedInstance];
     instance.persistenceController = mockPersistenceController;
     
-    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     NSArray *uploads = @[eventUpload, aliasUpload];
@@ -501,8 +501,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     
     id mockPersistenceController = OCMClassMock([MPPersistenceController class]);
     
-    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     [[mockPersistenceController expect] deleteUpload:eventUpload];
@@ -543,8 +543,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     
     id mockPersistenceController = OCMClassMock([MPPersistenceController class]);
     
-    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     [[mockPersistenceController expect] deleteUpload:eventUpload];

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -158,7 +158,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *eventURL = [networkCommunication eventURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *eventURL = [networkCommunication eventURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -172,7 +173,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [self swizzleInstanceMethodForInstancesOfClass:[NSBundle class] selector:@selector(infoDictionary)];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -187,7 +189,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -203,7 +206,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -221,7 +225,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -238,7 +243,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -256,7 +262,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     
@@ -281,7 +288,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [MParticle sharedInstance].networkOptions = options;
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    NSURL *aliasURL = [networkCommunication aliasURL].url;
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
+    NSURL *aliasURL = [networkCommunication aliasURLForUpload:upload].url;
     
     [self deswizzle];
     

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -303,7 +303,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
 
 - (void)testUploadsArrayZipFail {
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     OCMStub([mockZip compressedDataFromData:OCMOCK_ANY]).andReturn(nil);
@@ -318,7 +318,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusNotDetermined withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -335,7 +335,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusRestricted withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -352,7 +352,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusDenied withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -369,7 +369,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     [[MParticle sharedInstance] setATTStatus:MPATTAuthorizationStatusAuthorized withATTStatusTimestampMillis:nil];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     NSArray *uploads = @[upload];
     id mockZip = OCMClassMock([MPZip class]);
     [[mockZip expect] compressedDataFromData:[OCMArg checkWithBlock:^BOOL(id value) {
@@ -411,7 +411,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
     [[[mockNetworkCommunication stub] andReturn:mockConnector] makeConnector];
     
-    MPUpload *messageUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *messageUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     
     BOOL actualShouldStop = [networkCommunication performMessageUpload:messageUpload];
     XCTAssertEqual(shouldStop, actualShouldStop, @"Return code assertion: %d", returnCode);
@@ -446,7 +446,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
     [[[mockNetworkCommunication stub] andReturn:mockConnector] makeConnector];
     
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     BOOL actualShouldStop = [networkCommunication performAliasUpload:aliasUpload];
@@ -473,8 +473,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     MParticle *instance = [MParticle sharedInstance];
     instance.persistenceController = mockPersistenceController;
     
-    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     NSArray *uploads = @[eventUpload, aliasUpload];
@@ -501,8 +501,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     
     id mockPersistenceController = OCMClassMock([MPPersistenceController class]);
     
-    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1)];
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{kMPDeviceInformationKey: @{}} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     [[mockPersistenceController expect] deleteUpload:eventUpload];
@@ -543,8 +543,8 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     
     id mockPersistenceController = OCMClassMock([MPPersistenceController class]);
     
-    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
-    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *eventUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *aliasUpload = [[MPUpload alloc] initWithSessionId:@1 uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     aliasUpload.uploadType = MPUploadTypeAlias;
     
     [[mockPersistenceController expect] deleteUpload:eventUpload];

--- a/UnitTests/MPNetworkCommunicationTests.m
+++ b/UnitTests/MPNetworkCommunicationTests.m
@@ -413,7 +413,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     response.httpResponse = urlResponseMock;
     
     id mockConnector = OCMClassMock([MPConnector class]);
-    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY];
+    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY secret:OCMOCK_ANY];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
@@ -448,7 +448,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     response.httpResponse = urlResponseMock;
     
     id mockConnector = OCMClassMock([MPConnector class]);
-    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY];
+    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY secret:OCMOCK_ANY];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
@@ -469,7 +469,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     response.httpResponse = urlResponseMock;
     
     id mockConnector = OCMClassMock([MPConnector class]);
-    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY];
+    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY secret:OCMOCK_ANY];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
@@ -501,7 +501,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     response.httpResponse = urlResponseMock;
     
     id mockConnector = OCMClassMock([MPConnector class]);
-    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY];
+    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY secret:OCMOCK_ANY];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);
@@ -543,7 +543,7 @@ Method originalMethod = nil; Method swizzleMethod = nil;
     response.httpResponse = urlResponseMock;
     
     id mockConnector = OCMClassMock([MPConnector class]);
-    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY];
+    [[[mockConnector stub] andReturn:response] responseFromPostRequestToURL:OCMOCK_ANY message:OCMOCK_ANY serializedParams:OCMOCK_ANY secret:OCMOCK_ANY];
     
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     id mockNetworkCommunication = OCMPartialMock(networkCommunication);

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -100,7 +100,7 @@
                                                                              session:nil
                                                                          messageInfo:messageInfo];
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:@123 sessionId:nil messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:@123 sessionId:nil messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     __block BOOL tested = NO;
     [uploadBuilder build:^(MPUpload * _Nullable upload) {
         [persistence saveUpload:upload];
@@ -148,7 +148,7 @@
                                                                              session:session
                                                                          messageInfo:messageInfo];
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:@123 sessionId:@11 messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:@123 sessionId:@11 messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     __block BOOL tested = NO;
     [uploadBuilder build:^(MPUpload * _Nullable upload) {
         [persistence saveUpload:upload];
@@ -361,7 +361,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -408,7 +408,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -454,7 +454,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:nil apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -494,7 +494,7 @@
                                                                          messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     [uploadBuilder build:^(MPUpload *upload) {
         MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
@@ -521,7 +521,7 @@
     
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     [uploadBuilder build:^(MPUpload *upload) {
         MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
@@ -721,8 +721,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:@"test"
                                                            dataPlanVersion:@(1)
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     [uploadBuilder build: ^(MPUpload * _Nullable upload) {
     }];
@@ -887,7 +886,7 @@
     
     // Store an upload
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO, kMPSessionTimeoutKey:@120, kMPUploadIntervalKey:@10, kMPLifeTimeValueKey:@0, kMPMessagesKey:@[[message dictionaryRepresentation]], kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
     upload.timestamp = oneDayAgo;
     [instance.persistenceController saveUpload:upload];
     XCTAssertEqual([instance.persistenceController fetchUploads].count, 1);
@@ -923,7 +922,7 @@
     
     // Store an upload
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO, kMPSessionTimeoutKey:@120, kMPUploadIntervalKey:@10, kMPLifeTimeValueKey:@0, kMPMessagesKey:@[[message dictionaryRepresentation]], kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil uploadSettings:[MPUploadSettings currentUploadSettings]];
     upload.timestamp = sevenDaysAgo;
     [instance.persistenceController saveUpload:upload];
     XCTAssertEqual([instance.persistenceController fetchUploads].count, 1);

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -963,7 +963,8 @@
     XCTAssertEqual([instance.persistenceController fetchUploads].count, 1);
     
     // Cleanup all records except uploads
-    [instance.persistenceController clearDatabaseForWorkspaceSwitching];
+    [instance.persistenceController resetDatabaseForWorkspaceSwitching];
+    [instance.persistenceController openDatabase];
     
     // Check that the records no longer exist
     XCTAssertEqual([instance.persistenceController fetchMessagesForUploading].count, 0);

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -46,6 +46,10 @@
     [super setUp];
     
     [MParticle sharedInstance].persistenceController = [[MPPersistenceController alloc] init];
+    MPStateMachine *stateMachine = [[MPStateMachine alloc] init];
+    stateMachine.apiKey = @"test_key";
+    stateMachine.secret = @"test_secret";
+    [MParticle sharedInstance].stateMachine = stateMachine;
 }
 
 - (void)testMultiThreadedAccess {
@@ -96,7 +100,7 @@
                                                                              session:nil
                                                                          messageInfo:messageInfo];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:@123 sessionId:nil messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:@123 sessionId:nil messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     __block BOOL tested = NO;
     [uploadBuilder build:^(MPUpload * _Nullable upload) {
         [persistence saveUpload:upload];
@@ -144,7 +148,7 @@
                                                                              session:session
                                                                          messageInfo:messageInfo];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:@123 sessionId:@11 messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:@123 sessionId:@11 messages:@[[messageBuilder build]] sessionTimeout:100 uploadInterval:100 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     __block BOOL tested = NO;
     [uploadBuilder build:^(MPUpload * _Nullable upload) {
         [persistence saveUpload:upload];
@@ -357,7 +361,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -404,7 +408,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -450,7 +454,7 @@
                                        kMPMessagesKey:@[[message dictionaryRepresentation]],
                                        kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:nil];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:[NSNumber numberWithLongLong:session.sessionId] uploadDictionary:uploadDictionary dataPlanId:@"test" dataPlanVersion:nil apiKey:@"" apiSecret:@""];
     
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
     
@@ -490,7 +494,7 @@
                                                                          messageInfo:@{@"MessageKey1":@"MessageValue1"}];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:@"test" dataPlanVersion:@(1) apiKey:@"" apiSecret:@""];
     
     [uploadBuilder build:^(MPUpload *upload) {
         MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
@@ -517,7 +521,7 @@
     
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:nil dataPlanVersion:nil];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId] sessionId:@(session.sessionId) messages:@[message] sessionTimeout:120 uploadInterval:10 dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
     
     [uploadBuilder build:^(MPUpload *upload) {
         MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
@@ -710,13 +714,15 @@
     MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent session:session messageInfo:@{}];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
-                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:@"test"
-                                                            dataPlanVersion:@(1)];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                  messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:@"test"
+                                                           dataPlanVersion:@(1)
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     [uploadBuilder build: ^(MPUpload * _Nullable upload) {
     }];
@@ -881,7 +887,7 @@
     
     // Store an upload
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO, kMPSessionTimeoutKey:@120, kMPUploadIntervalKey:@10, kMPLifeTimeValueKey:@0, kMPMessagesKey:@[[message dictionaryRepresentation]], kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
     upload.timestamp = oneDayAgo;
     [instance.persistenceController saveUpload:upload];
     XCTAssertEqual([instance.persistenceController fetchUploads].count, 1);
@@ -917,7 +923,7 @@
     
     // Store an upload
     NSDictionary *uploadDictionary = @{kMPOptOutKey:@NO, kMPSessionTimeoutKey:@120, kMPUploadIntervalKey:@10, kMPLifeTimeValueKey:@0, kMPMessagesKey:@[[message dictionaryRepresentation]], kMPMessageIdKey:[[NSUUID UUID] UUIDString]};
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:@(session.sessionId) uploadDictionary:uploadDictionary dataPlanId:nil dataPlanVersion:nil apiKey:@"" apiSecret:@""];
     upload.timestamp = sevenDaysAgo;
     [instance.persistenceController saveUpload:upload];
     XCTAssertEqual([instance.persistenceController fetchUploads].count, 1);

--- a/UnitTests/MPURLRequestBuilderTests.m
+++ b/UnitTests/MPURLRequestBuilderTests.m
@@ -17,6 +17,7 @@
 #import "MParticleWebView.h"
 #import "MPExtensionProtocol.h"
 #import "MPURL.h"
+#import "MPUpload.h"
 
 @interface MParticle ()
 
@@ -104,8 +105,9 @@
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     
     MPMessage *message = [[MPMessage alloc] initWithSession:nil messageType:@"e" messageInfo:@{@"key":@"value"} uploadStatus:MPUploadStatusBatch UUID:[[NSUUID UUID] UUIDString] timestamp:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId] dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     
-    MPURLRequestBuilder *urlRequestBuilder = [MPURLRequestBuilder newBuilderWithURL:[networkCommunication eventURL]
+    MPURLRequestBuilder *urlRequestBuilder = [MPURLRequestBuilder newBuilderWithURL:[networkCommunication eventURLForUpload:upload]
                                                                             message:[message serializedString]
                                                                          httpMethod:@"POST"];
     
@@ -130,8 +132,9 @@
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     
     MPMessage *message = [[MPMessage alloc] initWithSession:nil messageType:@"e" messageInfo:@{@"key":@"value"} uploadStatus:MPUploadStatusBatch UUID:[[NSUUID UUID] UUIDString] timestamp:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId] dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     
-    MPURLRequestBuilder *urlRequestBuilder = [MPURLRequestBuilder newBuilderWithURL:[networkCommunication eventURL]
+    MPURLRequestBuilder *urlRequestBuilder = [MPURLRequestBuilder newBuilderWithURL:[networkCommunication eventURLForUpload:upload]
                                                                             message:[message serializedString]
                                                                          httpMethod:@"POST"];
     
@@ -396,8 +399,9 @@
     MPNetworkCommunication *networkCommunication = [[MPNetworkCommunication alloc] init];
     
     MPMessage *message = [[MPMessage alloc] initWithSession:nil messageType:@"e" messageInfo:@{@"key":@"value"} uploadStatus:MPUploadStatusBatch UUID:[[NSUUID UUID] UUIDString] timestamp:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId] dataPlanId:@"test" dataPlanVersion:@(1)];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:nil uploadDictionary:@{} dataPlanId:@"test" dataPlanVersion:@(1) uploadSettings:[MPUploadSettings currentUploadSettings]];
     
-    MPURLRequestBuilder *urlRequestBuilder = [MPURLRequestBuilder newBuilderWithURL:[networkCommunication eventURL]
+    MPURLRequestBuilder *urlRequestBuilder = [MPURLRequestBuilder newBuilderWithURL:[networkCommunication eventURLForUpload:upload]
                                                                             message:[message serializedString]
                                                                          httpMethod:@"POST"];
     NSMutableURLRequest *asyncURLRequest = [urlRequestBuilder build];

--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -130,14 +130,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
-                                                                    sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
-                                      ];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                messages:@[message]
+                                                          sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                          uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                              dataPlanId:message.dataPlanId
+                                                         dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -204,12 +203,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder newBuilderWithMpid:[MPPersistenceController mpId]
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:nil
                                                                 messages:@[message]
+                                                            sessionTimeout:0
                                                           uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                               dataPlanId:message.dataPlanId
-                                                         dataPlanVersion:message.dataPlanVersion
-                                      ];
+                                                         dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -282,14 +282,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
                                                                     sessionId:[NSNumber numberWithLong:session.sessionId]
                                                                    messages:@[message]
                                                              sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                              uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                  dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
-                                      ];
+                                                            dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -364,14 +363,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
                                                                     sessionId:[NSNumber numberWithLong:session.sessionId]
                                                                    messages:@[message]
                                                              sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                              uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                  dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
-                                      ];
+                                                            dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -443,14 +441,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
-                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                  messages:@[message]
                                                              sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
-    ];
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -525,14 +522,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
-                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
-    ];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                  messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -610,14 +606,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
-                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
-    ];
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                  messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -691,13 +686,13 @@
     [messageBuilder timestamp:[[NSDate date] timeIntervalSince1970]];
     MPMessage *message = [messageBuilder build];
     
-    MPUploadBuilder *uploadBuilder = [MPUploadBuilder    newBuilderWithMpid:[MPPersistenceController mpId]
-                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion
+    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion
     ];
     
     XCTAssertNotNil(uploadBuilder);

--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -137,8 +137,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion  
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -212,8 +211,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion 
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -293,8 +291,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
 
     XCTAssertNotNil(uploadBuilder);
     
@@ -376,8 +373,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion 
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -456,8 +452,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion 
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -539,8 +534,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -625,8 +619,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -707,8 +700,7 @@
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion
-                                                                    apiKey:@""
-                                                                 apiSecret:@""];
+                                                            uploadSettings:[MPUploadSettings currentUploadSettings]];
     
     XCTAssertNotNil(uploadBuilder);
     

--- a/UnitTests/MPUploadBuilderTests.m
+++ b/UnitTests/MPUploadBuilderTests.m
@@ -132,11 +132,13 @@
     
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                messages:@[message]
-                                                          sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                          uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                              dataPlanId:message.dataPlanId
-                                                         dataPlanVersion:message.dataPlanVersion];
+                                                                  messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion  
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -205,11 +207,13 @@
     
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
                                                                  sessionId:nil
-                                                                messages:@[message]
+                                                                  messages:@[message]
                                                             sessionTimeout:0
-                                                          uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                              dataPlanId:message.dataPlanId
-                                                         dataPlanVersion:message.dataPlanVersion];
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion 
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -283,13 +287,15 @@
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
-                                                                    sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion];
-    
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                  messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
+
     XCTAssertNotNil(uploadBuilder);
     
     NSDictionary *userAttributes = @{@"Dinosaur":@"T-Rex",
@@ -364,12 +370,14 @@
     MPMessage *message = [messageBuilder build];
     
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
-                                                                    sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
-                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
-                                                                 dataPlanId:message.dataPlanId
-                                                            dataPlanVersion:message.dataPlanVersion];
+                                                                 sessionId:[NSNumber numberWithLong:session.sessionId]
+                                                                  messages:@[message]
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            uploadInterval:DEFAULT_UPLOAD_INTERVAL
+                                                                dataPlanId:message.dataPlanId
+                                                           dataPlanVersion:message.dataPlanVersion 
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -444,10 +452,12 @@
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
                                                                   messages:@[message]
-                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
+                                                            sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
-                                                           dataPlanVersion:message.dataPlanVersion];
+                                                           dataPlanVersion:message.dataPlanVersion 
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -528,7 +538,9 @@
                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
-                                                           dataPlanVersion:message.dataPlanVersion];
+                                                           dataPlanVersion:message.dataPlanVersion
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -612,7 +624,9 @@
                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
-                                                           dataPlanVersion:message.dataPlanVersion];
+                                                           dataPlanVersion:message.dataPlanVersion
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     
@@ -688,12 +702,13 @@
     
     MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:[MPPersistenceController mpId]
                                                                  sessionId:[NSNumber numberWithLong:session.sessionId]
-                                                                messages:@[message]
+                                                                  messages:@[message]
                                                             sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                             uploadInterval:DEFAULT_UPLOAD_INTERVAL
                                                                 dataPlanId:message.dataPlanId
                                                            dataPlanVersion:message.dataPlanVersion
-    ];
+                                                                    apiKey:@""
+                                                                 apiSecret:@""];
     
     XCTAssertNotNil(uploadBuilder);
     

--- a/mParticle-Apple-SDK/Data Model/MPDataModelAbstract.h
+++ b/mParticle-Apple-SDK/Data Model/MPDataModelAbstract.h
@@ -6,7 +6,7 @@
     NSString *_uuid;
 }
 
-@property (nonatomic, strong, nonnull) NSString *uuid;
+@property (nonatomic, strong, nullable) NSString *uuid;
 
 - (nonnull id)copyWithZone:(nullable NSZone *)zone;
 

--- a/mParticle-Apple-SDK/Data Model/MPUpload.h
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.h
@@ -4,6 +4,24 @@
 
 @class MPSession;
 
+// Upload credentials and options
+@interface MPUploadSettings : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic, strong, nonnull) NSString *apiKey;
+@property (nonatomic, strong, nonnull) NSString *secret;
+@property (nonatomic, strong, nullable) NSString *eventsHost;
+@property (nonatomic, strong, nullable) NSString *eventsTrackingHost;
+@property (nonatomic) BOOL overridesEventsSubdirectory;
+@property (nonatomic, strong, nullable) NSString *aliasHost;
+@property (nonatomic, strong, nullable) NSString *aliasTrackingHost;
+@property (nonatomic) BOOL overridesAliasSubdirectory;
+@property (nonatomic) BOOL eventsOnly;
+
++ (nonnull MPUploadSettings *)currentUploadSettings;
+
+- (nonnull instancetype)initWithApiKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret eventsHost:(nullable NSString *)eventsHost eventsTrackingHost:(nullable NSString *)eventsTrackingHost overridesEventsSubdirectory:(BOOL)overridesEventsSubdirectory aliasHost:(nullable NSString *)aliasHost aliasTrackingHost:(nullable NSString *)aliasTrackingHost overridesAliasSubdirectory:(BOOL)overridesAliasSubdirectory eventsOnly:(BOOL)eventsOnly;
+
+@end
+
 @interface MPUpload : MPDataModelAbstract <NSCopying, MPDataModelProtocol>
 
 @property (nonatomic, strong, nonnull) NSData *uploadData;
@@ -14,15 +32,15 @@
 @property (nonatomic, strong, nullable) NSString *dataPlanId;
 @property (nonatomic, strong, nullable) NSNumber *dataPlanVersion;
 @property BOOL containsOptOutMessage;
-@property (nonatomic, strong, nonnull) NSString *apiKey;
-@property (nonatomic, strong, nonnull) NSString *apiSecret;
+
+@property (nonatomic, strong, nonnull) MPUploadSettings *uploadSettings;
+
 
 - (nonnull instancetype)initWithSessionId:(nullable NSNumber *)sessionId
                          uploadDictionary:(nonnull NSDictionary *)uploadDictionary
                                dataPlanId:(nullable NSString *)dataPlanId
                           dataPlanVersion:(nullable NSNumber *)dataPlanVersion
-                                   apiKey:(nonnull NSString *)apiKey
-                                apiSecret:(nonnull NSString *)apiSecret;
+                           uploadSettings:(nonnull MPUploadSettings *)uploadSettings;
 
 - (nonnull instancetype)initWithSessionId:(nullable NSNumber *)sessionId
                                  uploadId:(int64_t)uploadId
@@ -32,7 +50,6 @@
                                uploadType:(MPUploadType)uploadType
                                dataPlanId:(nullable NSString *)dataPlanId
                           dataPlanVersion:(nullable NSNumber *)dataPlanVersion
-                                   apiKey:(nonnull NSString *)apiKey
-                                apiSecret:(nonnull NSString *)apiSecret;
+                           uploadSettings:(nonnull MPUploadSettings *)uploadSettings;
 
 @end

--- a/mParticle-Apple-SDK/Data Model/MPUpload.h
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.h
@@ -14,11 +14,16 @@
 @property (nonatomic, strong, nullable) NSString *dataPlanId;
 @property (nonatomic, strong, nullable) NSNumber *dataPlanVersion;
 @property BOOL containsOptOutMessage;
+@property (nonatomic, strong, nonnull) NSString *apiKey;
+@property (nonatomic, strong, nonnull) NSString *apiSecret;
 
 - (nonnull instancetype)initWithSessionId:(nullable NSNumber *)sessionId
                          uploadDictionary:(nonnull NSDictionary *)uploadDictionary
                                dataPlanId:(nullable NSString *)dataPlanId
-                          dataPlanVersion:(nullable NSNumber *)dataPlanVersion;
+                          dataPlanVersion:(nullable NSNumber *)dataPlanVersion
+                                   apiKey:(nonnull NSString *)apiKey
+                                apiSecret:(nonnull NSString *)apiSecret;
+
 - (nonnull instancetype)initWithSessionId:(nullable NSNumber *)sessionId
                                  uploadId:(int64_t)uploadId
                                      UUID:(nonnull NSString *)uuid
@@ -26,6 +31,8 @@
                                 timestamp:(NSTimeInterval)timestamp
                                uploadType:(MPUploadType)uploadType
                                dataPlanId:(nullable NSString *)dataPlanId
-                          dataPlanVersion:(nullable NSNumber *)dataPlanVersion;
+                          dataPlanVersion:(nullable NSNumber *)dataPlanVersion
+                                   apiKey:(nonnull NSString *)apiKey
+                                apiSecret:(nonnull NSString *)apiSecret;
 
 @end

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -77,7 +77,7 @@ static NSString * const kEventsOnly = @"eventsOnly";
 }
 
 + (BOOL)supportsSecureCoding {
-    return TRUE;
+    return YES;
 }
 
 - (id)copyWithZone:(NSZone *)zone {

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -4,9 +4,8 @@
 
 @implementation MPUpload
 
-- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadDictionary:(NSDictionary *)uploadDictionary dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion {
+- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadDictionary:(NSDictionary *)uploadDictionary dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion apiKey:(nonnull NSString *)apiKey apiSecret:(nonnull NSString *)apiSecret {
     NSData *uploadData = [NSJSONSerialization dataWithJSONObject:uploadDictionary options:0 error:nil];
-    
     return [self initWithSessionId:sessionId
                           uploadId:0
                               UUID:uploadDictionary[kMPMessageIdKey]
@@ -14,10 +13,12 @@
                          timestamp:[uploadDictionary[kMPTimestampKey] doubleValue]
                         uploadType:MPUploadTypeMessage
                         dataPlanId:dataPlanId
-                   dataPlanVersion:dataPlanVersion];
+                   dataPlanVersion:dataPlanVersion
+                            apiKey:apiKey
+                         apiSecret:apiSecret];
 }
 
-- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadId:(int64_t)uploadId UUID:(NSString *)uuid uploadData:(NSData *)uploadData timestamp:(NSTimeInterval)timestamp uploadType:(MPUploadType)uploadType dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion {
+- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadId:(int64_t)uploadId UUID:(NSString *)uuid uploadData:(NSData *)uploadData timestamp:(NSTimeInterval)timestamp uploadType:(MPUploadType)uploadType dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion apiKey:(nonnull NSString *)apiKey apiSecret:(nonnull NSString *)apiSecret {
     self = [super init];
     if (self) {
         _sessionId = sessionId;
@@ -29,6 +30,8 @@
         _containsOptOutMessage = NO;
         _dataPlanId = dataPlanId;
         _dataPlanVersion = dataPlanVersion;
+        _apiKey = apiKey;
+        _apiSecret = apiSecret;
     }
     
     return self;
@@ -70,8 +73,9 @@
                                                      timestamp:_timestamp
                                                     uploadType:_uploadType
                                                     dataPlanId:[_dataPlanId copy]
-                                               dataPlanVersion:[_dataPlanVersion copy]];
-    
+                                               dataPlanVersion:[_dataPlanVersion copy]
+                                                        apiKey:[_apiKey copy]
+                                                     apiSecret:[_apiSecret copy]];
     return copyObject;
 }
 

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -1,10 +1,102 @@
 #import "MPUpload.h"
 #import "MPSession.h"
 #import "MPIConstants.h"
+#import "mParticle.h"
+#import "MPStateMachine.h"
+
+@interface MParticle()
+@property (nonatomic, strong) MPStateMachine *stateMachine;
+@end
+
+@implementation MPUploadSettings
+
++ (MPUploadSettings *)currentUploadSettings {
+    MParticle *mParticle = [MParticle sharedInstance];
+    MPUploadSettings *uploadSettings = [[MPUploadSettings alloc] initWithApiKey:mParticle.stateMachine.apiKey
+                                                                         secret:mParticle.stateMachine.secret
+                                                                     eventsHost:mParticle.networkOptions.eventsHost
+                                                             eventsTrackingHost:mParticle.networkOptions.eventsTrackingHost
+                                                    overridesEventsSubdirectory:mParticle.networkOptions.overridesEventsSubdirectory
+                                                                      aliasHost:mParticle.networkOptions.aliasHost
+                                                              aliasTrackingHost:mParticle.networkOptions.aliasTrackingHost
+                                                     overridesAliasSubdirectory:mParticle.networkOptions.overridesAliasSubdirectory
+                                                                     eventsOnly:mParticle.networkOptions.eventsOnly];
+    return uploadSettings;
+}
+
+- (instancetype)initWithApiKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret eventsHost:(nullable NSString *)eventsHost eventsTrackingHost:(nullable NSString *)eventsTrackingHost overridesEventsSubdirectory:(BOOL)overridesEventsSubdirectory aliasHost:(nullable NSString *)aliasHost aliasTrackingHost:(nullable NSString *)aliasTrackingHost overridesAliasSubdirectory:(BOOL)overridesAliasSubdirectory eventsOnly:(BOOL)eventsOnly {
+    if (self = [super init]) {
+        _apiKey = apiKey;
+        _secret = secret;
+        _eventsHost = eventsHost;
+        _eventsTrackingHost = eventsTrackingHost;
+        _overridesEventsSubdirectory = overridesEventsSubdirectory;
+        _aliasHost = aliasHost;
+        _aliasTrackingHost = aliasTrackingHost;
+        _overridesAliasSubdirectory = overridesAliasSubdirectory;
+        _eventsOnly = eventsOnly;
+    }
+    return self;
+}
+
+static NSString * const kApiKey = @"apiKey";
+static NSString * const kSecret = @"secret";
+static NSString * const kEventsHost = @"eventsHost";
+static NSString * const kEventsTrackingHost = @"eventsTrackingHost";
+static NSString * const kOverridesEventsSubdirectory = @"overridesEventsSubdirectory";
+static NSString * const kAliasHost = @"aliasHost";
+static NSString * const kAliasTrackingHost = @"aliasTrackingHost";
+static NSString * const kOverridesAliasSubdirectory = @"overridesAliasSubdirectory";
+static NSString * const kEventsOnly = @"eventsOnly";
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
+    if (self = [super init]) {
+        _apiKey = [coder decodeObjectForKey:kApiKey];
+        _secret = [coder decodeObjectForKey:kSecret];
+        _eventsHost = [coder decodeObjectForKey:kEventsHost];
+        _eventsTrackingHost = [coder decodeObjectForKey:kEventsTrackingHost];
+        _overridesEventsSubdirectory = [coder decodeBoolForKey:kOverridesEventsSubdirectory];
+        _aliasHost = [coder decodeObjectForKey:kAliasHost];
+        _aliasTrackingHost = [coder decodeObjectForKey:kAliasTrackingHost];
+        _overridesAliasSubdirectory = [coder decodeBoolForKey:kOverridesAliasSubdirectory];
+        _eventsOnly = [coder decodeBoolForKey:kEventsOnly];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)coder {
+    [coder encodeObject:_apiKey forKey:kApiKey];
+    [coder encodeObject:_secret forKey:kSecret];
+    [coder encodeObject:_eventsHost forKey:kEventsHost];
+    [coder encodeObject:_eventsTrackingHost forKey:kEventsTrackingHost];
+    [coder encodeBool:_overridesEventsSubdirectory forKey:kOverridesEventsSubdirectory];
+    [coder encodeObject:_aliasHost forKey:kAliasHost];
+    [coder encodeObject:_aliasTrackingHost forKey:kAliasTrackingHost];
+    [coder encodeBool:_overridesAliasSubdirectory forKey:kOverridesAliasSubdirectory];
+    [coder encodeBool:_eventsOnly forKey:kEventsOnly];
+}
+
++ (BOOL)supportsSecureCoding {
+    return TRUE;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    return [[MPUploadSettings alloc] initWithApiKey:_apiKey
+                                             secret:_secret
+                                         eventsHost:_eventsHost
+                                 eventsTrackingHost:_eventsTrackingHost
+                        overridesEventsSubdirectory:_overridesEventsSubdirectory
+                                          aliasHost:_aliasHost
+                                  aliasTrackingHost:_aliasTrackingHost
+                         overridesAliasSubdirectory:_overridesAliasSubdirectory
+                                         eventsOnly:_eventsOnly];
+}
+
+@end
 
 @implementation MPUpload
 
-- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadDictionary:(NSDictionary *)uploadDictionary dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion apiKey:(nonnull NSString *)apiKey apiSecret:(nonnull NSString *)apiSecret {
+- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadDictionary:(NSDictionary *)uploadDictionary dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion uploadSettings:(nonnull MPUploadSettings *)uploadSettings {
     NSData *uploadData = [NSJSONSerialization dataWithJSONObject:uploadDictionary options:0 error:nil];
     return [self initWithSessionId:sessionId
                           uploadId:0
@@ -14,11 +106,10 @@
                         uploadType:MPUploadTypeMessage
                         dataPlanId:dataPlanId
                    dataPlanVersion:dataPlanVersion
-                            apiKey:apiKey
-                         apiSecret:apiSecret];
+                    uploadSettings:uploadSettings];
 }
 
-- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadId:(int64_t)uploadId UUID:(NSString *)uuid uploadData:(NSData *)uploadData timestamp:(NSTimeInterval)timestamp uploadType:(MPUploadType)uploadType dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion apiKey:(nonnull NSString *)apiKey apiSecret:(nonnull NSString *)apiSecret {
+- (instancetype)initWithSessionId:(NSNumber *)sessionId uploadId:(int64_t)uploadId UUID:(NSString *)uuid uploadData:(NSData *)uploadData timestamp:(NSTimeInterval)timestamp uploadType:(MPUploadType)uploadType dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion uploadSettings:(nonnull MPUploadSettings *)uploadSettings {
     self = [super init];
     if (self) {
         _sessionId = sessionId;
@@ -30,8 +121,7 @@
         _containsOptOutMessage = NO;
         _dataPlanId = dataPlanId;
         _dataPlanVersion = dataPlanVersion;
-        _apiKey = apiKey;
-        _apiSecret = apiSecret;
+        _uploadSettings = uploadSettings;
     }
     
     return self;
@@ -74,8 +164,7 @@
                                                     uploadType:_uploadType
                                                     dataPlanId:[_dataPlanId copy]
                                                dataPlanVersion:[_dataPlanVersion copy]
-                                                        apiKey:[_apiKey copy]
-                                                     apiSecret:[_apiSecret copy]];
+                                                uploadSettings:[_uploadSettings copy]];
     return copyObject;
 }
 

--- a/mParticle-Apple-SDK/Identity/MPIdentityApi.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApi.m
@@ -486,7 +486,9 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
                                                          timestamp:[NSDate date].timeIntervalSince1970
                                                         uploadType:MPUploadTypeAlias
                                                         dataPlanId:[MParticle sharedInstance].dataPlanId
-                                                   dataPlanVersion:[MParticle sharedInstance].dataPlanVersion];
+                                                   dataPlanVersion:[MParticle sharedInstance].dataPlanVersion
+                                                            apiKey:[MParticle sharedInstance].stateMachine.apiKey
+                                                         apiSecret:[MParticle sharedInstance].stateMachine.secret];
             
             [MParticle.sharedInstance.persistenceController saveUpload:upload];
             [MParticle.sharedInstance.backendController waitForKitsAndUploadWithCompletionHandler:nil];

--- a/mParticle-Apple-SDK/Identity/MPIdentityApi.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApi.m
@@ -487,8 +487,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
                                                         uploadType:MPUploadTypeAlias
                                                         dataPlanId:[MParticle sharedInstance].dataPlanId
                                                    dataPlanVersion:[MParticle sharedInstance].dataPlanVersion
-                                                            apiKey:[MParticle sharedInstance].stateMachine.apiKey
-                                                         apiSecret:[MParticle sharedInstance].stateMachine.secret];
+                                                    uploadSettings:[MPUploadSettings currentUploadSettings]];
             
             [MParticle.sharedInstance.persistenceController saveUpload:upload];
             [MParticle.sharedInstance.backendController waitForKitsAndUploadWithCompletionHandler:nil];

--- a/mParticle-Apple-SDK/MPBackendController.h
+++ b/mParticle-Apple-SDK/MPBackendController.h
@@ -104,6 +104,7 @@ extern const NSInteger kInvalidKey;
 - (MPExecStatus)waitForKitsAndUploadWithCompletionHandler:(void (^ _Nullable)(void))completionHandler;
 - (nonnull NSMutableDictionary<NSString *, id> *)userAttributesForUserId:(nonnull NSNumber *)userId;
 - (nonnull NSMutableArray<NSDictionary<NSString *, id> *> *)userIdentitiesForUserId:(nonnull NSNumber *)userId;
+- (void)prepareBatchesForUpload;
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -662,7 +662,6 @@ static BOOL skipNextUpload = NO;
 
 - (void)prepareBatchesForUpload {
     MPPersistenceController *persistence = [MParticle sharedInstance].persistenceController;
-    MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;
     
     //Fetch all stored messages (1)
     NSDictionary *mpidMessages = [persistence fetchMessagesForUploading];
@@ -681,7 +680,14 @@ static BOOL skipNextUpload = NO;
                         
                         for (int i = 0; i < batchMessageArrays.count; i += 1) {
                             NSArray *limitedMessages = batchMessageArrays[i];
-                            MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid sessionId:nullableSessionID messages:limitedMessages sessionTimeout:self.sessionTimeout uploadInterval:self.uploadInterval dataPlanId:nullableDataPlanId dataPlanVersion:nullableDataPlanVersion apiKey:stateMachine.apiKey apiSecret:stateMachine.secret];
+                            MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid
+                                                                                         sessionId:nullableSessionID
+                                                                                          messages:limitedMessages
+                                                                                    sessionTimeout:self.sessionTimeout
+                                                                                    uploadInterval:self.uploadInterval
+                                                                                        dataPlanId:nullableDataPlanId
+                                                                                   dataPlanVersion:nullableDataPlanVersion
+                                                                                    uploadSettings:[MPUploadSettings currentUploadSettings]];
                             [uploadBuilder withUserAttributes:[self userAttributesForUserId:mpid] deletedUserAttributes:self.deletedUserAttributes];
                             [uploadBuilder withUserIdentities:[self userIdentitiesForUserId:mpid]];
                             [uploadBuilder build:^(MPUpload *upload) {

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1545,7 +1545,6 @@ static BOOL skipNextUpload = NO;
         
         MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeFirstRun session:self.session messageInfo:nil];
                 
-        // TODO: BEN - This needs to handle cases where the workspace changed
         [self processOpenSessionsEndingCurrent:NO completionHandler:^(void) {}];
         
         [self beginUploadTimer];

--- a/mParticle-Apple-SDK/Network/MPConnector.h
+++ b/mParticle-Apple-SDK/Network/MPConnector.h
@@ -36,6 +36,6 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
 @interface MPConnector : NSObject<MPConnectorProtocol>
 
 - (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromGetRequestToURL:(nonnull MPURL *)url;
-- (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams;
+- (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams secret:(nullable NSString *)secret;
 
 @end

--- a/mParticle-Apple-SDK/Network/MPConnector.m
+++ b/mParticle-Apple-SDK/Network/MPConnector.m
@@ -240,10 +240,10 @@ static NSArray *mpStoredCertificates = nil;
     return response;
 }
 
-- (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams {
+- (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams secret:(nullable NSString *)secret {
     MPConnectorResponse *response = [[MPConnectorResponse alloc] init];
     
-    NSMutableURLRequest *urlRequest = [[[MPURLRequestBuilder newBuilderWithURL:url message:message httpMethod:kMPHTTPMethodPost] withPostData:serializedParams] build];
+    NSMutableURLRequest *urlRequest = [[[[MPURLRequestBuilder newBuilderWithURL:url message:message httpMethod:kMPHTTPMethodPost] withPostData:serializedParams] withSecret:secret] build];
     
     if (urlRequest) {
         requestStartTime = [NSDate date];

--- a/mParticle-Apple-SDK/Network/MPConnectorProtocol.h
+++ b/mParticle-Apple-SDK/Network/MPConnectorProtocol.h
@@ -7,7 +7,7 @@
 @protocol MPConnectorProtocol<NSObject>
 
 - (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromGetRequestToURL:(nonnull MPURL *)url;
-- (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams;
+- (nonnull NSObject<MPConnectorResponseProtocol> *)responseFromPostRequestToURL:(nonnull MPURL *)url message:(nullable NSString *)message serializedParams:(nullable NSData *)serializedParams secret:(nullable NSString *)secret;
 
 @end
 

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+@class MPURL;
 @class MPSession;
 @class MPUpload;
 @class MPIdentityApiRequest;
@@ -24,6 +25,14 @@ typedef void (^MPIdentityApiManagerModifyCallback)(MPIdentityHTTPModifySuccessRe
 typedef void(^ _Nonnull MPConfigCompletionHandler)(BOOL success);
 
 @interface MPNetworkCommunication : NSObject
+
+@property (nonatomic, strong, readonly, nonnull) MPURL *configURL;
+@property (nonatomic, strong, readonly, nonnull) MPURL *identifyURL;
+@property (nonatomic, strong, readonly, nonnull) MPURL *loginURL;
+@property (nonatomic, strong, readonly, nonnull) MPURL *logoutURL;
+@property (nonatomic, strong, readonly, nonnull) MPURL *modifyURL;
+- (nonnull MPURL *)eventURLForUpload:(nonnull MPUpload *)mpUpload;
+- (nonnull MPURL *)aliasURLForUpload:(nonnull MPUpload *)mpUpload;
 
 + (void)setConnectorFactory:(NSObject<MPConnectorFactoryProtocol> *_Nullable)connectorFactory;
 + (NSObject<MPConnectorFactoryProtocol> *_Nullable)connectorFactory;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.h
@@ -26,13 +26,13 @@ typedef void(^ _Nonnull MPConfigCompletionHandler)(BOOL success);
 
 @interface MPNetworkCommunication : NSObject
 
-@property (nonatomic, strong, readonly, nonnull) MPURL *configURL;
-@property (nonatomic, strong, readonly, nonnull) MPURL *identifyURL;
-@property (nonatomic, strong, readonly, nonnull) MPURL *loginURL;
-@property (nonatomic, strong, readonly, nonnull) MPURL *logoutURL;
-@property (nonatomic, strong, readonly, nonnull) MPURL *modifyURL;
-- (nonnull MPURL *)eventURLForUpload:(nonnull MPUpload *)mpUpload;
-- (nonnull MPURL *)aliasURLForUpload:(nonnull MPUpload *)mpUpload;
+@property (nonatomic, strong, readonly, nullable) MPURL *configURL;
+@property (nonatomic, strong, readonly, nullable) MPURL *identifyURL;
+@property (nonatomic, strong, readonly, nullable) MPURL *loginURL;
+@property (nonatomic, strong, readonly, nullable) MPURL *logoutURL;
+@property (nonatomic, strong, readonly, nullable) MPURL *modifyURL;
+- (nullable MPURL *)eventURLForUpload:(nonnull MPUpload *)mpUpload;
+- (nullable MPURL *)aliasURLForUpload:(nonnull MPUpload *)mpUpload;
 
 + (void)setConnectorFactory:(NSObject<MPConnectorFactoryProtocol> *_Nullable)connectorFactory;
 + (NSObject<MPConnectorFactoryProtocol> *_Nullable)connectorFactory;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -84,14 +84,6 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 @interface MPNetworkCommunication()
 
-@property (nonatomic, strong, readonly) MPURL *configURL;
-@property (nonatomic, strong, readonly) MPURL *identifyURL;
-@property (nonatomic, strong, readonly) MPURL *loginURL;
-@property (nonatomic, strong, readonly) MPURL *logoutURL;
-@property (nonatomic, strong, readonly) MPURL *modifyURL;
-- (MPURL *)eventURLForUpload:(MPUpload *)mpUpload;
-- (MPURL *)aliasURLForUpload:(MPUpload *)mpUpload;
-
 @property (nonatomic, strong) NSString *context;
 @property (nonatomic) BOOL identifying;
 

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -857,7 +857,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:mpURL
                                                                                           message:nil
                                                                                  serializedParams:data 
-                                                                                           secret:upload.uploadSettings.secret];
+                                                                                           secret:nil];
         
         NSData *responseData = response.data;
         error = response.error;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -857,7 +857,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:mpURL
                                                                                           message:nil
                                                                                  serializedParams:data 
-                                                                                           secret:nil];
+                                                                                           secret:upload.uploadSettings.secret];
         
         NSData *responseData = response.data;
         error = response.error;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -573,8 +573,9 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     [MPListenerController.sharedInstance onNetworkRequestStarted:MPEndpointEvents url:eventURL.url.absoluteString body:@[uploadString, zipUploadData]];
     
     NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:eventURL
-                                                                    message:uploadString
-                                                           serializedParams:zipUploadData];
+                                                                                      message:uploadString
+                                                                             serializedParams:zipUploadData
+                                                                                       secret:upload.uploadSettings.secret];
     NSData *data = response.data;
     NSHTTPURLResponse *httpResponse = response.httpResponse;
     
@@ -646,8 +647,9 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     [MPListenerController.sharedInstance onNetworkRequestStarted:MPEndpointAlias url:aliasURL.url.absoluteString body:@[uploadString, upload.uploadData]];
     
     NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:aliasURL
-                                                                    message:uploadString
-                                                           serializedParams:upload.uploadData];
+                                                                                      message:uploadString
+                                                                             serializedParams:upload.uploadData
+                                                                                       secret:upload.uploadSettings.secret];
     NSData *data = response.data;
     NSHTTPURLResponse *httpResponse = response.httpResponse;
     
@@ -853,8 +855,9 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         
         NSObject<MPConnectorProtocol> *connector = [self makeConnector];
         NSObject<MPConnectorResponseProtocol> *response = [connector responseFromPostRequestToURL:mpURL
-                                                                        message:nil
-                                                               serializedParams:data];
+                                                                                          message:nil
+                                                                                 serializedParams:data 
+                                                                                           secret:nil];
         
         NSData *responseData = response.data;
         error = response.error;

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -204,7 +204,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     }
     
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
-    MPURL *eventURL = nil;
+    MPURL *eventURL;
     if (modifiedURL && defaultURL) {
         eventURL = [[MPURL alloc] initWithURL:modifiedURL defaultURL:defaultURL];
     }
@@ -328,7 +328,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     defaultURL.accessibilityHint = @"identity";
     modifiedURL.accessibilityHint = @"identity";
     
-    MPURL *aliasURL = nil;
+    MPURL *aliasURL;
     if (modifiedURL && defaultURL) {
         aliasURL = [[MPURL alloc] initWithURL:modifiedURL defaultURL:defaultURL];
     }

--- a/mParticle-Apple-SDK/Network/MPURLRequestBuilder.h
+++ b/mParticle-Apple-SDK/Network/MPURLRequestBuilder.h
@@ -15,6 +15,7 @@
 - (nonnull MPURLRequestBuilder *)withHeaderData:(nullable NSData *)headerData;
 - (nonnull MPURLRequestBuilder *)withHttpMethod:(nonnull NSString *)httpMethod;
 - (nonnull MPURLRequestBuilder *)withPostData:(nullable NSData *)postData;
+- (nonnull MPURLRequestBuilder *)withSecret:(nullable NSString *)secret;
 - (nonnull NSMutableURLRequest *)build;
 
 @end

--- a/mParticle-Apple-SDK/Persistence/MPDatabaseMigrationController.m
+++ b/mParticle-Apple-SDK/Persistence/MPDatabaseMigrationController.m
@@ -290,7 +290,7 @@
     } else if (oldVersionValue < 31) {
         selectStatement = "SELECT uuid, message_data, timestamp, session_id, upload_type, data_plan_id, data_plan_version FROM uploads ORDER BY _id";
     } else {
-        selectStatement = "SELECT uuid, message_data, timestamp, session_id, upload_type, data_plan_id, data_plan_version, api_key, api_secret FROM uploads ORDER BY _id";
+        selectStatement = "SELECT uuid, message_data, timestamp, session_id, upload_type, data_plan_id, data_plan_version, upload_settings FROM uploads ORDER BY _id";
     }
     
     insertStatement = "INSERT INTO uploads (uuid, message_data, timestamp, session_id, upload_type, data_plan_id, data_plan_version, upload_settings) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.h
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.h
@@ -67,6 +67,7 @@
 - (void)updateConsumerInfo:(nonnull MPConsumerInfo *)consumerInfo;
 - (void)updateSession:(nonnull MPSession *)session;
 - (nonnull NSDictionary<NSString *, NSDictionary *> *)appAndDeviceInfoForSessionId:(nonnull NSNumber *)sessionId;
+- (void)clearDatabaseForWorkspaceSwitching;
 
 @end
 

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.h
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.h
@@ -67,7 +67,7 @@
 - (void)updateConsumerInfo:(nonnull MPConsumerInfo *)consumerInfo;
 - (void)updateSession:(nonnull MPSession *)session;
 - (nonnull NSDictionary<NSString *, NSDictionary *> *)appAndDeviceInfoForSessionId:(nonnull NSNumber *)sessionId;
-- (void)clearDatabaseForWorkspaceSwitching;
+- (void)resetDatabaseForWorkspaceSwitching;
 
 @end
 

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -251,7 +251,7 @@ const int MaxBreadcrumbs = 50;
     [self removeDatabase];
 }
 
-- (void)clearDatabaseForWorkspaceSwitching {
+- (void)resetDatabaseForWorkspaceSwitching {
     [self openDatabase];
     
     // Delete all records except uploads
@@ -276,6 +276,8 @@ const int MaxBreadcrumbs = 50;
             MPILogError("Problem clearing table for workspace switching: %s\n", sqlStatement.c_str());
         }
     }
+    
+    [self closeDatabase];
 }
 
 - (void)saveCookie:(MPCookie *)cookie forConsumerInfo:(MPConsumerInfo *)consumerInfo {

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -251,6 +251,33 @@ const int MaxBreadcrumbs = 50;
     [self removeDatabase];
 }
 
+- (void)clearDatabaseForWorkspaceSwitching {
+    [self openDatabase];
+    
+    // Delete all records except uploads
+    vector<string> sqlStatements = {
+        "DELETE FROM sessions",
+        "DELETE FROM previous_session",
+        "DELETE FROM messages",
+        "DELETE FROM breadcrumbs",
+        "DELETE FROM consumer_info",
+        "DELETE FROM cookies",
+        "DELETE FROM product_bags",
+        "DELETE FROM forwarding_records",
+        "DELETE FROM integration_attributes"
+    };
+    
+    int status;
+    char *errMsg;
+    for (const auto &sqlStatement : sqlStatements) {
+        status = sqlite3_exec(mParticleDB, sqlStatement.c_str(), NULL, NULL, &errMsg);
+        
+        if (status != SQLITE_OK) {
+            MPILogError("Problem clearing table for workspace switching: %s\n", sqlStatement.c_str());
+        }
+    }
+}
+
 - (void)saveCookie:(MPCookie *)cookie forConsumerInfo:(MPConsumerInfo *)consumerInfo {
     sqlite3_stmt *preparedStatement;
     
@@ -406,9 +433,6 @@ const int MaxBreadcrumbs = 50;
             session_number INTEGER NOT NULL, \
             mpid INTEGER NOT NULL \
         )",
-        "DROP TABLE IF EXISTS standalone_messages",
-        "DROP TABLE IF EXISTS standalone_uploads",
-        "DROP TABLE IF EXISTS remote_notifications",
         "CREATE TABLE IF NOT EXISTS consumer_info ( \
             _id INTEGER PRIMARY KEY AUTOINCREMENT, \
             mpid INTEGER, \

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.h
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.h
@@ -2,6 +2,7 @@
 
 @class MPMessage;
 @class MPUpload;
+@class MPUploadSettings;
 @class MPSession;
 
 @interface MPUploadBuilder : NSObject
@@ -16,8 +17,8 @@
                       uploadInterval:(NSTimeInterval)uploadInterval
                           dataPlanId:(nullable NSString *)dataPlanId
                      dataPlanVersion:(nullable NSNumber *)dataPlanVersion
-                              apiKey:(nonnull NSString *)apiKey
-                           apiSecret:(nonnull NSString *)apiSecret;
+                      uploadSettings:(nonnull MPUploadSettings *)uploadSettings;
+
 - (void)build:(void (^ _Nonnull)(MPUpload * _Nullable upload))completionHandler;
 - (nonnull MPUploadBuilder *)withUserAttributes:(nonnull NSDictionary<NSString *, id> *)userAttributes deletedUserAttributes:(nullable NSSet<NSString *> *)deletedUserAttributes;
 - (nonnull MPUploadBuilder *)withUserIdentities:(nonnull NSArray<NSDictionary<NSString *, id> *> *)userIdentities;

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.h
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.h
@@ -15,7 +15,9 @@
                       sessionTimeout:(NSTimeInterval)sessionTimeout
                       uploadInterval:(NSTimeInterval)uploadInterval
                           dataPlanId:(nullable NSString *)dataPlanId
-                     dataPlanVersion:(nullable NSNumber *)dataPlanVersion;
+                     dataPlanVersion:(nullable NSNumber *)dataPlanVersion
+                              apiKey:(nonnull NSString *)apiKey
+                           apiSecret:(nonnull NSString *)apiSecret;
 - (void)build:(void (^ _Nonnull)(MPUpload * _Nullable upload))completionHandler;
 - (nonnull MPUploadBuilder *)withUserAttributes:(nonnull NSDictionary<NSString *, id> *)userAttributes deletedUserAttributes:(nullable NSSet<NSString *> *)deletedUserAttributes;
 - (nonnull MPUploadBuilder *)withUserIdentities:(nonnull NSArray<NSDictionary<NSString *, id> *> *)userIdentities;

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.h
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.h
@@ -9,18 +9,6 @@
 @property (nonatomic, strong, readonly, nullable) NSNumber *sessionId;
 @property (nonatomic, strong, readonly, nonnull) NSMutableArray<NSNumber *> *preparedMessageIds;
 
-+ (nonnull MPUploadBuilder *)newBuilderWithMpid:(nonnull NSNumber *)mpid
-                                       messages:(nonnull NSArray<MPMessage *> *)messages
-                                 uploadInterval:(NSTimeInterval)uploadInterval
-                                     dataPlanId:(nullable NSString *)dataPlanId
-                                dataPlanVersion:(nullable NSNumber *)dataPlanVersion;
-+ (nonnull MPUploadBuilder *)newBuilderWithMpid:(nonnull NSNumber *)mpid
-                                      sessionId:(nullable NSNumber *)sessionId
-                                       messages:(nonnull NSArray<MPMessage *> *)messages
-                                 sessionTimeout:(NSTimeInterval)sessionTimeout
-                                 uploadInterval:(NSTimeInterval)uploadInterval
-                                     dataPlanId:(nullable NSString *)dataPlanId
-                                dataPlanVersion:(nullable NSNumber *)dataPlanVersion;
 - (nonnull instancetype)initWithMpid:(nonnull NSNumber *)mpid
                            sessionId:(nullable NSNumber *)sessionId
                             messages:(nonnull NSArray<MPMessage *> *)messages

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
@@ -129,17 +129,6 @@
     return description;
 }
 
-#pragma mark Public class methods
-+ (nonnull MPUploadBuilder *)newBuilderWithMpid: (nonnull NSNumber *) mpid messages:(nonnull NSArray<MPMessage *> *)messages uploadInterval:(NSTimeInterval)uploadInterval dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion{
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid sessionId:nil messages:messages sessionTimeout:0 uploadInterval:uploadInterval dataPlanId:dataPlanId dataPlanVersion:dataPlanVersion];
-    return uploadBuilder;
-}
-
-+ (nonnull MPUploadBuilder *)newBuilderWithMpid: (nonnull NSNumber *) mpid sessionId:(nullable NSNumber *)sessionId messages:(nonnull NSArray<MPMessage *> *)messages sessionTimeout:(NSTimeInterval)sessionTimeout uploadInterval:(NSTimeInterval)uploadInterval dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion {
-    MPUploadBuilder *uploadBuilder = [[MPUploadBuilder alloc] initWithMpid:mpid sessionId:sessionId messages:messages sessionTimeout:sessionTimeout uploadInterval:uploadInterval dataPlanId:dataPlanId dataPlanVersion:dataPlanVersion];
-    return uploadBuilder;
-}
-
 #pragma mark Public instance methods
 - (void)build:(void (^)(MPUpload *upload))completionHandler {
     MPStateMachine *stateMachine = [MParticle sharedInstance].stateMachine;

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
@@ -30,17 +30,22 @@
     BOOL containsOptOutMessage;
     NSString *dPId;
     NSNumber *dPVersion;
+    NSString *aKey;
+    NSString *aSecret;
 }
 
 @end
 
 @implementation MPUploadBuilder
 
-- (nonnull instancetype)initWithMpid: (nonnull NSNumber *) mpid sessionId:(nullable NSNumber *)sessionId messages:(nonnull NSArray<MPMessage *> *)messages sessionTimeout:(NSTimeInterval)sessionTimeout uploadInterval:(NSTimeInterval)uploadInterval dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion {
+- (nonnull instancetype)initWithMpid: (nonnull NSNumber *) mpid sessionId:(nullable NSNumber *)sessionId messages:(nonnull NSArray<MPMessage *> *)messages sessionTimeout:(NSTimeInterval)sessionTimeout uploadInterval:(NSTimeInterval)uploadInterval dataPlanId:(nullable NSString *)dataPlanId dataPlanVersion:(nullable NSNumber *)dataPlanVersion apiKey:(nonnull NSString *)apiKey apiSecret:(nonnull NSString *)apiSecret {
     self = [super init];
     if (!self || !messages || messages.count == 0) {
         return nil;
     }
+    
+    aKey = apiKey;
+    aSecret = apiSecret;
     
     _sessionId = sessionId;
     containsOptOutMessage = NO;
@@ -239,7 +244,7 @@
         }
     }
     
-    MPUpload *upload = [[MPUpload alloc] initWithSessionId:_sessionId uploadDictionary:uploadDictionary dataPlanId:dPId dataPlanVersion:dPVersion];
+    MPUpload *upload = [[MPUpload alloc] initWithSessionId:_sessionId uploadDictionary:uploadDictionary dataPlanId:dPId dataPlanVersion:dPVersion apiKey:aKey apiSecret:aSecret];
     upload.containsOptOutMessage = containsOptOutMessage;
     completionHandler(upload);
 }


### PR DESCRIPTION
 ## Summary
This is an updated implementation of workspace switching. This significantly reduces the amount of time it will take to switch workspaces, since only upload batching is performed before the switch, and any remaining batches are uploaded later.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested extensively using a test app sending events to two different workspaces in addition to unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6593
