### PR TITLE
fix: Ensure UserDefaults has valid instance of Identity

### DIFF
--- a/mParticle-Apple-SDK/MPConstants.swift
+++ b/mParticle-Apple-SDK/MPConstants.swift
@@ -15,7 +15,7 @@ func MPMilliseconds(timestamp: Double) -> Double {
 // NOTE: I kept the same naming here for clarity, but we should rename these
 //       after we remove them from the MPIConstants.h file
 
-let kMParticleSDKVersion = "8.27.5"
+let kMParticleSDKVersion = "8.28.0"
 
 struct MessageKeys {
     static let kMPMessagesKey = "msgs"

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -553,7 +553,7 @@ static NSString *const kMPStateKey = @"state";
     BOOL startKitsAsync = options.startKitsAsync;
     
     __weak MParticle *weakSelf = self;
-    MPUserDefaults *userDefaults = [MPUserDefaults standardUserDefaultsWithStateMachine:_stateMachine backendController:_backendController identity:_identity];
+    MPUserDefaults *userDefaults = [MPUserDefaults standardUserDefaultsWithStateMachine:_stateMachine backendController:_backendController identity:self.identity];
     BOOL firstRun = [userDefaults mpObjectForKey:kMParticleFirstRun userId:[MPPersistenceController_PRIVATE mpId]] == nil;
     if (firstRun) {
         NSDate *firstSeen = [NSDate date];


### PR DESCRIPTION
## Summary
 - Ensure MPUserDefaults is always initialized with valid instance of Identity.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7163
