### PR TITLE
feat: Add disabledKits option 

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -703,6 +703,55 @@
 
 }
 
+- (void)testConfiguredKitsWhenDisabled {
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+    
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    NSNumber *kitId = configurations[1][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[0]];
+    kitId = configurations[0][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+    
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 2);
+    XCTAssertEqualObjects(activeKits[0].code, @42);
+    XCTAssertEqualObjects(activeKits[1].code, @314);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+  
+    NSArray<NSNumber *> *disabledKitsId = @[@(42)];
+    [kitContainer setDisabledKits:disabledKitsId];
+    NSArray<id<MPExtensionKitProtocol>> *updatedActiveKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(updatedActiveKits.count, 1);
+    XCTAssertEqualObjects(updatedActiveKits[0].code, @314);
+    NSArray<NSNumber *> *updatedConfiguredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(updatedConfiguredKits.count, 1);
+    XCTAssertTrue([updatedConfiguredKits containsObject:@314]);
+}
+
 - (void)testForwardLoggedInUserWithMultipleKits {
     MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
     currentUser.isLoggedIn = true;

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -393,6 +393,8 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  */
 @property (nonatomic, strong, readwrite, nullable) MPDataPlanOptions *dataPlanOptions;
 
+@property (nonatomic, strong, readwrite, nullable) NSArray<NSNumber *> *disabledKits;
+
 /**
  Set the App Tracking Transparency Authorization Status upon starting the SDK.
  Only sets a new state if it has changed.

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -64,6 +64,7 @@ static NSString *const kMPStateKey = @"state";
 @property (nonatomic, strong, nullable) NSString *dataPlanId;
 @property (nonatomic, strong, nullable) NSNumber *dataPlanVersion;
 @property (nonatomic, readwrite) MPDataPlanOptions *dataPlanOptions;
+@property (nonatomic, readwrite) NSArray<NSNumber *> *disabledKits;
 
 @end
 

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -671,6 +671,7 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
     
     _kitContainer_PRIVATE = [[MPKitContainer_PRIVATE alloc] init];
     _kitContainer_PRIVATE.sideloadedKits = options.sideloadedKits ?: [NSArray array];
+    _kitContainer_PRIVATE.disabledKits = options.disabledKits;
     NSUInteger sideLoadedKitsCount = _kitContainer_PRIVATE.sideloadedKits.count;
     [userDefaults setSideloadedKitsCount:sideLoadedKitsCount];
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 -  introduces a disabledKits property (an array of kit IDs as NSNumbers) to the MParticleOptions class. This allows developers to pass a list of kits they want to disable when starting the SDK.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
