### PR TITLE
refactor: Change MPConvertJS.identityApiRequest parameter nullability

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPConvertJS.swift
+++ b/mParticle-Apple-SDK/Utils/MPConvertJS.swift
@@ -248,10 +248,10 @@ import Foundation
         return MPIdentity(rawValue: identityTypeNumber.uintValue) ?? .other
     }
     
-    @objc public static func identityApiRequest(_ json: [AnyHashable : Any]) -> MPIdentityApiRequest? {
+    @objc public static func identityApiRequest(_ json: [AnyHashable : Any]?) -> MPIdentityApiRequest? {
         let request = MPIdentityApiRequest.withEmptyUser()
         
-        guard let userIdentities = json["UserIdentities"] as? [[AnyHashable : Any]] else {
+        guard let userIdentities = json?["UserIdentities"] as? [[AnyHashable : Any]] else {
             MPLogger.MPLogError(format: "Unexpected user identity data received from webview")
             return nil
         }
@@ -266,8 +266,8 @@ import Foundation
             }
         }
 
-        if let identity = json["Identity"] as? String,
-           let identityTypeNumber = json["Type"] as? NSNumber,
+        if let identity = json?["Identity"] as? String,
+           let identityTypeNumber = json?["Type"] as? NSNumber,
            let identityType = MPIdentity(rawValue: identityTypeNumber.uintValue) {
             request.setIdentity(identity, identityType: identityType)
         }


### PR DESCRIPTION
 ## Summary
 - Change MPConvertJS.identityApiRequest parameter nullability

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Ran static analyzer and it now passes and I confirmed the code did require a nullable parameter

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/6861
