### PR TITLE
fix: Properly attribute events when workspace switches on new launch

### DIFF
--- a/mParticle-Apple-SDK/Data Model/MPUpload.h
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.h
@@ -3,6 +3,7 @@
 #import "MPEnums.h"
 
 @class MPSession;
+@class MPNetworkOptions;
 
 // Upload credentials and options
 @interface MPUploadSettings : NSObject <NSCopying, NSSecureCoding>
@@ -19,6 +20,8 @@
 + (nonnull MPUploadSettings *)currentUploadSettings;
 
 - (nonnull instancetype)initWithApiKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret eventsHost:(nullable NSString *)eventsHost eventsTrackingHost:(nullable NSString *)eventsTrackingHost overridesEventsSubdirectory:(BOOL)overridesEventsSubdirectory aliasHost:(nullable NSString *)aliasHost aliasTrackingHost:(nullable NSString *)aliasTrackingHost overridesAliasSubdirectory:(BOOL)overridesAliasSubdirectory eventsOnly:(BOOL)eventsOnly;
+
+- (nonnull instancetype)initWithApiKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret networkOptions:(nullable MPNetworkOptions *)networkOptions;
 
 @end
 

--- a/mParticle-Apple-SDK/Data Model/MPUpload.m
+++ b/mParticle-Apple-SDK/Data Model/MPUpload.m
@@ -14,13 +14,7 @@
     MParticle *mParticle = [MParticle sharedInstance];
     MPUploadSettings *uploadSettings = [[MPUploadSettings alloc] initWithApiKey:mParticle.stateMachine.apiKey
                                                                          secret:mParticle.stateMachine.secret
-                                                                     eventsHost:mParticle.networkOptions.eventsHost
-                                                             eventsTrackingHost:mParticle.networkOptions.eventsTrackingHost
-                                                    overridesEventsSubdirectory:mParticle.networkOptions.overridesEventsSubdirectory
-                                                                      aliasHost:mParticle.networkOptions.aliasHost
-                                                              aliasTrackingHost:mParticle.networkOptions.aliasTrackingHost
-                                                     overridesAliasSubdirectory:mParticle.networkOptions.overridesAliasSubdirectory
-                                                                     eventsOnly:mParticle.networkOptions.eventsOnly];
+                                                                 networkOptions:mParticle.networkOptions];
     return uploadSettings;
 }
 
@@ -37,6 +31,18 @@
         _eventsOnly = eventsOnly;
     }
     return self;
+}
+
+- (nonnull instancetype)initWithApiKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret networkOptions:(MPNetworkOptions *)networkOptions {
+    return [self initWithApiKey:apiKey
+                         secret:secret
+                     eventsHost:networkOptions.eventsHost
+             eventsTrackingHost:networkOptions.eventsTrackingHost
+    overridesEventsSubdirectory:networkOptions.overridesEventsSubdirectory
+                      aliasHost:networkOptions.aliasHost
+              aliasTrackingHost:networkOptions.aliasTrackingHost
+     overridesAliasSubdirectory:networkOptions.overridesAliasSubdirectory
+                     eventsOnly:networkOptions.eventsOnly];        
 }
 
 static NSString * const kApiKey = @"apiKey";

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -343,7 +343,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  
  (Provided to accomodate certain advanced use cases. Most integrations of the SDK will not require modifying this property.)
  */
-@property (nonatomic, strong, readwrite) MPNetworkOptions *networkOptions;
+@property (nonatomic, strong, readwrite, nullable) MPNetworkOptions *networkOptions;
 
 /**
  Consent state.
@@ -572,7 +572,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  Allows you to proxy SDK traffic by overriding the default network endpoints and certificates used by the SDK.
  @see MParticleOptions
  */
