### PR TITLE
fix: Potential crash in MPStateMachine when entering foreground

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPStateMachine.m
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.m
@@ -106,31 +106,29 @@ static BOOL runningInBackground = NO;
         
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         
-        __weak MPStateMachine *weakSelf = self;
         dispatch_async(dispatch_get_main_queue(), ^{
-            __strong MPStateMachine *strongSelf = weakSelf;
             
-            strongSelf.storedSDKVersion = kMParticleSDKVersion;
+            self.storedSDKVersion = kMParticleSDKVersion;
             
-            [strongSelf.reachability startNotifier];
-            strongSelf.networkStatus = [strongSelf.reachability currentReachabilityStatus];
+            [self.reachability startNotifier];
+            self.networkStatus = [self.reachability currentReachabilityStatus];
             
-            [notificationCenter addObserver:strongSelf
+            [notificationCenter addObserver:self
                                    selector:@selector(handleApplicationDidEnterBackground:)
                                        name:UIApplicationDidEnterBackgroundNotification
                                      object:nil];
             
-            [notificationCenter addObserver:strongSelf
+            [notificationCenter addObserver:self
                                    selector:@selector(handleApplicationWillEnterForeground:)
                                        name:UIApplicationWillEnterForegroundNotification
                                      object:nil];
             
-            [notificationCenter addObserver:strongSelf
+            [notificationCenter addObserver:self
                                    selector:@selector(handleApplicationWillTerminate:)
                                        name:UIApplicationWillTerminateNotification
                                      object:nil];
             
-            [notificationCenter addObserver:strongSelf
+            [notificationCenter addObserver:self
                                    selector:@selector(handleReachabilityChanged:)
                                        name:MParticleReachabilityChangedNotification
                                      object:nil];
@@ -259,21 +257,11 @@ static BOOL runningInBackground = NO;
 - (void)handleApplicationDidEnterBackground:(NSNotification *)notification {
     [MPApplication updateLastUseDate:_launchDate];
     _backgrounded = YES;
-    
-    __weak MPStateMachine *weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __strong MPStateMachine *strongSelf = weakSelf;
-        strongSelf.launchInfo = nil;
-    });
+    self.launchInfo = nil;
 }
 
 - (void)handleApplicationWillEnterForeground:(NSNotification *)notification {
-    __weak MPStateMachine *weakSelf = self;
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __strong MPStateMachine *strongSelf = weakSelf;
-        strongSelf->_backgrounded = NO;
-    });
+    _backgrounded = NO;
 }
 
 - (void)handleApplicationWillTerminate:(NSNotification *)notification {


### PR DESCRIPTION
 ## Summary
Fix for potential crash in `MPStateMachine` when entering the foreground due to potential null pointer dereference. 

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.

Smoke tested E2E using test app including backgrounding/foregrounding

I also confirmed via logging pointers that the same object/pointer/address is passed into the `addObserver:` calls. 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6853
