### PR TITLE
docs: Updates link to IDSync docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Next, you'll need to start the SDK:
 }
 ```
 
-Please see [Identity](http://docs.mparticle.com/developers/sdk/ios/identity/) for more information on supplying an `MPIdentityApiRequest` object during SDK initialization.
+Please see [Identity](https://docs.mparticle.com/developers/client-sdks/ios/idsync/) for more information on supplying an `MPIdentityApiRequest` object during SDK initialization.
 
 
 ## Example Project with Sample Code


### PR DESCRIPTION
 ## Summary
 - Replaces an outdated link to the iOS SDK IDSync docs at docs.mparticle.com

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
