### PR TITLE
feat: Identify if Provided Email in Rokt SelectPlacements

### DIFF
--- a/UnitTests/MPRoktTests.m
+++ b/UnitTests/MPRoktTests.m
@@ -7,6 +7,7 @@
 
 @interface MPRokt ()
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)getRoktPlacementAttributesMapping;
+- (void)confirmEmail:(NSString * _Nullable)email user:(MParticleUser * _Nullable)user;
 @end
 
 @interface MPRokt (Testing)
@@ -40,10 +41,11 @@
     
     // Set up test parameters
     NSString *viewName = @"testView";
-    NSDictionary *attributes = @{@"key": @"value", @"sandbox": @"false"};
+    NSDictionary *attributes = @{@"email": @"test@gmail.com", @"sandbox": @"false"};
     
     // Set up expectations for kit container
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];
+    OCMExpect([self.mockRokt confirmEmail:@"test@gmail.com" user:OCMOCK_ANY]);
     SEL roktSelector = @selector(executeWithViewName:attributes:placements:callbacks:filteredUser:);
     OCMExpect([mockContainer forwardSDKCall:roktSelector
                                       event:nil
@@ -93,6 +95,7 @@
     
     // Set up expectations for kit container
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];
+    OCMExpect([self.mockRokt confirmEmail:nil user:OCMOCK_ANY]);
     SEL roktSelector = @selector(executeWithViewName:attributes:placements:callbacks:filteredUser:);
     OCMExpect([mockContainer forwardSDKCall:roktSelector
                                       event:nil

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -28,50 +28,51 @@
               attributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes
               placements:(NSDictionary<NSString *, MPRoktEmbeddedView *> * _Nullable)placements
                callbacks:(MPRoktEventCallback *)callbacks {
-    NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributesMapping];
     MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
     NSString *email = attributes[@"email"];
     
-    // If email is passed in as an attribute and its not set on the identity, set it
-    [self confirmEmail:email user:currentUser];
-    
-    // If attributeMap is nil the kit hasn't been initialized
-    if (attributeMap) {
-        NSMutableDictionary *mappedAttributes = attributes.mutableCopy;
-        for (NSDictionary<NSString *, NSString *> *map in attributeMap) {
-            NSString *mapFrom = map[@"map"];
-            NSString *mapTo = map[@"value"];
-            if (mappedAttributes[mapFrom]) {
-                NSString * value = mappedAttributes[mapFrom];
-                [mappedAttributes removeObjectForKey:mapFrom];
-                mappedAttributes[mapTo] = value;
+    // If email is passed in as an attribute and it's different than the existing identity, identify with it
+    [self confirmEmail:email user:currentUser completion:^(MParticleUser *_Nullable resolvedUser) {
+        NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributesMapping];
+
+        // If attributeMap is nil the kit hasn't been initialized
+        if (attributeMap) {
+            NSMutableDictionary *mappedAttributes = attributes.mutableCopy;
+            for (NSDictionary<NSString *, NSString *> *map in attributeMap) {
+                NSString *mapFrom = map[@"map"];
+                NSString *mapTo = map[@"value"];
+                if (mappedAttributes[mapFrom]) {
+                    NSString * value = mappedAttributes[mapFrom];
+                    [mappedAttributes removeObjectForKey:mapFrom];
+                    mappedAttributes[mapTo] = value;
+                }
             }
-        }
-        for (NSString *key in mappedAttributes) {
-            if (![key isEqual:@"sandbox"]) {
-                [currentUser setUserAttribute:key value:mappedAttributes[key]];
+            for (NSString *key in mappedAttributes) {
+                if (![key isEqual:@"sandbox"]) {
+                    [resolvedUser setUserAttribute:key value:mappedAttributes[key]];
+                }
             }
-        }
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            // Forwarding call to kits
-            MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
-            [queueParameters addParameter:identifier];
-            [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
-            [queueParameters addParameter:placements];
-            [queueParameters addParameter:callbacks];
             
-            SEL roktSelector = @selector(executeWithViewName:attributes:placements:callbacks:filteredUser:);
-            [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
-                                                                      event:nil
-                                                                 parameters:queueParameters
-                                                                messageType:MPMessageTypeEvent
-                                                                   userInfo:nil
-            ];
-        });
-    } else {
-        MPILogVerbose(@"[MParticle.Rokt selectPlacements: not performed since Kit not configured");
-    }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // Forwarding call to kits
+                MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
+                [queueParameters addParameter:identifier];
+                [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
+                [queueParameters addParameter:placements];
+                [queueParameters addParameter:callbacks];
+                
+                SEL roktSelector = @selector(executeWithViewName:attributes:placements:callbacks:filteredUser:);
+                [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
+                                                                          event:nil
+                                                                     parameters:queueParameters
+                                                                    messageType:MPMessageTypeEvent
+                                                                       userInfo:nil
+                ];
+            });
+        } else {
+            MPILogVerbose(@"[MParticle.Rokt selectPlacements: not performed since Kit not configured");
+        }
+    }];
 }
 
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)getRoktPlacementAttributesMapping {
@@ -140,19 +141,22 @@
     return finalAttributes;
 }
 
