### PR TITLE
fix: forward original event names to UI for kits with mapped events

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -70,8 +70,6 @@
 - (void)attemptToLogEventToKit:(id<MPExtensionKitProtocol>)kitRegister kitFilter:(MPKitFilter *)kitFilter selector:(SEL)selector parameters:(nullable MPForwardQueueParameters *)parameters messageType:(MPMessageType)messageType userInfo:(NSDictionary *)userInfo;
 
 
-
-
 @end
 
 

--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -70,6 +70,8 @@
 - (void)attemptToLogEventToKit:(id<MPExtensionKitProtocol>)kitRegister kitFilter:(MPKitFilter *)kitFilter selector:(SEL)selector parameters:(nullable MPForwardQueueParameters *)parameters messageType:(MPMessageType)messageType userInfo:(NSDictionary *)userInfo;
 
 
+
+
 @end
 
 
@@ -1482,6 +1484,8 @@
     
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
     MPKitFilter *kitFilter = [kitContainer filter:kitRegister forEvent:event selector:@selector(logEvent:)];
+    MPEvent *eventCopy = (MPEvent *)kitFilter.originalEventCopy;
+    
 
     XCTAssert([kitFilter.forwardEvent isKindOfClass:[MPEvent class]]);
     MPEvent *forwardEvent = (MPEvent *)kitFilter.forwardEvent;
@@ -1489,6 +1493,10 @@
     XCTAssertEqualObjects(forwardEvent.name, @"new_premium_subscriber");
     XCTAssertNotNil(forwardEvent.customAttributes);
     XCTAssertEqual(forwardEvent.customAttributes.count, 3);
+    XCTAssertNotNil(kitFilter.appliedProjections);
+    XCTAssertEqualObjects(eventCopy.name, @"subscription_success");
+    XCTAssertNotNil(eventCopy.customAttributes);
+    XCTAssertEqual(eventCopy.customAttributes.count, 3);
 }
 
 - (void)testForwardAppsFlyerCommerceEvent {
@@ -1650,6 +1658,7 @@
     
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
     MPKitFilter *kitFilter = [kitContainer filter:kitRegister forCommerceEvent:commerceEvent];
+    MPEvent *commerceEventCopy = (MPEvent *)kitFilter.originalCommerceEventCopy;
     
     XCTAssert([kitFilter.forwardEvent isKindOfClass:[MPEvent class]]);
     MPEvent *event = (MPEvent *)kitFilter.forwardEvent;
@@ -1657,6 +1666,9 @@
     XCTAssertEqualObjects(event.customAttributes[@"af_content_id"], @"OutATime");
     XCTAssertEqualObjects(event.customAttributes[@"af_content_type"], @"Time Machine");
     XCTAssertEqualObjects(event.name, @"af_add_to_cart");
+    XCTAssertNotNil(kitFilter.appliedProjections);
+    XCTAssertEqual(commerceEventCopy.type, MPEventTypeAddToCart);
+    
 }
 
 - (void)testMatchArrayProjection {
@@ -1748,6 +1760,7 @@
     XCTAssertNotNil(forwardEvent);
     XCTAssertNotNil(forwardEvent.customAttributes);
     XCTAssertEqual(forwardEvent.customAttributes.count, 2);
+    MPEvent *eventCopy = (MPEvent *)kitFilter.originalEventCopy;
     
     [foundEventNames addObject:forwardEvent.name];
     
@@ -1755,6 +1768,9 @@
         XCTAssertTrue([foundEventNames containsObject:@"X_NEW_SUBSCRIPTION"]);
         XCTAssertTrue([foundEventNames containsObject:@"X_NEW_NOAH_SUBSCRIPTION"]);
     }
