### PR TITLE
fix: Issue when setting Identity Attributes to nil

### DIFF
--- a/UnitTests/MPBackendControllerTests.m
+++ b/UnitTests/MPBackendControllerTests.m
@@ -781,6 +781,24 @@
     XCTAssertNil([identities objectForKey:@(MPUserIdentityEmail)]);
 }
 
+- (void)testSetIdentityToNSNull {
+    [[self backendController] setUserIdentity:@"foo" identityType:MPUserIdentityEmail
+                                    timestamp:[NSDate date]
+                            completionHandler:^(NSString * _Nullable identityString, MPUserIdentity identityType, MPExecStatus execStatus) {
+                                
+                            }];
+    NSDictionary *identities = [MParticle sharedInstance].identity.currentUser.identities;
+    XCTAssertEqualObjects(@"foo", [identities objectForKey:@(MPUserIdentityEmail)]);
+    [[self backendController] setUserIdentity:(NSString *)[NSNull null] identityType:MPUserIdentityEmail
+                                    timestamp:[NSDate date]
+                            completionHandler:^(NSString * _Nullable identityString, MPUserIdentity identityType, MPExecStatus execStatus) {
+                                
+                            }];
+    
+    identities = [MParticle sharedInstance].identity.currentUser.identities;
+    XCTAssertNil([identities objectForKey:@(MPUserIdentityEmail)]);
+}
+
 - (void)testDoNotSetDuplicateIdentityCasing {
     __block MPExecStatus status = MPExecStatusFail;
     [[self backendController] setUserIdentity:@"foo" identityType:MPUserIdentityEmail

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1768,6 +1768,10 @@ static BOOL skipNextUpload = NO;
     
     NSAssert(completionHandler != nil, @"completionHandler cannot be nil.");
     
+    if (MPIsNull(identityString)) {
+        identityString = nil;
+    }
+    
     MPUserIdentityInstance_PRIVATE *newUserIdentity = [[MPUserIdentityInstance_PRIVATE alloc] initWithType:identityType
                                                                                                      value:identityString];
     


### PR DESCRIPTION
## Summary
 - Setting identity to nil in an identity request was causing a crash once it was reaching swift code

 ## Testing Plan
 - Tested locally and through unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7144
