### PR TITLE
ci: Add Test for Commerce Event Upload

### DIFF
--- a/mParticle-Apple-SDK/Include/MPApplication.h
+++ b/mParticle-Apple-SDK/Include/MPApplication.h
@@ -3,6 +3,27 @@
 @class UIApplication;
 
 extern NSString * _Nonnull const kMPApplicationInformationKey;
+extern NSString * _Nonnull const kMPApplicationNameKey;
+extern NSString * _Nonnull const kMPApplicationVersionKey;
+extern NSString * _Nonnull const kMPAppPackageNameKey;
+extern NSString * _Nonnull const kMPAppInitialLaunchTimeKey;
+extern NSString * _Nonnull const kMPAppBuildNumberKey;
+extern NSString * _Nonnull const kMPAppBuildUUIDKey;
+extern NSString * _Nonnull const kMPAppArchitectureKey;
+extern NSString * _Nonnull const kMPAppPiratedKey;
+extern NSString * _Nonnull const kMPAppDeploymentTargetKey;
+extern NSString * _Nonnull const kMPAppBuildSDKKey;
+extern NSString * _Nonnull const kMPAppUpgradeDateKey;
+extern NSString * _Nonnull const kMPAppLaunchCountKey;
+extern NSString * _Nonnull const kMPAppLaunchCountSinceUpgradeKey;
+extern NSString * _Nonnull const kMPAppLastUseDateKey;
+extern NSString * _Nonnull const kMPAppStoredVersionKey;
+extern NSString * _Nonnull const kMPAppStoredBuildKey;
+extern NSString * _Nonnull const kMPAppEnvironmentKey;
+extern NSString * _Nonnull const kMPAppStoreReceiptKey;
+extern NSString * _Nonnull const kMPAppImageBaseAddressKey;
+extern NSString * _Nonnull const kMPAppImageSizeKey;
+extern NSString * _Nonnull const kMPAppSideloadKitsCountKey;
 
 @interface MPApplication_PRIVATE : NSObject <NSCopying>
 


### PR DESCRIPTION
## Summary
 - Setup a single integration test that can be performed to capture the event payload from a commerce event.  In the test, we should parse each string and ensure they conform to the types as described in this open api file for our events API: https://docs.mparticle.com/developers/apis/http/#json-format

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - ran all unit tests succesfully

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7181
