### PR TITLE
refactor: Initialize Kits in Background Thread

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -517,7 +517,13 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         }
         
         if ([kitRegister.wrapperInstance respondsToSelector:@selector(didFinishLaunchingWithConfiguration:)]) {
-            [kitRegister.wrapperInstance didFinishLaunchingWithConfiguration:configuration];
+            if ([NSThread isMainThread]) {
+                [kitRegister.wrapperInstance didFinishLaunchingWithConfiguration:configuration];
+            } else {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [kitRegister.wrapperInstance didFinishLaunchingWithConfiguration:configuration];
+                });
+            }
         }
     }
 }

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1474,7 +1474,7 @@ static BOOL skipNextUpload = NO;
     }
     
     if (![MParticle sharedInstance].stateMachine.optOut) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async([MParticle messageQueue], ^{
             [[MParticle sharedInstance].kitContainer initializeKits];
         });
     }


### PR DESCRIPTION
## Summary
 - InitializeKits doesn't need to be called on the main thread

 ## Testing Plan
 - Tested in simulator with several of our most used kits

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6616