+    XCTAssertNotNil(kitFilter.appliedProjections);
+    XCTAssertEqual(kitFilter.appliedProjections.count, 2);
+    XCTAssertEqualObjects(eventCopy.name, @"SUBSCRIPTION_END");
 }
 
 - (void)testScreenViewProjectionToBaseEvent {
@@ -1847,10 +1863,13 @@
     [(id <MPKitProtocol>)[kitWrapperMock reject] logScreen:OCMOCK_ANY];
     
     MPKitFilter *kitFilter = [kitContainer filter:kitRegister forEvent:event selector:@selector(logScreen:)];
+    MPEvent *eventCopy = (MPEvent *)kitFilter.originalEventCopy;
     
     [kitWrapperMock verifyWithDelay:5.0];
 
     XCTAssert([kitFilter.forwardEvent isKindOfClass:[MPEvent class]]);
+    XCTAssertNotNil(kitFilter.appliedProjections);
+    XCTAssertEqualObjects(eventCopy.name, @"SUBSCRIPTION_END");
 }
 
 - (void)testNonMatchingMatchArrayProjection {

--- a/mParticle-Apple-SDK/Data Model/MPForwardRecord.m
+++ b/mParticle-Apple-SDK/Data Model/MPForwardRecord.m
@@ -112,10 +112,13 @@ NSString *const kMPFROptOutState = @"s";
     if (kitFilter.appliedProjections.count > 0) {
         NSMutableArray *projections = [[NSMutableArray alloc] initWithCapacity:kitFilter.appliedProjections.count];
         NSMutableDictionary *projectionDictionary;
-        NSString *currentProjectionName = ((MPEvent *)kitFilter.originalEvent).name;
+        NSString *currentProjectionName;
+        if ([kitFilter.originalEvent isKindOfClass:[MPEvent class]]) {
+            currentProjectionName = ((MPEvent *)kitFilter.originalEvent).name;
+        }
         
         for (MPEventProjection *eventProjection in kitFilter.appliedProjections) {
-            if (eventProjection.projectedName == currentProjectionName) {
+            if ([eventProjection.projectedName isEqual:currentProjectionName]) {
                 projectionDictionary = [[NSMutableDictionary alloc] initWithCapacity:4];
                 projectionDictionary[kMPFRProjectionId] = @(eventProjection.projectionId);
                 projectionDictionary[kMPMessageTypeKey] = NSStringFromMessageType(messageType);

--- a/mParticle-Apple-SDK/Data Model/MPForwardRecord.m
+++ b/mParticle-Apple-SDK/Data Model/MPForwardRecord.m
@@ -112,19 +112,22 @@ NSString *const kMPFROptOutState = @"s";
     if (kitFilter.appliedProjections.count > 0) {
         NSMutableArray *projections = [[NSMutableArray alloc] initWithCapacity:kitFilter.appliedProjections.count];
         NSMutableDictionary *projectionDictionary;
+        NSString *currentProjectionName = ((MPEvent *)kitFilter.originalEvent).name;
         
         for (MPEventProjection *eventProjection in kitFilter.appliedProjections) {
-            projectionDictionary = [[NSMutableDictionary alloc] initWithCapacity:4];
-            projectionDictionary[kMPFRProjectionId] = @(eventProjection.projectionId);
-            projectionDictionary[kMPMessageTypeKey] = NSStringFromMessageType(messageType);
-            
-            projectionDictionary[kMPEventTypeKey] = NSStringFromEventType(eventProjection.eventType);
-            
-            if (eventProjection.projectedName) {
-                projectionDictionary[kMPFRProjectionName] = eventProjection.projectedName;
+            if (eventProjection.projectedName == currentProjectionName) {
+                projectionDictionary = [[NSMutableDictionary alloc] initWithCapacity:4];
+                projectionDictionary[kMPFRProjectionId] = @(eventProjection.projectionId);
+                projectionDictionary[kMPMessageTypeKey] = NSStringFromMessageType(messageType);
+                
+                projectionDictionary[kMPEventTypeKey] = NSStringFromEventType(eventProjection.eventType);
+                
+                if (eventProjection.projectedName) {
+                    projectionDictionary[kMPFRProjectionName] = eventProjection.projectedName;
+                }
+                
+                [projections addObject:projectionDictionary];
             }
-            
-            [projections addObject:projectionDictionary];
         }
         
         _dataDictionary[kMPFRProjections] = projections;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -801,7 +801,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         
         if (!projectedEvents.empty()) {
             for (auto &projectedEvent : projectedEvents) {
-                kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:NO appliedProjections:appliedProjectionsArray];
+                kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:NO appliedProjections:appliedProjectionsArray eventCopy:nil commerceEventCopy:commerceEvent];
                 [self attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:@selector(logEvent:) parameters:nil messageType:MPMessageTypeEvent userInfo:[[NSDictionary alloc] init]];
             }
         }
@@ -905,7 +905,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         NSArray<MPEventProjection *> *appliedProjectionsArray = !appliedProjections.empty() ? [NSArray arrayWithObjects:&appliedProjections[0] count:appliedProjections.size()] : nil;
         
         for (auto &projectedEvent : projectedEvents) {
-            kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:shouldFilter appliedProjections:appliedProjectionsArray];
+            kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:shouldFilter appliedProjections:appliedProjectionsArray eventCopy:event commerceEventCopy:nil];
             SEL mutableSelector = selector;
             if (selector == @selector(logScreen:)) {
                 for (int i = 0; i < appliedProjectionsArray.count; i += 1) {
@@ -2212,13 +2212,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
             if (execStatus.success && ![lastKit isEqualToNumber:currentKit]) {
                 lastKit = currentKit;
                 
-                MPForwardRecord *forwardRecord = [[MPForwardRecord alloc] initWithMessageType:MPMessageTypeCommerceEvent
-                                                                                   execStatus:execStatus
-                                                                                    kitFilter:kitFilter
-                                                                                originalEvent:kitFilter.originalCommerceEvent];
-                dispatch_async([MParticle messageQueue], ^{
-                    [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
-                });
+                [self forwardCommerceEventRecord:kitFilter execStatus:execStatus commerceEvent:kitFilter.originalCommerceEvent];
                 MPILogDebug(@"Forwarded logCommerceEvent call to kit: %@", kitRegister.name);
             }
         });
@@ -2339,25 +2333,46 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         if (execStatus.success && ![lastKit isEqualToNumber:currentKit] && messageType != MPMessageTypeUnknown && messageType != MPMessageTypeMedia) {
             lastKit = currentKit;
             
-            MPForwardRecord *forwardRecord = nil;
-            
-            if (messageType == MPMessageTypeOptOut || messageType == MPMessageTypePushRegistration) {
-                forwardRecord = [[MPForwardRecord alloc] initWithMessageType:messageType
-                                                                  execStatus:execStatus
-                                                                   stateFlag:[userInfo[@"state"] boolValue]];
-            } else {
-                forwardRecord = [[MPForwardRecord alloc] initWithMessageType:messageType
-                                                                  execStatus:execStatus
-                                                                   kitFilter:kitFilter
-                                                               originalEvent:kitFilter.originalEvent];
-            }
-            
-            if (forwardRecord != nil) {
-                dispatch_async([MParticle messageQueue], ^{
-                    [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
-                });
+            if (!kitFilter.appliedProjections) {
+                [self forwardEventRecord:kitFilter messageType:messageType userInfo:userInfo execStatus:execStatus event:kitFilter.originalEvent];
+            } else if (kitFilter.originalCommerceEventCopy) {
+                [self forwardCommerceEventRecord:kitFilter execStatus:execStatus commerceEvent:kitFilter.originalCommerceEventCopy];
+            } else if (kitFilter.originalEventCopy) {
+                [self forwardEventRecord:kitFilter messageType:messageType userInfo:userInfo execStatus:execStatus event:kitFilter.originalEventCopy];
             }
         }
+    });
+}
+
+- (void)forwardEventRecord:(MPKitFilter *)kitFilter messageType:(MPMessageType)messageType userInfo:(NSDictionary *)userInfo execStatus:(MPKitExecStatus*) execStatus event:(MPBaseEvent *)event{
+    MPForwardRecord *forwardRecord = nil;
+    
+    if (messageType == MPMessageTypeOptOut || messageType == MPMessageTypePushRegistration) {
+        forwardRecord = [[MPForwardRecord alloc] initWithMessageType:messageType
+                                                          execStatus:execStatus
+                                                           stateFlag:[userInfo[@"state"] boolValue]];
+    } else {
+        
+        forwardRecord = [[MPForwardRecord alloc] initWithMessageType:messageType
+                                                          execStatus:execStatus
+                                                           kitFilter:kitFilter
+                                                       originalEvent:event];
+    }
+    
+    if (forwardRecord != nil) {
+        dispatch_async([MParticle messageQueue], ^{
+            [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
+        });
+    }
+}
+
+- (void)forwardCommerceEventRecord:(MPKitFilter *)kitFilter execStatus:(MPKitExecStatus*) execStatus commerceEvent:(MPCommerceEvent *)commerceEvent{
+    MPForwardRecord *forwardRecord = [[MPForwardRecord alloc] initWithMessageType:MPMessageTypeCommerceEvent
+                                                                       execStatus:execStatus
+                                                                        kitFilter:kitFilter
+                                                                    originalEvent:commerceEvent];
+    dispatch_async([MParticle messageQueue], ^{
+        [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
     });
 }
 

--- a/mParticle-Apple-SDK/Kits/MPKitFilter.h
+++ b/mParticle-Apple-SDK/Kits/MPKitFilter.h
@@ -11,6 +11,8 @@
 @property (nonatomic, strong, readonly, nullable) NSDictionary *filteredAttributes;
 @property (nonatomic, strong, readonly, nullable) MPCommerceEvent *originalCommerceEvent;
 @property (nonatomic, strong, readonly, nullable) MPBaseEvent *originalEvent;
+@property (nonatomic, strong, readonly, nullable) MPCommerceEvent *originalCommerceEventCopy;
+@property (nonatomic, strong, readonly, nullable) MPBaseEvent *originalEventCopy;
 @property (nonatomic, strong, readonly, nullable) MPCommerceEvent *forwardCommerceEvent;
 @property (nonatomic, strong, readonly, nullable) MPBaseEvent *forwardEvent;
 @property (nonatomic, strong, readonly, nullable) MPConsentState *forwardConsentState;
@@ -19,7 +21,7 @@
 - (nonnull instancetype)initWithFilter:(BOOL)shouldFilter;
 - (nonnull instancetype)initWithFilter:(BOOL)shouldFilter filteredAttributes:(nullable NSDictionary *)filteredAttributes;
 - (nonnull instancetype)initWithEvent:(nonnull MPBaseEvent *)event shouldFilter:(BOOL)shouldFilter;
-- (nonnull instancetype)initWithEvent:(nonnull MPBaseEvent *)event shouldFilter:(BOOL)shouldFilter appliedProjections:(nullable NSArray<MPEventProjection *> *)appliedProjections;
+- (nonnull instancetype)initWithEvent:(nonnull MPBaseEvent *)event shouldFilter:(BOOL)shouldFilter appliedProjections:(nullable NSArray<MPEventProjection *> *)appliedProjections eventCopy:(nullable MPBaseEvent *)eventCopy commerceEventCopy:(nullable MPCommerceEvent *)commerceEventCopy;
 - (nonnull instancetype)initWithCommerceEvent:(nonnull MPCommerceEvent *)commerceEvent shouldFilter:(BOOL)shouldFilter;
 - (nonnull instancetype)initWithCommerceEvent:(nonnull MPCommerceEvent *)commerceEvent shouldFilter:(BOOL)shouldFilter appliedProjections:(nullable NSArray<MPEventProjection *> *)appliedProjections;
 - (nonnull instancetype)initWithConsentState:(nonnull MPConsentState *)state shouldFilter:(BOOL)shouldFilter;

--- a/mParticle-Apple-SDK/Kits/MPKitFilter.m
+++ b/mParticle-Apple-SDK/Kits/MPKitFilter.m
@@ -27,10 +27,10 @@
 }
 
 - (instancetype)initWithEvent:(MPBaseEvent *)event shouldFilter:(BOOL)shouldFilter {
-    return [self initWithEvent:event shouldFilter:shouldFilter appliedProjections:nil];
+    return [self initWithEvent:event shouldFilter:shouldFilter appliedProjections:nil eventCopy:nil commerceEventCopy:nil];
 }
 
-- (instancetype)initWithEvent:(MPEvent *)event shouldFilter:(BOOL)shouldFilter appliedProjections:(NSArray<MPEventProjection *> *)appliedProjections {
+- (instancetype)initWithEvent:(MPEvent *)event shouldFilter:(BOOL)shouldFilter appliedProjections:(NSArray<MPEventProjection *> *)appliedProjections eventCopy:(MPEvent *)eventCopy commerceEventCopy:(MPCommerceEvent *)commerceEventCopy{
     self = [self initWithFilter:shouldFilter filteredAttributes:event.customAttributes];
     if (!self) {
         return nil;
@@ -39,6 +39,8 @@
     _originalEvent = event;
     _forwardEvent = event;
     _appliedProjections = appliedProjections;
+    _originalEventCopy = eventCopy;
+    _originalCommerceEventCopy = commerceEventCopy;
     
     return self;
 }


### PR DESCRIPTION
 ## Summary
 - When a kit have custom mappings (such as AppsFlyer and GA4 firebase) we currently forward the mapped event name to the UI in livestream and event forwarding view where only the outbound is increased while the inbound is 0, while for the original event the inbound is increased and the output will not. This fix will forward the reporting issue by only forwarding the reporting of the original event in the outbound and will not create a new event to the schema and only increase the outbound.

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - partial-E2E testing with breakpoints in the AppsFlyer kit to see if the mapped event forwarded as expected as well as full E2E testing on the UI to see if the original event is reported as is.
 - Unit testing cases added to check if projectedEvents are not nil and the originalEventCopy variable in kitFiler have the original event name.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6752
