### PR TITLE
feat: Add disabledKits option to MParticleOptions

### DIFF
--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -703,6 +703,87 @@
 
 }
 
+- (void)testActiveKitsWhenNotDisabled {
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    NSNumber *kitId = configurations[1][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[0]];
+    kitId = configurations[0][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 2);
+    XCTAssertEqualObjects(activeKits[0].code, @42);
+    XCTAssertEqualObjects(activeKits[1].code, @314);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+}
+
+- (void)testActiveKitsWhenDisabled {
+    NSArray<NSNumber *> *disabledKitsId = @[@(42)];
+    kitContainer.disabledKits = disabledKitsId;
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    NSNumber *kitId = configurations[1][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[0]];
+    kitId = configurations[0][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 1);
+    XCTAssertEqualObjects(activeKits[0].code, @314);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+}
+
 - (void)testForwardLoggedInUserWithMultipleKits {
     MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
     currentUser.isLoggedIn = true;

--- a/UnitTests/MPKitContainerTests.m
+++ b/UnitTests/MPKitContainerTests.m
@@ -784,6 +784,139 @@
     XCTAssertTrue([configuredKits containsObject:@314]);
 }
 
+- (void)testDisableNonExistentKit {
+    NSArray<NSNumber *> *disabledKitsId = @[@(14)];
+    kitContainer.disabledKits = disabledKitsId;
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    NSNumber *kitId = configurations[1][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[0]];
+    kitId = configurations[0][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 2);
+    XCTAssertEqualObjects(activeKits[0].code, @42);
+    XCTAssertEqualObjects(activeKits[1].code, @314);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+}
+
+- (void)testEmptyDisabledKitsArray {
+    NSArray<NSNumber *> *disabledKitsId = @[];
+    kitContainer.disabledKits = disabledKitsId;
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    NSNumber *kitId = configurations[1][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[0]];
+    kitId = configurations[0][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 2);
+    XCTAssertEqualObjects(activeKits[0].code, @42);
+    XCTAssertEqualObjects(activeKits[1].code, @314);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+}
+
+- (void)testDisableMultipleKits {
+    NSArray<NSNumber *> *disabledKitsId = @[@(42), @(400)];
+    kitContainer.disabledKits = disabledKitsId;
+    NSArray *configurations = @[
+                                @{
+                                    @"id":@(42),
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@314,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    },
+                                @{
+                                    @"id":@400,
+                                    @"as":@{
+                                            @"secretKey":@"MySecretKey",
+                                            @"sendTransactionData":@"true"
+                                            },
+                                    @"eau":@false
+                                    }
+                                ];
+
+    MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[1]];
+    NSNumber *kitId = configurations[1][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+    kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:configurations[0]];
+    kitId = configurations[0][@"id"];
+    [[kitContainer startKit:kitId configuration:kitConfiguration] start];
+
+    [kitContainer configureKits:nil];
+    [kitContainer configureKits:configurations];
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [kitContainer activeKitsRegistry];
+    XCTAssertEqual(activeKits.count, 1);
+    XCTAssertEqualObjects(activeKits[0].code, @314);
+    NSArray<NSNumber *> *configuredKits = [kitContainer configuredKitsRegistry];
+    XCTAssertEqual(configuredKits.count, 2);
+    XCTAssertTrue([configuredKits containsObject:@42]);
+    XCTAssertTrue([configuredKits containsObject:@314]);
+}
+
 - (void)testForwardLoggedInUserWithMultipleKits {
     MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
     currentUser.isLoggedIn = true;

--- a/mParticle-Apple-SDK/Include/MPEnums.h
+++ b/mParticle-Apple-SDK/Include/MPEnums.h
@@ -285,34 +285,40 @@ typedef NS_ENUM(NSUInteger, MPKitInstance) {
     MPKitInstanceResponsys = 102,
     /** Kit code for Apptimize */
     MPKitInstanceApptimize = 105,
+    /** Kit code for Bing */
+    MPKitInstanceBingAds = 107,
     /** Kit code for Reveal Mobile */
     MPKitInstanceRevealMobile = 112,
     /** Kit code for Radar */
     MPKitInstanceRadar = 117,
-    /** Kit code for Skyhook */
-    MPKitInstanceSkyhook = 121,
-    /** Kit code for Iterable */
-    MPKitInstanceIterable = 1003,
-    /** Kit code for Button */
-    MPKitInstanceButton = 1022,
     /** Kit code for Singular */
     MPKitInstanceSingular = 119,
-    /** Kit code for Adobe */
-    MPKitInstanceAdobe = 124,
+    /** Kit code for Skyhook */
+    MPKitInstanceSkyhook = 121,
     /** Kit code for Instabot */
     MPKitInstanceInstabot = 123,
+    /** Kit code for Adobe */
+    MPKitInstanceAdobe = 124,
     /** Kit code for Appsee */
     MPKitInstanceAppsee = 126,
     /** Kit code for Taplytics */
     MPKitInstanceTaplytics = 129,
+    /** Kit code for OneTrust */
+    MPKitInstanceOneTrust = 134,
     /** Kit code for CleverTap */
     MPKitInstanceCleverTap = 135,
-    /** Kit code for Pilgrim */
-    MPKitInstancePilgrim = 211,
     /** Kit code for Google Analytics for Firebase */
     MPKitInstanceGoogleAnalyticsFirebase = 136,
+    /** Kit code for Google Tag Manager */
+    MPKitInstanceGoogleTagManager = 140,
     /** Kit code for Google Analytics 4 for Firebase */
     MPKitInstanceGoogleAnalyticsFirebaseGA4 = 160,
+    /** Kit code for Pilgrim */
+    MPKitInstancePilgrim = 211,
+    /** Kit code for Iterable */
+    MPKitInstanceIterable = 1003,
+    /** Kit code for Button */
+    MPKitInstanceButton = 1022,
     /** Kit code for Blueshift */
     MPKitInstanceBlueshift = 1144
 };

--- a/mParticle-Apple-SDK/Include/MPEnums.h
+++ b/mParticle-Apple-SDK/Include/MPEnums.h
@@ -309,8 +309,6 @@ typedef NS_ENUM(NSUInteger, MPKitInstance) {
     MPKitInstanceCleverTap = 135,
     /** Kit code for Google Analytics for Firebase */
     MPKitInstanceGoogleAnalyticsFirebase = 136,
-    /** Kit code for Google Tag Manager */
-    MPKitInstanceGoogleTagManager = 140,
     /** Kit code for Google Analytics 4 for Firebase */
     MPKitInstanceGoogleAnalyticsFirebaseGA4 = 160,
     /** Kit code for Pilgrim */

--- a/mParticle-Apple-SDK/Include/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Include/MPKitContainer.h
@@ -18,6 +18,7 @@
 @property (nonatomic, strong, nonnull) NSArray<NSDictionary *> *originalConfig;
 
 @property (nonatomic, strong, nonnull) NSArray<MPSideloadedKit*> *sideloadedKits;
+@property (nonatomic, strong, readwrite, nullable) NSArray<NSNumber *> *disabledKits;
 
 + (BOOL)registerKit:(nonnull id<MPExtensionKitProtocol>)kitRegister;
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -394,6 +394,13 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 @property (nonatomic, strong, readwrite, nullable) MPDataPlanOptions *dataPlanOptions;
 
 /**
+ Disabled Kits.
+ 
+ Include the Kit Integration ID of any kit you'd like to disable
+ */
+@property (nonatomic, strong, readwrite, nullable) NSArray<NSNumber *> *disabledKits;
+
+/**
  Set the App Tracking Transparency Authorization Status upon starting the SDK.
  Only sets a new state if it has changed.
  */

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -397,6 +397,7 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  Disabled Kits.
  
  Include the Kit Integration ID of any kit you'd like to disable
+ @see MPKitInstance
  */
 @property (nonatomic, strong, readwrite, nullable) NSArray<NSNumber *> *disabledKits;
 

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -64,6 +64,7 @@ static NSString *const kMPStateKey = @"state";
 @property (nonatomic, strong, nullable) NSString *dataPlanId;
 @property (nonatomic, strong, nullable) NSNumber *dataPlanVersion;
 @property (nonatomic, readwrite) MPDataPlanOptions *dataPlanOptions;
+@property (nonatomic, readwrite) NSArray<NSNumber *> *disabledKits;
 
 @end
 
@@ -727,6 +728,7 @@ onShouldHideLoadingIndicator:(void (^ _Nullable)(void))onShouldHideLoadingIndica
     
     _kitContainer_PRIVATE = [[MPKitContainer_PRIVATE alloc] init];
     _kitContainer_PRIVATE.sideloadedKits = options.sideloadedKits ?: [NSArray array];
+    _kitContainer_PRIVATE.disabledKits = options.disabledKits;
     NSUInteger sideLoadedKitsCount = _kitContainer_PRIVATE.sideloadedKits.count;
     [userDefaults setSideloadedKitsCount:sideLoadedKitsCount];
 


### PR DESCRIPTION
## Summary
 - Added a disabledKits property to mParticleOptions that prevents an kit with a matching kit ID from being initialized or sent events.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally and through sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7214
