### PR TITLE
fix: Make selectPlacement Use Message Queue

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -2303,7 +2303,8 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                     if (kitFilter.shouldFilter) {
                         return;
                     }
-                    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:[[[MParticle sharedInstance] identity] currentUser] kitConfiguration:self.kitConfigurations[kitRegister.code]];
+                    MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
+                    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:currentUser kitConfiguration:self.kitConfigurations[kitRegister.code]];
                     execStatus = [kitRegister.wrapperInstance executeWithViewName:parameters[0]
                                                                        attributes:parameters[1]
                                                                        placements:parameters[2]

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -11,6 +11,12 @@
 #import "MPILogger.h"
 #import "MPIConstants.h"
 
+@interface MParticle ()
+
++ (dispatch_queue_t)messageQueue;
+
+@end
+
 @implementation MPRoktEventCallback
 @end
 
@@ -57,7 +63,7 @@
                 }
             }
             
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async([MParticle messageQueue], ^{
                 // Forwarding call to kits
                 MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
                 [queueParameters addParameter:identifier];


### PR DESCRIPTION
## Summary
 - Timing issues led to user attributes not being set when an identify needed called within the selectPlacements method. Changing the dispatch to the message queue guarantees that all the setUserAttributes are completed before the kit code is called and thankfully in 'attemptToLogEventToKit' of 'MPKitContainer.mm'  (which comes after that dispatch in the mp core code) we dispatch back to the main queue as needed.
 
 The change to 'MPKitContainer.mm' is just to make debugging with breakpoints easier.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with example app on simulator

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
