### PR TITLE
fix: Prevent Apple Xcode Crash

### DIFF
--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -2207,7 +2207,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2244,7 +2244,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2331,7 +2331,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2374,7 +2374,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Whenever I opened up the mparticle-apple-sdk project xCode would immediately crash. 
 still crashed 

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               Xcode [3588]
Path:                  /Applications/Xcode-beta.app/Contents/MacOS/Xcode
Identifier:            com.apple.dt.Xcode
Version:               26.0 (24141.31)
Build Info:            IDEApplication-24141031000000000~4 (17A5241o)
Code Type:             ARM-64 (Native)
Parent Process:        launchd [1]
User ID:               501

Date/Time:             2025-07-02 10:11:03.6838 -0400
OS Version:            macOS 15.5 (24F74)
Report Version:        12
Anonymous UUID:        F7D8C6DC-5A19-7292-53AB-8C2729CA757F


Time Awake Since Boot: 1300 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000

Termination Reason:    Namespace SIGNAL, Code 6 Abort trap: 6
Terminating Process:   Xcode [3588]

Application Specific Information:
abort() called


Application Specific Signatures:
(row >= 0) && (row < subviews.count)

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x184b7d388 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x184bb688c pthread_kill + 296
2   libsystem_c.dylib             	       0x184abfc60 abort + 124
3   IDEKit                        	       0x108c8b234 +[IDEAssertionHandler _handleAssertionWithLogString:assertionSignature:assertionReason:extraBacktrace:] + 964
4   IDEKit                        	       0x108c8b6a4 -[IDEAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] + 872
5   DVTFoundation                 	       0x1035f03ec _DVTAssertionHandler + 412
6   DVTFoundation                 	       0x1035f0550 _DVTAssertionFailureHandler + 196
7   IDEKit                        	       0x1094e60f8 -[IDECapsuleListView capsuleViewAtRow:].cold.1 + 148
8   IDEKit                        	       0x108ca4768 -[IDECapsuleListView capsuleViewAtRow:] + 132
9   IDEKit                        	       0x108ca4ad0 -[IDECapsuleListView scrollRowToVisible:] + 20
10  Xcode3UI                      	       0x12e6fad40 __36-[Xcode3BuildPhasesEditor takeFocus]_block_invoke + 332
11  Foundation                    	       0x1862530ac __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 24
12  Foundation                    	       0x186252f74 -[NSBlockOperation main] + 96
13  Foundation                    	       0x186252f0c __NSOPERATION_IS_INVOKING_MAIN__ + 16
14  Foundation                    	       0x18625227c -[NSOperation start] + 640
15  Foundation                    	       0x186251ff4 __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 16
16  Foundation                    	       0x186251ee4 __NSOQSchedule_f + 164
17  libdispatch.dylib             	       0x184a0e338 _dispatch_block_async_invoke2 + 148
18  libdispatch.dylib             	       0x184a1885c _dispatch_client_callout + 16
19  libdispatch.dylib             	       0x184a35b58 _dispatch_main_queue_drain.cold.5 + 812
20  libdispatch.dylib             	       0x184a0ddb0 _dispatch_main_queue_drain + 180
21  libdispatch.dylib             	       0x184a0dcec _dispatch_main_queue_callback_4CF + 44
22  CoreFoundation                	       0x184cdfda4 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16
23  CoreFoundation                	       0x184ca0a9c __CFRunLoopRun + 1980
24  CoreFoundation                	       0x184c9fc58 CFRunLoopRunSpecific + 572
25  HIToolbox                     	       0x19073427c RunCurrentEventLoopInMode + 324
26  HIToolbox                     	       0x1907374e8 ReceiveNextEventCommon + 676
27  HIToolbox                     	       0x1908c2484 _BlockUntilNextEventMatchingListInModeWithFilter + 76
28  AppKit                        	       0x188bc7ab4 _DPSNextEvent + 684
29  AppKit                        	       0x1895665b0 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 688
30  AppKit                        	       0x188bbac64 -[NSApplication run] + 480
31  IDEKit                        	       0x108c5f560 -[IDEApplication run] + 192
32  AppKit                        	       0x188b9135c NSApplicationMain + 880
33  dyld                          	       0x184816b98 start + 6076
```

 - Fixed Platform Configuration Ambiguity
Changed SDKROOT = auto to SDKROOT = iphoneos for main framework targets
This resolved the "Could not choose a single platform" error

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Never had any trouble running the code when pulled in an app trhough cocaopods or SPM but confirmed this allowed me to launch the project and run unit tests.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
