### PR TITLE
fix: Fix Swift File Support

### DIFF
--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -19,6 +19,7 @@
 #import "MPListenerController.h"
 #import "MPForwardRecord.h"
 #import <UIKit/UIKit.h>
+#import "MParticleSwift.h"
 
 #if TARGET_OS_IOS == 1
     #ifndef MPARTICLE_LOCATION_DISABLE

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -22,7 +22,6 @@
 #import "MParticleWebView.h"
 #import "MPDataPlanFilter.h"
 #import "MPResponseConfig.h"
-#import "MParticleSwift.h"
 #import "MPUpload.h"
 
 static dispatch_queue_t messageQueue = nil;


### PR DESCRIPTION
## Summary
 - certain files like GDPRConsent need to be available publicly for kits and secondary sdks that wrap the core sdk

 ## Testing Plan
 - Ran and tested locally

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6905
