### PR TITLE
feat: Add scripts to analyze project test coverage

### DIFF
--- a/Scripts/check_coverage.py
+++ b/Scripts/check_coverage.py
@@ -1,0 +1,54 @@
+import sys
+import json
+import os
+
+
+files_to_check = set()
+
+COVERAGE_THRESHOLD=90
+
+IGNORED_PATHS = [
+    "UnitTests"
+]
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+
+def is_ignored(path):
+    for ignore in IGNORED_PATHS:
+        if ignore in path:
+            return True
+    
+    return False
+
+with open("./build/coverage.json") as f:
+    data = json.load(f)
+    
+failed_files = []
+
+def matched_file_list(full_path):
+    return any(full_path.endwith(check_path) for check_path in files_to_check)
+
+for target in data.get("targets", []):
+    for file in target.get("files", []):
+        path = file.get("path", file["name"])
+        
+        if files_to_check and not matched_file_list(path):
+            continue
+            
+        if is_ignored(path):
+            continue
+            
+        coverage = file.get("lineCoverage", 0) * 100
+        
+        if coverage == 100:
+            color = GREEN
+            continue
+        elif coverage >= COVERAGE_THRESHOLD:
+            color = GREEN
+        else:
+            color = RED
+            failed_files.append((path, coverage))
+            
+        print(f"{color}{path}: {coverage:.3f}%{RESET}")

--- a/Scripts/check_coverage.sh
+++ b/Scripts/check_coverage.sh
@@ -1,0 +1,16 @@
+SCHEME="mParticle-Apple-SDK"
+DESTINATION="platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+RESULT_BUNDLE_PATH="./build/TestResults.xcresult"
+
+rm -rf "$RESULT_BUNDLE_PATH"
+
+xcodebuild test \
+  -project ../mParticle-Apple-SDK.xcodeproj \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION" \
+  -enableCodeCoverage YES \
+  -resultBundlePath "$RESULT_BUNDLE_PATH" \
+  
+xcrun xccov view --report --json "$RESULT_BUNDLE_PATH" > ./build/coverage.json
+
+python3 check_coverage.py


### PR DESCRIPTION
 ## Summary
 - This PR contains two script files `check_coverage.sh` and `check_coverage.py` to build project coverage report
 - To build report  you can run `check_coverage.sh` from build folder.
 - `check_coverage.py` contains `COVERAGE_THRESHOLD` which is used to highlight files with red if coverage less the threshold.
 - Script doesn't display files which have 100% coverage

 ## Testing Plan
 - [*] Was this tested locally? If not, explain why.
 - to check project test coverage you can run `check_coverage.sh` from build folder.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-7484