### PR TITLE
chore: Add prefix for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     open-pull-requests-limit: 4
     labels:
       - dependabot
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Add prefix for dependabot

 ## Testing Plan
 - N/A

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes N/A
