### PR TITLE
fix: MPAppNotificationHandler webpageURL issue

### DIFF
--- a/UnitTests/MPAppNotificationHandlerTests.m
+++ b/UnitTests/MPAppNotificationHandlerTests.m
@@ -84,4 +84,19 @@
     [appNotificationHandler openURL:url options:options];
 }
 
+- (void)testContinueUserActivityNoCrash {
+    MPAppNotificationHandler *appNotificationHandler = [MParticle sharedInstance].appNotificationHandler;
+    
+    NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:@"test"];
+    userActivity.webpageURL = [[NSURL alloc] initWithString:@"http://mparticle.com"];
+    [appNotificationHandler continueUserActivity:userActivity restorationHandler:^(NSArray<id<UIUserActivityRestoring>> *restorationHandler){}];
+}
+
+- (void)testContinueUserActivityWithNilURLNoCrash {
+    MPAppNotificationHandler *appNotificationHandler = [MParticle sharedInstance].appNotificationHandler;
+    
+    NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:@"test"];
+    [appNotificationHandler continueUserActivity:userActivity restorationHandler:^(NSArray<id<UIUserActivityRestoring>> *restorationHandler){}];
+}
+
 @end

--- a/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.m
+++ b/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.m
@@ -281,7 +281,12 @@
         return NO;
     }
     
-    stateMachine.launchInfo = [[MPLaunchInfo alloc] initWithURL:userActivity.webpageURL options:nil];
+    if (userActivity.webpageURL != nil) {
+        stateMachine.launchInfo = [[MPLaunchInfo alloc] initWithURL:userActivity.webpageURL options:nil];
+    } else {
+        NSURL *defaultURL = [[NSURL alloc] initWithString:@""];
+        stateMachine.launchInfo = [[MPLaunchInfo alloc] initWithURL:defaultURL options:nil];
+    }
     
     SEL continueUserActivitySelector = @selector(continueUserActivity:restorationHandler:);
     


### PR DESCRIPTION
## Summary
 - Prevent nil webpageURL from crashing SDK

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested through unit tests and standard smoke tests though was not able to recreate the original crash prior to fix.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7334