-@property (nonatomic, readonly) MPNetworkOptions *networkOptions;
+@property (nonatomic, readonly, nullable) MPNetworkOptions *networkOptions;
  
  #if TARGET_OS_IOS == 1
  /**

--- a/mParticle-Apple-SDK/MPBackendController.h
+++ b/mParticle-Apple-SDK/MPBackendController.h
@@ -19,6 +19,8 @@
 @class MPCommerceEvent;
 @class MPConsentState;
 @class MParticleSession;
+@class MPUploadSettings;
+@class MPNetworkOptions;
 
 @protocol MPBackendControllerDelegate;
 
@@ -97,14 +99,14 @@ extern const NSInteger kInvalidKey;
 - (void)setUserAttribute:(nonnull NSString *)key values:(nullable NSArray<NSString *> *)values timestamp:(nonnull NSDate *)timestamp completionHandler:(void (^ _Nullable)(NSString * _Nonnull key, NSArray<NSString *> * _Nullable values, MPExecStatus execStatus))completionHandler;
 - (void)removeUserAttribute:(nonnull NSString *)key timestamp:(nonnull NSDate *)timestamp completionHandler:(void (^ _Nullable)(NSString * _Nullable key, id _Nullable value, MPExecStatus execStatus))completionHandler;
 - (void)setUserIdentity:(nullable NSString *)identityString identityType:(MPUserIdentity)identityType timestamp:(nonnull NSDate *)timestamp completionHandler:(void (^ _Nonnull)(NSString * _Nullable identityString, MPUserIdentity identityType, MPExecStatus execStatus))completionHandler;
-- (void)startWithKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret firstRun:(BOOL)firstRun installationType:(MPInstallationType)installationType proxyAppDelegate:(BOOL)proxyAppDelegate startKitsAsync:(BOOL)startKitsAsync consentState:(MPConsentState *_Nullable)consentState completionHandler:(dispatch_block_t _Nonnull)completionHandler;
+- (void)startWithKey:(nonnull NSString *)apiKey secret:(nonnull NSString *)secret networkOptions:(nullable MPNetworkOptions *)networkOptions firstRun:(BOOL)firstRun installationType:(MPInstallationType)installationType proxyAppDelegate:(BOOL)proxyAppDelegate startKitsAsync:(BOOL)startKitsAsync consentState:(MPConsentState *_Nullable)consentState completionHandler:(dispatch_block_t _Nonnull)completionHandler;
 - (void)unproxyOriginalAppDelegate;
 - (void)saveMessage:(nonnull MPMessage *)message updateSession:(BOOL)updateSession;
 - (void)skipNextUpload;
 - (MPExecStatus)waitForKitsAndUploadWithCompletionHandler:(void (^ _Nullable)(void))completionHandler;
 - (nonnull NSMutableDictionary<NSString *, id> *)userAttributesForUserId:(nonnull NSNumber *)userId;
 - (nonnull NSMutableArray<NSDictionary<NSString *, id> *> *)userIdentitiesForUserId:(nonnull NSNumber *)userId;
-- (void)prepareBatchesForUpload;
+- (void)prepareBatchesForUpload:(nonnull MPUploadSettings *)uploadSettings;
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1542,15 +1542,12 @@ static BOOL skipNextUpload = NO;
             // Different workspace, so batch previous messages under old upload settings before starting
             [self prepareBatchesForUpload:lastUploadSettings];
             
-            // Delete the stored upload settings
-            [[MPIUserDefaults standardUserDefaults] setLastUploadSettings:nil];
-            
             // Delete the cached config
             [MPResponseConfig deleteConfig];
         }
         
         // Cache the upload settings in case we switch workspaces on startup
-        MPUploadSettings *uploadSettings = [MPUploadSettings currentUploadSettings];
+        MPUploadSettings *uploadSettings = [[MPUploadSettings alloc] initWithApiKey:apiKey secret:secret networkOptions:networkOptions];
         [[MPIUserDefaults standardUserDefaults] setLastUploadSettings:uploadSettings];
         
         // Restore cached config if exists

--- a/mParticle-Apple-SDK/MPIConstants.h
+++ b/mParticle-Apple-SDK/MPIConstants.h
@@ -229,6 +229,7 @@ extern NSString * _Nonnull const kMPUserAgentValueUserDefaultsKey;
 extern NSString * _Nonnull const kMPFirstSeenUser;
 extern NSString * _Nonnull const kMPLastSeenUser;
 extern NSString * _Nonnull const kMPAppForePreviousForegroundTime;
+extern NSString * _Nonnull const kMPLastUploadSettingsUserDefaultsKey;
 
 // Remote configuration
 extern NSString * _Nonnull const kMPRemoteConfigExceptionHandlingModeKey;

--- a/mParticle-Apple-SDK/MPIConstants.m
+++ b/mParticle-Apple-SDK/MPIConstants.m
@@ -180,6 +180,7 @@ NSString *const kMPUserAgentValueUserDefaultsKey = @"UserAgentValue";
 NSString *const kMPFirstSeenUser = @"fsu";
 NSString *const kMPLastSeenUser = @"lsu";
 NSString *const kMPAppForePreviousForegroundTime = @"pft";
+NSString *const kMPLastUploadSettingsUserDefaultsKey = @"lastUploadSettings";
 
 // Remote configuration
 NSString *const kMPRemoteConfigExceptionHandlingModeKey = @"cue";

--- a/mParticle-Apple-SDK/Utils/MPIUserDefaults.h
+++ b/mParticle-Apple-SDK/Utils/MPIUserDefaults.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @class MPKitConfiguration;
+@class MPUploadSettings;
 
 @interface MPIUserDefaults : NSObject
 
@@ -29,6 +30,8 @@
 - (BOOL)isConfigurationParametersOutdated;
 - (void)setSideloadedKitsCount:(NSUInteger)sideloadedKitsCount;
 - (NSUInteger)sideloadedKitsCount;
+- (void)setLastUploadSettings:(nullable MPUploadSettings *)lastUploadSettings;
+- (nullable MPUploadSettings *)lastUploadSettings;
 
 + (NSString *_Nullable)stringFromDeviceToken:(NSData *_Nonnull)deviceToken;
 

--- a/mParticle-Apple-SDK/Utils/MPIUserDefaults.m
+++ b/mParticle-Apple-SDK/Utils/MPIUserDefaults.m
@@ -8,6 +8,7 @@
 #import "MPStateMachine.h"
 #import "MPKitContainer.h"
 #import "MParticleSwift.h"
+#import "MPUpload.h"
 
 @interface MParticle ()
 
@@ -432,6 +433,35 @@ static NSString *const NSUserDefaultsPrefix = @"mParticle::";
 
 - (NSUInteger)sideloadedKitsCount {
     return [[[NSUserDefaults standardUserDefaults] objectForKey:MPSideloadedKitsCountUserDefaultsKey] intValue];
+}
+
+- (void)setLastUploadSettings:(nullable MPUploadSettings *)lastUploadSettings {
+    if (!lastUploadSettings) {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kMPLastUploadSettingsUserDefaultsKey];
+        return;
+    }
+    
+    @try {
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:lastUploadSettings];
+        [[NSUserDefaults standardUserDefaults] setObject:data forKey:kMPLastUploadSettingsUserDefaultsKey];
+    } @catch(NSException *exception) {
+        MPILogError(@"Error serializing last upload settings: %@: %@", exception.name, exception.reason);
+        [self setLastUploadSettings:nil];
+    }
+}
+
+- (nullable MPUploadSettings *)lastUploadSettings {
+    NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:kMPLastUploadSettingsUserDefaultsKey];
+    if (data) {
+        @try {
+            MPUploadSettings *uploadSettings = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+            return uploadSettings;
+        } @catch(NSException *exception) {
+            MPILogError(@"Error deserializing last upload settings: %@: %@", exception.name, exception.reason);
+            [self setLastUploadSettings:nil];
+        }
+    }
+    return nil;
 }
 
 #pragma mark Objective-C Literals

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -24,6 +24,7 @@
 #import "MPDataPlanFilter.h"
 #import "MPResponseConfig.h"
 #import "MParticleSwift.h"
+#import "MPUpload.h"
 
 #if TARGET_OS_IOS == 1
 #ifndef MPARTICLE_LOCATION_DISABLE
@@ -74,7 +75,7 @@ static NSString *const kMPStateKey = @"state";
 @property (nonatomic, strong, nullable) MPKitActivity *kitActivity;
 @property (nonatomic) BOOL initialized;
 @property (nonatomic, strong, nonnull) NSMutableArray *kitsInitializedBlocks;
-@property (nonatomic, readwrite) MPNetworkOptions *networkOptions;
+@property (nonatomic, readwrite, nullable) MPNetworkOptions *networkOptions;
 @property (nonatomic, strong, nullable) NSArray<NSDictionary *> *deferredKitConfiguration;
 @property (nonatomic, strong) MParticleWebView *webView;
 @property (nonatomic, strong, nullable) NSString *dataPlanId;
@@ -613,6 +614,7 @@ static NSString *const kMPStateKey = @"state";
 
     [self.backendController startWithKey:apiKey
                                   secret:secret
+                          networkOptions:options.networkOptions
                                 firstRun:firstRun
                         installationType:installationType
                         proxyAppDelegate:proxyAppDelegate
@@ -765,7 +767,7 @@ static NSString *const kMPStateKey = @"state";
         
         // Batch any remaining messages into upload records
         [MParticle executeOnMessage:^{
-            [self.backendController prepareBatchesForUpload];
+            [self.backendController prepareBatchesForUpload:[MPUploadSettings currentUploadSettings]];
             finishReset();
         }];
     } else {


### PR DESCRIPTION
 ## Summary
 - While working on the previous workspace switching feature, I found this edge case where launching the app with a new workspace (instead of calling switchWorkspace while app is running) will result in any waiting, un-batched messages  to be uploaded to the new workspace instead of the previous one. 

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with 2 workspaces and confirmed un-batched events from previous workspace upload to the previous workspace as intended. 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6648
