### PR TITLE
feat: Automatically include sandbox in MPRokt Attributes

### DIFF
--- a/UnitTests/MPRoktTests.m
+++ b/UnitTests/MPRoktTests.m
@@ -31,7 +31,8 @@
 
 - (void)testSelectPlacementsSimpleWithValidParameters {
     [[[self.mockRokt stub] andReturn:@[]] getRoktPlacementAttributes];
-    id mockInstance = OCMClassMock([MParticle class]);
+    MParticle *instance = [MParticle sharedInstance];
+    id mockInstance = OCMPartialMock(instance);
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
@@ -74,7 +75,8 @@
 
 - (void)testSelectPlacementsExpandedWithValidParameters {
     [[[self.mockRokt stub] andReturn:@[]] getRoktPlacementAttributes];
-    id mockInstance = OCMClassMock([MParticle class]);
+    MParticle *instance = [MParticle sharedInstance];
+    id mockInstance = OCMPartialMock(instance);
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
@@ -130,7 +132,8 @@
 
 - (void)testSelectPlacementsExpandedWithNilParameters {
     [[[self.mockRokt stub] andReturn:@[]] getRoktPlacementAttributes];
-    id mockInstance = OCMClassMock([MParticle class]);
+    MParticle *instance = [MParticle sharedInstance];
+    id mockInstance = OCMPartialMock(instance);
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
@@ -181,7 +184,8 @@
 
 - (void)testSelectPlacementsSimpleWithMapping {
     [[[self.mockRokt stub] andReturn:@[@{@"map": @"f.name", @"maptype": @"UserAttributeClass.Name", @"value": @"firstname"}, @{@"map": @"zip", @"maptype": @"UserAttributeClass.Name", @"value": @"billingzipcode"}, @{@"map": @"l.name", @"maptype": @"UserAttributeClass.Name", @"value": @"lastname"}]] getRoktPlacementAttributes];
-    id mockInstance = OCMClassMock([MParticle class]);
+    MParticle *instance = [MParticle sharedInstance];
+    id mockInstance = OCMPartialMock(instance);
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
@@ -225,7 +229,8 @@
 
 - (void)testSelectPlacementsSimpleWithNilMapping {
     [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributes];
-    id mockInstance = OCMClassMock([MParticle class]);
+    MParticle *instance = [MParticle sharedInstance];
+    id mockInstance = OCMPartialMock(instance);
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
@@ -250,7 +255,8 @@
 }
 
 - (void)testGetRoktPlacementAttributes {
-    id mockInstance = OCMClassMock([MParticle class]);
+    MParticle *instance = [MParticle sharedInstance];
+    id mockInstance = OCMPartialMock(instance);
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     NSArray *kitConfig = @[@{
         @"AllowJavaScriptResponse": @"True",

--- a/UnitTests/MPRoktTests.m
+++ b/UnitTests/MPRoktTests.m
@@ -38,7 +38,7 @@
     
     // Set up test parameters
     NSString *viewName = @"testView";
-    NSDictionary *attributes = @{@"key": @"value"};
+    NSDictionary *attributes = @{@"key": @"value", @"sandbox": @"false"};
     
     // Set up expectations for kit container
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];
@@ -82,6 +82,7 @@
     // Set up test parameters
     NSString *viewName = @"testView";
     NSDictionary *attributes = @{@"key": @"value"};
+    NSDictionary *finalAttributes = @{@"key": @"value", @"sandbox": @"true"};
     NSDictionary *placements = @{@"placement": @"test"};
     void (^onLoad)(void) = ^{};
     void (^onUnLoad)(void) = ^{};
@@ -96,7 +97,7 @@
                                       event:nil
                                  parameters:[OCMArg checkWithBlock:^BOOL(MPForwardQueueParameters *params) {
         XCTAssertEqualObjects(params[0], viewName);
-        XCTAssertEqualObjects(params[1], attributes);
+        XCTAssertEqualObjects(params[1], finalAttributes);
         XCTAssertEqualObjects(params[2], placements);
         XCTAssertTrue(params[3] != nil);
         XCTAssertTrue(params[4] != nil);
@@ -134,8 +135,11 @@
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
     
+    // Set up test parameters
+    NSString *viewName = @"testView";
+    
     // Execute method with nil parameters
-    [self.rokt selectPlacements:nil
+    [self.rokt selectPlacements:viewName
                      attributes:nil
                      placements:nil
                          onLoad:nil
@@ -147,11 +151,22 @@
     // Wait for async operation
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];
     
-    // Verify the call is still forwarded with nil parameters
     SEL roktSelector = @selector(executeWithViewName:attributes:placements:onLoad:onUnLoad:onShouldShowLoadingIndicator:onShouldHideLoadingIndicator:onEmbeddedSizeChange:filteredUser:);
+    NSDictionary *finalAttributes = @{@"sandbox": @"true"};
+
     OCMExpect([mockContainer forwardSDKCall:roktSelector
                                       event:nil
-                                 parameters:[OCMArg any]
+                                 parameters:[OCMArg checkWithBlock:^BOOL(MPForwardQueueParameters *params) {
+        XCTAssertEqualObjects(params[0], viewName);
+        XCTAssertEqualObjects(params[1], finalAttributes);
+        XCTAssertNil(params[2]);
+        XCTAssertNil(params[3]);
+        XCTAssertNil(params[4]);
+        XCTAssertNil(params[5]);
+        XCTAssertNil(params[6]);
+        XCTAssertNil(params[7]);
+        return true;
+    }]
                                 messageType:MPMessageTypeEvent
                                    userInfo:nil]).andDo(^(NSInvocation *invocation) {
         [expectation fulfill];
@@ -174,7 +189,7 @@
     // Set up test parameters
     NSString *viewName = @"testView";
     NSDictionary *attributes = @{@"f.name": @"Brandon"};
-    NSDictionary *mappedAttributes = @{@"firstname": @"Brandon"};
+    NSDictionary *mappedAttributes = @{@"firstname": @"Brandon", @"sandbox": @"true"};
     
     // Set up expectations for kit container
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -267,7 +267,7 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
     NSString *sandboxKey = @"sandbox";
     
     // Determine the value of the sandbox attribute based off the current environment
-    NSString *sandboxValue = ([[MParticle sharedInstance] environment] == MPEnvironmentProduction) ? @"false" : @"true";
+    NSString *sandboxValue = ([[MParticle sharedInstance] environment] == MPEnvironmentDevelopment) ? @"true" : @"false";
     
     if (finalAttributes != nil) {
         // Only set sandbox if it`s not set by the client

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -176,8 +176,6 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
     onEmbeddedSizeChange:(void (^ _Nullable)(NSString * _Nonnull, CGFloat))onEmbeddedSizeChange {
     NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributes];
     
-    attributes = [self confirmSandboxAttribute:attributes];
-
     // If attributeMap is nil the kit hasn't been initialized
     if (attributeMap) {
         NSMutableDictionary *mappedAttributes = attributes.mutableCopy;
@@ -198,7 +196,7 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
             // Forwarding call to kits
             MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
             [queueParameters addParameter:identifier];
-            [queueParameters addParameter:mappedAttributes];
+            [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
             [queueParameters addParameter:placements];
             [queueParameters addParameter:onLoad];
             [queueParameters addParameter:onUnLoad];

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -163,49 +163,7 @@ static NSString *const kMPStateKey = @"state";
 
 - (void)selectPlacements:(NSString *)identifier
               attributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes {
-    NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributes];
-    
-    attributes = [self confirmSandboxAttribute:attributes];
-    
-    // If attributeMap is nil the kit hasn't been initialized
-    if (attributeMap) {
-        NSMutableDictionary *mappedAttributes = attributes.mutableCopy;
-        for (NSDictionary<NSString *, NSString *> *map in attributeMap) {
-            NSString *mapFrom = map[@"map"];
-            NSString *mapTo = map[@"value"];
-            if (mappedAttributes[mapFrom]) {
-                NSString * value = mappedAttributes[mapFrom];
-                [mappedAttributes removeObjectForKey:mapFrom];
-                mappedAttributes[mapTo] = value;
-            }
-        }
-        for (NSString *key in mappedAttributes) {
-            [[MParticle sharedInstance].identity.currentUser setUserAttribute:key value:mappedAttributes[key]];
-        }
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            // Forwarding call to kits
-            MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
-            [queueParameters addParameter:identifier];
-            [queueParameters addParameter:mappedAttributes];
-            [queueParameters addParameter:nil];
-            [queueParameters addParameter:nil];
-            [queueParameters addParameter:nil];
-            [queueParameters addParameter:nil];
-            [queueParameters addParameter:nil];
-            [queueParameters addParameter:nil];
-            
-            SEL roktSelector = @selector(executeWithViewName:attributes:placements:onLoad:onUnLoad:onShouldShowLoadingIndicator:onShouldHideLoadingIndicator:onEmbeddedSizeChange:filteredUser:);
-            [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
-                                                                      event:nil
-                                                                 parameters:queueParameters
-                                                                messageType:MPMessageTypeEvent
-                                                                   userInfo:nil
-            ];
-        });
-    } else {
-        MPILogVerbose(@"[MParticle.Rokt selectPlacements:attributes:] not performed due to kit not being configured");
-    }
+    [self selectPlacements:identifier attributes:attributes placements:nil onLoad:nil onUnLoad:nil onShouldShowLoadingIndicator:nil onShouldHideLoadingIndicator:nil onEmbeddedSizeChange:nil];
 }
 
 - (void)selectPlacements:(NSString *)identifier
@@ -307,15 +265,12 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
 - (NSDictionary<NSString *, NSString *> *)confirmSandboxAttribute:(NSDictionary<NSString *, NSString *> * _Nullable)attributes {
     NSMutableDictionary<NSString *, NSString *> *finalAttributes = attributes.mutableCopy;
     NSString *sandboxKey = @"sandbox";
-    NSString *sandboxValue = @"true";
     
     // Determine the value of the sandbox attribute based off the current environment
-    if ([[MParticle sharedInstance] environment] == MPEnvironmentProduction) {
-        sandboxValue = @"false";
-    }
+    NSString *sandboxValue = ([[MParticle sharedInstance] environment] == MPEnvironmentProduction) ? @"false" : @"true";
     
     if (finalAttributes != nil) {
-        // Only set sanbox if its not set by the client
+        // Only set sandbox if it`s not set by the client
         if (![finalAttributes.allKeys containsObject:sandboxKey]) {
             finalAttributes[sandboxKey] = sandboxValue;
         }
@@ -323,7 +278,7 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
         finalAttributes = [[NSMutableDictionary alloc] initWithDictionary:@{sandboxKey: sandboxValue}];
     }
     
-    return  finalAttributes;
+    return finalAttributes;
 }
 
 @end

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -165,6 +165,8 @@ static NSString *const kMPStateKey = @"state";
               attributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes {
     NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributes];
     
+    attributes = [self confirmSandboxAttribute:attributes];
+    
     // If attributeMap is nil the kit hasn't been initialized
     if (attributeMap) {
         NSMutableDictionary *mappedAttributes = attributes.mutableCopy;
@@ -216,6 +218,8 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
     onEmbeddedSizeChange:(void (^ _Nullable)(NSString * _Nonnull, CGFloat))onEmbeddedSizeChange {
     NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributes];
     
+    attributes = [self confirmSandboxAttribute:attributes];
+
     // If attributeMap is nil the kit hasn't been initialized
     if (attributeMap) {
         NSMutableDictionary *mappedAttributes = attributes.mutableCopy;
@@ -298,6 +302,28 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
     }
     
     return attributeMap;
+}
+
+- (NSDictionary<NSString *, NSString *> *)confirmSandboxAttribute:(NSDictionary<NSString *, NSString *> * _Nullable)attributes {
+    NSMutableDictionary<NSString *, NSString *> *finalAttributes = attributes.mutableCopy;
+    NSString *sandboxKey = @"sandbox";
+    NSString *sandboxValue = @"true";
+    
+    // Determine the value of the sandbox attribute based off the current environment
+    if ([[MParticle sharedInstance] environment] == MPEnvironmentProduction) {
+        sandboxValue = @"false";
+    }
+    
+    if (finalAttributes != nil) {
+        // Only set sanbox if its not set by the client
+        if (![finalAttributes.allKeys containsObject:sandboxKey]) {
+            finalAttributes[sandboxKey] = sandboxValue;
+        }
+    } else {
+        finalAttributes = [[NSMutableDictionary alloc] initWithDictionary:@{sandboxKey: sandboxValue}];
+    }
+    
+    return  finalAttributes;
 }
 
 @end


### PR DESCRIPTION
## Summary
 - Updated the `selectPlacements` logic to add the sandbox attribute if it hasn't already been included by the client. The value of this attribute is based off the environment.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested manually and through existing and updated unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7205
