### PR TITLE
fix: Remove alreadySynchedUserIdentities

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -2097,13 +2097,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                     }
                 }
                 
-                NSArray *alreadySynchedUserIdentities = userDefaults[kMPSynchedUserIdentitiesKey];
-                if (userIdentities && [kitInstance respondsToSelector:@selector(setUserIdentity:identityType:)] && ![alreadySynchedUserIdentities containsObject:integrationId]) {
-                    NSMutableArray *synchedUserIdentities = [[NSMutableArray alloc] initWithCapacity:alreadySynchedUserIdentities.count + 1];
-                    [synchedUserIdentities addObjectsFromArray:alreadySynchedUserIdentities];
-                    [synchedUserIdentities addObject:integrationId];
-                    userDefaults[kMPSynchedUserIdentitiesKey] = synchedUserIdentities;
-                    
+                if (userIdentities && [kitInstance respondsToSelector:@selector(setUserIdentity:identityType:)]) {
                     for (NSDictionary *userIdentity in userIdentities) {
                         MPUserIdentity identityType = (MPUserIdentity)[userIdentity[kMPUserIdentityTypeKey] intValue];
                         if (![MParticle.sharedInstance.dataPlanFilter isBlockedUserIdentityType:(MPIdentity)identityType]) {


### PR DESCRIPTION
## Summary
 - On iOs we're preventing identity values from being forwarded to kits if they'd already been sent in the past. This code was very old and did not match the behavior of the Android SDK. Removing this code ensures that we favor over sending data over our clients potentially not recieving the data and brings iOs and Ansroid into better parity.

 ## Testing Plan
 - [x] Was this tested locally? Yes
 - Tested using simulator and confirmed data flowing to the Appsflyer Kit

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7304
