### PR TITLE
fix: Fix set opt out for kits

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -2377,6 +2377,45 @@
     [kitWrapperMock verifyWithDelay:5.0];
 }
 
+- (void)testAttemptToSetOptOutToKitTrue {
+    MPKitContainer *localKitContainer = [[MPKitContainer alloc] init];
+    
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
+    id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
+    id kitRegisterMock = OCMPartialMock(kitRegister);
+    OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
+    MPKitFilter *kitFilter = [kitContainer filter:kitRegisterMock forEvent:nil selector:@selector(setOptOut:)];
+    
+    [(id <MPKitProtocol>)[kitWrapperMock expect] setOptOut:YES];
+    
+    MPForwardQueueParameters *optOutParameters = [[MPForwardQueueParameters alloc] init];
+    [optOutParameters addParameter:@(1)];
+    
+    [localKitContainer attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:@selector(setOptOut:) parameters:optOutParameters messageType:MPMessageTypeOptOut userInfo:@{@"state":@(1)}];
+    
+    [kitWrapperMock verifyWithDelay:5.0];
+}
+
+- (void)testAttemptToSetOptOutToKitFalse {
+    MPKitContainer *localKitContainer = [[MPKitContainer alloc] init];
+    
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
+    id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
+    id kitRegisterMock = OCMPartialMock(kitRegister);
+    OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
+    MPKitFilter *kitFilter = [kitContainer filter:kitRegisterMock forEvent:nil selector:@selector(setOptOut:)];
+    
+    [(id <MPKitProtocol>)[kitWrapperMock expect] setOptOut:FALSE];
+    
+    MPForwardQueueParameters *optOutParameters = [[MPForwardQueueParameters alloc] init];
+    NSNumber *optOutStatus = @(0);
+    [optOutParameters addParameter:optOutStatus];
+    
+    [localKitContainer attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:@selector(setOptOut:) parameters:optOutParameters messageType:MPMessageTypeOptOut userInfo:@{@"state":optOutStatus}];
+    
+    [kitWrapperMock verifyWithDelay:5.0];
+}
+
 - (void)testAttemptToLegacyOpenURLToKit {
     MPKitContainer *localKitContainer = [[MPKitContainer alloc] init];
     SEL selector = @selector(openURL:sourceApplication:annotation:);

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -2307,11 +2307,8 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                     NSNumber *timestamp = [parameters[1] isKindOfClass:[NSNumber class]] ? (NSNumber*)parameters[1] : nil;
                     execStatus = [kitRegister.wrapperInstance setATTStatus:status withATTStatusTimestampMillis:timestamp];
                 } else if (selector == @selector(setOptOut:)) {
-                    if (parameters.count == 1 && [parameters[0] boolValue]) {
-                        execStatus = [kitRegister.wrapperInstance setOptOut:true];
-                    } else {
-                        execStatus = [kitRegister.wrapperInstance setOptOut:false];
-                    }
+                    BOOL isOptOut = (parameters.count >= 1 && [parameters[0] boolValue]);
+                    execStatus = [kitRegister.wrapperInstance setOptOut:isOptOut];
                 } else if (parameters.count == 3) {
                     typedef MPKitExecStatus *(*send_type)(id, SEL, id, id, id);
                     send_type func = (send_type)objc_msgSend;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -2306,6 +2306,12 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                     MPATTAuthorizationStatus status = (MPATTAuthorizationStatus)[parameters[0] unsignedIntValue];
                     NSNumber *timestamp = [parameters[1] isKindOfClass:[NSNumber class]] ? (NSNumber*)parameters[1] : nil;
                     execStatus = [kitRegister.wrapperInstance setATTStatus:status withATTStatusTimestampMillis:timestamp];
+                } else if (selector == @selector(setOptOut:)) {
+                    if (parameters.count == 1 && [parameters[0] boolValue]) {
+                        execStatus = [kitRegister.wrapperInstance setOptOut:true];
+                    } else {
+                        execStatus = [kitRegister.wrapperInstance setOptOut:false];
+                    }
                 } else if (parameters.count == 3) {
                     typedef MPKitExecStatus *(*send_type)(id, SEL, id, id, id);
                     send_type func = (send_type)objc_msgSend;

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -450,9 +450,12 @@ static NSString *const kMPStateKey = @"state";
     self.stateMachine.optOut = optOut;
     
     // Forwarding calls to kits
+    MPForwardQueueParameters *optOutParameters = [[MPForwardQueueParameters alloc] init];
+    [optOutParameters addParameter:@(optOut)];
+    
     [[MParticle sharedInstance].kitContainer forwardSDKCall:@selector(setOptOut:)
                                                       event:nil
-                                                 parameters:nil
+                                                 parameters:optOutParameters
                                                 messageType:MPMessageTypeOptOut
                                                    userInfo:@{kMPStateKey:@(optOut)}
      ];


### PR DESCRIPTION
## Summary
 - Bool parameter on setOptOut was not being sent.

 ## Testing Plan
 - Tested locally on simulator and through unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6839
