### PR TITLE
fix: Prevent Repeated Sessions on active Background

### DIFF
--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -2092,7 +2092,7 @@ static BOOL skipNextUpload = NO;
         [MParticle executeOnMessage:^{
             [[MParticle sharedInstance].persistenceController updateSession:self.session];
             [self processOpenSessionsEndingCurrent:YES completionHandler:^(void) {
-                [self beginSession];
+                MPILogVerbose(@"Session ended in the background. New session will begin if an mParticle event is logged or app enters foreground.");
             }];
         }];
     }
@@ -2228,6 +2228,8 @@ static BOOL skipNextUpload = NO;
             [self updateSessionBackgroundTime];
         }
         
+        [self beginSession];
+
         #if TARGET_OS_IOS == 1
         #ifndef MPARTICLE_LOCATION_DISABLE
         [MParticle executeOnMain:^{


### PR DESCRIPTION
## Summary
 - Do not automatically start a new session after we close out an idle background session.

 ## Testing Plan
 - Tested in sample app using music player to test activity in background

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6724
