### PR TITLE
fix: Prevent Swift Name Spacing for Encodable Objects

### DIFF
--- a/mParticle-Apple-SDK/Utils/MPDevice.swift
+++ b/mParticle-Apple-SDK/Utils/MPDevice.swift
@@ -13,7 +13,8 @@ import MachO
 import CoreTelephony
 #endif
 
-@objc public class MPDevice : NSObject, NSCopying {
+@objc(MPDevice)
+public class MPDevice : NSObject, NSCopying {
     private var stateMachine: MPStateMachine_PRIVATE
     private var userDefaults: MPUserDefaults
     private var identity: MPIdentityApi

--- a/mParticle-Apple-SDK/Utils/MPUploadSettings.swift
+++ b/mParticle-Apple-SDK/Utils/MPUploadSettings.swift
@@ -14,7 +14,8 @@ private let kAliasTrackingHost = "aliasTrackingHost"
 private let kOverridesAliasSubdirectory = "overridesAliasSubdirectory"
 private let kEventsOnly = "eventsOnly"
 
-@objc public class MPUploadSettings: NSObject, NSCopying, NSSecureCoding {
+@objc(MPUploadSettings)
+public class MPUploadSettings: NSObject, NSCopying, NSSecureCoding {
     @objc public var apiKey: String
     @objc public var secret: String
     @objc public var eventsHost: String?


### PR DESCRIPTION
## Summary
 - While namespacing is not a concern when developing with Frameworks in Swift or Objective C in isolation it can cause issues in Objective C frameworks like NSSecureCoding when bridging from Swift. By adding the annotation @objc(name), namespacing is ignored even if we are working with Swift. 
 
 Here's the latest error message the client was running into
 ```
 [21:45:29]: ▸ Testing failed:
[21:45:29]: ▸ 'MPLocationManager_PRIVATE' has different definitions in different modules; first difference is definition in module 'mParticle_Apple_SDK_NoLocation.Swift' found method
[21:45:29]: ▸ 'MPDevice' has different definitions in different modules; first difference is definition in module 'mParticle_Apple_SDK.Swift' found property 'carrier'
[21:45:29]: ▸ Command SwiftCompile failed with a nonzero exit code
[21:45:29]: ▸ ** TEST FAILED **
 ```

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed functionality in sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7527