-- (void)confirmEmail:(NSString * _Nullable)email user:(MParticleUser * _Nullable)user {
-    if (!user.identities[@(MPIdentityEmail)] && email) {
+- (void)confirmEmail:(NSString * _Nullable)email user:(MParticleUser * _Nullable)user completion:(void (^)(MParticleUser *_Nullable))completion {
+    if (email && email != user.identities[@(MPIdentityEmail)]) {
         MPIdentityApiRequest *identityRequest = [MPIdentityApiRequest requestWithUser:user];
         identityRequest.email = email;
         
-        [[[MParticle sharedInstance] identity] modify:identityRequest completion:^(MPModifyApiResult *_Nullable apiResult, NSError *_Nullable error) {
+        [[[MParticle sharedInstance] identity] identify:identityRequest completion:^(MPIdentityApiResult *_Nullable apiResult, NSError *_Nullable error) {
             if (error) {
                 NSLog(@"Failed to automatically update email from selectPlacement: %@", error);
+                completion(user);
             } else {
-                NSLog(@"Updated email identity based off selectPlacement's attributes: %@", apiResult.identityChanges);
+                NSLog(@"Updated email identity based off selectPlacement's attributes: %@", apiResult.user.identities.description);
+                completion(apiResult.user);
             }
         }];
     }
+    completion(user);
 }
 
 @end

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -143,15 +143,19 @@
 
 - (void)confirmEmail:(NSString * _Nullable)email user:(MParticleUser * _Nullable)user completion:(void (^)(MParticleUser *_Nullable))completion {
     if (email && email != user.identities[@(MPIdentityEmail)]) {
+        // If there is an existing email but it doesn't match the email passed in, warn the customer
+        if (user.identities[@(MPIdentityEmail)]) {
+            NSLog(@"The existing email on the user (%@) does not match the email passed in to `selectPlacements:` (%@). Please remember to sync the email identity to mParticle as soon as you receive it. We will now identify the user before contuing to `selectPlacements:`", user.identities[@(MPIdentityEmail)], email);
+        }
         MPIdentityApiRequest *identityRequest = [MPIdentityApiRequest requestWithUser:user];
         identityRequest.email = email;
         
         [[[MParticle sharedInstance] identity] identify:identityRequest completion:^(MPIdentityApiResult *_Nullable apiResult, NSError *_Nullable error) {
             if (error) {
-                NSLog(@"Failed to automatically update email from selectPlacement: %@", error);
+                NSLog(@"Failed to sync email from selectPlacement to user: %@", error);
                 completion(user);
             } else {
-                NSLog(@"Updated email identity based off selectPlacement's attributes: %@", apiResult.user.identities.description);
+                NSLog(@"Updated email identity based off selectPlacement's attributes: %@", apiResult.user.identities[@(MPIdentityEmail)]);
                 completion(apiResult.user);
             }
         }];


### PR DESCRIPTION
 ## Summary
 - After a developer calls selectPlacements with email, we should check to see if email is on the user yet.  If it isn’t, we should call identify with email (along with all other current user identities)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested live and with unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7247
