### PR TITLE
ci: Update actions to macos-14, Xcode 16, iOS 18

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -4,13 +4,13 @@ on: [pull_request]
 
 jobs:
   pod-lint:
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        run: sudo xcode-select -s /Applications/Xcode_16.app
         
       - name: Update xcodeproj gem
         run: sudo gem install xcodeproj
@@ -25,13 +25,13 @@ jobs:
         run: git checkout *.podspec
 
   carthage-build:
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        run: sudo xcode-select -s /Applications/Xcode_16.app
 
       - name: Build with Carthage
         run: ./Scripts/carthage.sh build --no-skip-current || true
@@ -43,7 +43,7 @@ jobs:
         run: ls 2>&1 | grep .framework.zip
 
   compile-extension:
-    runs-on: macOS-13
+    runs-on: macOS-14
     defaults:
       run:
         working-directory: ./Example
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        run: sudo xcode-select -s /Applications/Xcode_16.app
 
       - name: Update CocoaPods repo
         run: pod repo update
@@ -61,17 +61,17 @@ jobs:
         run: pod install
 
       - name: Build iOS extension scheme
-        run: xcodebuild -allowProvisioningUpdates -workspace mParticleExample.xcworkspace -scheme mParticleExample_Extension -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+        run: xcodebuild -allowProvisioningUpdates -workspace mParticleExample.xcworkspace -scheme mParticleExample_Extension -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
 
   run-analyzer:
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        run: sudo xcode-select -s /Applications/Xcode_16.app
 
       - name: Run static analyzer
         run: |
-          bash -c '! (set -o pipefail && xcodebuild -project "mParticle-Apple-SDK.xcodeproj" -scheme "mParticle-Apple-SDK" -sdk iphonesimulator -configuration Debug -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" clean analyze | grep -v "warning: The iOS Simulator deployment target" | grep -B3 "warning")'
+          bash -c '! (set -o pipefail && xcodebuild -project "mParticle-Apple-SDK.xcodeproj" -scheme "mParticle-Apple-SDK" -sdk iphonesimulator -configuration Debug -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" clean analyze | grep -v "warning: The iOS Simulator deployment target" | grep -B3 "warning")'

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   run-ios-tests:
     timeout-minutes: 30
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: "Checkout Cross Platform Tests"
         uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
       - name: "Install Cocoapods"
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: Choose Xcode version
-        run: xcode-select -p; sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer; xcode-select -p
+        run: xcode-select -p; sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer; xcode-select -p
       - name: Run Tests
         run: ./gradlew runIos
       - name: Archive Test Results

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -12,15 +12,15 @@ jobs:
   native-unit-tests:
     strategy:
       matrix:
-        xcode: ["15.2"]
+        xcode: ["16"]
         platform: [iOS, tvOS]
         scheme: [mParticle-Apple-SDK, mParticle-Apple-SDK-NoLocation]
         include:
           - platform: iOS
-            device: iPhone 15
+            device: iPhone 16
           - platform: tvOS
             device: Apple TV
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -16,7 +16,7 @@ jobs:
 
   create-release-branch:
     name: Create release branch
-    runs-on: macOS-13
+    runs-on: macOS-14
     needs: confirm-main-branch
     steps:
       - name: Checkout development branch
@@ -33,7 +33,7 @@ jobs:
 
   release:
     name: Perform release
-    runs-on: macOS-13
+    runs-on: macOS-14
     needs: create-release-branch
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        run: sudo xcode-select -s /Applications/Xcode_16.app
 
       - name: Validate environment
         env:
@@ -155,7 +155,7 @@ jobs:
   sync-repository:
     name: Finalize release
     needs: release
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v4


### PR DESCRIPTION
 ## Summary
 - Update actions to macos-14, Xcode 16, iOS 18

 ## Testing Plan

The updated CI will run in this PR to confirm funcitonality

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6862
