### PR TITLE
feat: Update Hashed Email for Rokt

### DIFF
--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -199,13 +199,13 @@
 
 - (void)confirmUser:(NSDictionary<NSString *, NSString *> * _Nullable)attributes user:(MParticleUser * _Nullable)user completion:(void (^)(MParticleUser *_Nullable))completion {
     NSString *email = attributes[@"email"];
-    NSString *hashedEmail = attributes[@"other"];
+    NSString *hashedEmail = attributes[@"emailsha256"];
     
     if ((email && ![email isEqualToString:user.identities[@(MPIdentityEmail)]]) || (hashedEmail && ![hashedEmail isEqualToString: user.identities[@(MPIdentityOther)]])) {
         // If there is an existing email or hashed email but it doesn't match the what was passed in, warn the customer
-        if (user.identities[@(MPIdentityEmail)]) {
+        if (email && user.identities[@(MPIdentityEmail)]) {
             NSLog(@"The existing email on the user (%@) does not match the email passed in to `selectPlacements:` (%@). Please remember to sync the email identity to mParticle as soon as you receive it. We will now identify the user before contuing to `selectPlacements:`", user.identities[@(MPIdentityEmail)], email);
-        } else if (user.identities[@(MPIdentityOther)]) {
+        } else if (hashedEmail && user.identities[@(MPIdentityOther)]) {
             NSLog(@"The existing hashed email on the user (%@) does not match the email passed in to `selectPlacements:` (%@). Please remember to sync the email identity to mParticle as soon as you receive it. We will now identify the user before contuing to `selectPlacements:`", user.identities[@(MPIdentityOther)], hashedEmail);
         }
         


### PR DESCRIPTION
## Summary
 - Updated according to new specs
(1 is the only one that affects the core sdk)
1.  If other is a current identity, and the developer passes  emailsha256 attribute with a different value from other identity to selectPlacements, log a warning to the user, and call identify with other using the value from emailsha256
2. Never remove other from the attributes passed to selectPlacements because it's considered a normal attribute
3. If email identity exists on the user, and emailsha256 attribute is passed to selectPlacements, do not send email attribute to the selectPlacements call.  OR if email identity and other identity exist on the user, only pass emailsha256 attribute with the value from other identity

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested on simulator and with unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7555
