### PR TITLE
feat: SDKE-61 Extract and test callback logic. Part 1

### DIFF
--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -1,0 +1,3 @@
+@interface MParticle (Tests)
+- (void)setOptOutCompletion:(MPExecStatus)execStatus optOut:(BOOL)optOut;
+@end

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -1,3 +1,6 @@
 @interface MParticle (Tests)
 - (void)setOptOutCompletion:(MPExecStatus)execStatus optOut:(BOOL)optOut;
+- (void)identifyNoDispatchCallback:(MPIdentityApiResult * _Nullable)apiResult
+                             error:(NSError * _Nullable)error
+                           options:(MParticleOptions * _Nonnull)options;
 @end

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -3,4 +3,6 @@
 - (void)identifyNoDispatchCallback:(MPIdentityApiResult * _Nullable)apiResult
                              error:(NSError * _Nullable)error
                            options:(MParticleOptions * _Nonnull)options;
+- (void)configureWithOptions:(MParticleOptions * _Nonnull)options;
+@property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
 @end

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -72,4 +72,14 @@ class MParticleTestsSwift: XCTestCase {
         XCTAssertEqual(receivedMessage, "mParticle -> Identify request failed with error: Error Domain= Code=0 \"(null)\"")
         XCTAssertNil(sut.deferredKitConfiguration_PRIVATE)
     }
+    
+    func testConfigure_defaultConfigurationExist_optionParametersAreNotSet() {
+        let options = MParticleOptions()
+        sut.configure(with: options)
+        XCTAssertEqual(sut.backendController.sessionTimeout, 0.0)
+        XCTAssertEqual(sut.backendController.uploadInterval, 0.0)
+        XCTAssertEqual(sut.customUserAgent, nil)
+        XCTAssertEqual(sut.collectUserAgent, true)
+        XCTAssertEqual(sut.trackNotifications, true)
+    }
 }

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -7,7 +7,7 @@ import mParticle_Apple_SDK
 
 class MParticleTestsSwift: XCTestCase {
     var receivedMessage: String?
-    var sut: MParticle!
+    var mparticle: MParticle!
     
     func customLogger(_ message: String) {
         receivedMessage = message
@@ -16,9 +16,9 @@ class MParticleTestsSwift: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = MParticle.sharedInstance()
-        sut.logLevel = .verbose
-        sut.customLogger = customLogger
+        mparticle = MParticle.sharedInstance()
+        mparticle.logLevel = .verbose
+        mparticle.customLogger = customLogger
     }
     
     override func tearDown() {
@@ -26,18 +26,18 @@ class MParticleTestsSwift: XCTestCase {
         receivedMessage = nil
     }
     
-    func testSetOptOutCompletion_success() {
-        sut.setOptOutCompletion(.success, optOut: true)
+    func testSetOptOutCompletionSuccess() {
+        mparticle.setOptOutCompletion(.success, optOut: true)
         XCTAssertEqual(receivedMessage, "mParticle -> Set Opt Out: 1")
     }
     
-    func testSetOptOutCompletion_falure() {
-        sut.setOptOutCompletion(.fail, optOut: true)
+    func testSetOptOutCompletionFailure() {
+        mparticle.setOptOutCompletion(.fail, optOut: true)
         XCTAssertEqual(receivedMessage, "mParticle -> Set Opt Out Failed: 1")
     }
     
-    func testIdentifyNoDispatchCallback_noError_defferedKitAvailable() {
-        sut.deferredKitConfiguration_PRIVATE = [[String: String]]();
+    func testIdentifyNoDispatchCallbackNoErrorDefferedKitAvailable() {
+        mparticle.deferredKitConfiguration_PRIVATE = [[String: String]]();
         let expectedApiResult = MPIdentityApiResult()
         let options = MParticleOptions()
         let expectation = XCTestExpectation()
@@ -47,15 +47,15 @@ class MParticleTestsSwift: XCTestCase {
             
             expectation.fulfill()
         }
-        sut.identifyNoDispatchCallback(expectedApiResult, error: nil, options: options)
+        mparticle.identifyNoDispatchCallback(expectedApiResult, error: nil, options: options)
         
         wait(for: [expectation], timeout: 0.1)
         XCTAssertNil(receivedMessage)
-        XCTAssertNil(sut.deferredKitConfiguration_PRIVATE)
+        XCTAssertNil(mparticle.deferredKitConfiguration_PRIVATE)
     }
     
-    func testIdentifyNoDispatchCallback_withError_defferedKitAvailable() {
-        sut.deferredKitConfiguration_PRIVATE = [[String: String]]();
+    func testIdentifyNoDispatchCallbackWithErrorDefferedKitAvailable() {
+        mparticle.deferredKitConfiguration_PRIVATE = [[String: String]]();
         let expectedApiResult = MPIdentityApiResult()
         let expectedError = NSError(domain: "", code: 0)
         let options = MParticleOptions()
@@ -66,20 +66,20 @@ class MParticleTestsSwift: XCTestCase {
             
             expectation.fulfill()
         }
-        sut.identifyNoDispatchCallback(expectedApiResult, error: expectedError, options: options)
+        mparticle.identifyNoDispatchCallback(expectedApiResult, error: expectedError, options: options)
         
         wait(for: [expectation], timeout: 0.1)
         XCTAssertEqual(receivedMessage, "mParticle -> Identify request failed with error: Error Domain= Code=0 \"(null)\"")
-        XCTAssertNil(sut.deferredKitConfiguration_PRIVATE)
+        XCTAssertNil(mparticle.deferredKitConfiguration_PRIVATE)
     }
     
-    func testConfigure_defaultConfigurationExist_optionParametersAreNotSet() {
+    func testConfigureDefaultConfigurationExistOptionParametersAreNotSet() {
         let options = MParticleOptions()
-        sut.configure(with: options)
-        XCTAssertEqual(sut.backendController.sessionTimeout, 0.0)
-        XCTAssertEqual(sut.backendController.uploadInterval, 0.0)
-        XCTAssertEqual(sut.customUserAgent, nil)
-        XCTAssertEqual(sut.collectUserAgent, true)
-        XCTAssertEqual(sut.trackNotifications, true)
+        mparticle.configure(with: options)
+        XCTAssertEqual(mparticle.backendController.sessionTimeout, 0.0)
+        XCTAssertEqual(mparticle.backendController.uploadInterval, 0.0)
+        XCTAssertEqual(mparticle.customUserAgent, nil)
+        XCTAssertEqual(mparticle.collectUserAgent, true)
+        XCTAssertEqual(mparticle.trackNotifications, true)
     }
 }

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -1,0 +1,33 @@
+import XCTest
+#if MPARTICLE_LOCATION_DISABLE
+import mParticle_Apple_SDK_NoLocation
+#else
+import mParticle_Apple_SDK
+#endif
+
+class MParticleTestsSwift: XCTestCase {
+    var receivedMessage: String?
+    var sut: MParticle!
+    
+    func customLogger(_ message: String) {
+        receivedMessage = message
+    }
+    
+    override func setUp() {
+        super.setUp()
+        
+        sut = MParticle.sharedInstance()
+        sut.logLevel = .verbose
+        sut.customLogger = customLogger
+    }
+    
+    func testSetOptOutCompletion_success() {
+        sut.setOptOutCompletion(.success, optOut: true)
+        XCTAssertEqual(receivedMessage, "mParticle -> Set Opt Out: 1")
+    }
+    
+    func testSetOptOutCompletion_falure() {
+        sut.setOptOutCompletion(.fail, optOut: true)
+        XCTAssertEqual(receivedMessage, "mParticle -> Set Opt Out Failed: 1")
+    }
+}

--- a/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
+++ b/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
@@ -4,3 +4,4 @@
 #import "MPAttributionResult+MParticlePrivate.h"
 #import "MParticleSession+MParticlePrivate.h"
 #import "MParticleOptions+MParticlePrivate.h"
+#import "MParticle+PrivateMethods.h"

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		35329FF32E54CA78009AC4FD /* MParticleOptions+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35329FF12E54CA78009AC4FD /* MParticleOptions+MParticlePrivate.m */; };
 		35329FF52E54CB8C009AC4FD /* MParticleOptions+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */; };
 		35329FF62E54CB8C009AC4FD /* MParticleOptions+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */; };
+		359BAFE82E55ED8900A8A704 /* MParticleTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */; };
+		359BAFE92E55ED8900A8A704 /* MParticleTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */; };
 		35E3FCC02E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC12E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC32E53B5C600DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */; };
@@ -550,6 +552,8 @@
 		35329FEE2E54CA49009AC4FD /* MParticleOptions+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MParticleOptions+MParticlePrivate.h"; sourceTree = "<group>"; };
 		35329FF12E54CA78009AC4FD /* MParticleOptions+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MParticleOptions+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MParticleOptions+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
+		359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MParticleTestsSwift.swift; sourceTree = "<group>"; };
+		359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MParticle+PrivateMethods.h"; sourceTree = "<group>"; };
 		35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPAttributionResult+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPAttributionResult+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		35E3FCC52E53B70100DB5B18 /* MPAttributionResult+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPAttributionResult+MParticlePrivate.h"; sourceTree = "<group>"; };
@@ -1221,6 +1225,8 @@
 		53A79C6729CE019E00E7489F /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */,
+				359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */,
 				35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */,
 				35329FEB2E54C480009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift */,
 				35E3FCD12E549AED00DB5B18 /* MParticleSession+MParticlePrivateTests.swift */,
@@ -1722,6 +1728,7 @@
 				534CD28C29CE2CE1008452B3 /* MPUserDefaultsTests.m in Sources */,
 				534CD28D29CE2CE1008452B3 /* MPUploadBuilderTests.m in Sources */,
 				534CD28E29CE2CE1008452B3 /* MPBaseTestCase.m in Sources */,
+				359BAFE92E55ED8900A8A704 /* MParticleTestsSwift.swift in Sources */,
 				35329FEC2E54C483009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift in Sources */,
 				534CD28F29CE2CE1008452B3 /* MPIdentityApiRequestTests.m in Sources */,
 				534CD29029CE2CE1008452B3 /* MPKitAppsFlyerTest.m in Sources */,
@@ -1903,6 +1910,7 @@
 				53A79CD629CE019F00E7489F /* MPCCPAConsentTests.m in Sources */,
 				53A79CE129CE019F00E7489F /* MPUserDefaultsTests.m in Sources */,
 				53A79CCD29CE019F00E7489F /* MPUploadBuilderTests.m in Sources */,
+				359BAFE82E55ED8900A8A704 /* MParticleTestsSwift.swift in Sources */,
 				35329FED2E54C483009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift in Sources */,
 				53A79CE829CE019F00E7489F /* MPBaseTestCase.m in Sources */,
 				53A79CC029CE019F00E7489F /* MPIdentityApiRequestTests.m in Sources */,

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -258,6 +258,14 @@ static NSString *const kMPStateKey = @"state";
     return [MParticle sharedInstance].stateMachine.optOut;
 }
 
+- (void)setOptOutCompletion:(MPExecStatus)execStatus optOut:(BOOL)optOut {
+    if (execStatus == MPExecStatusSuccess) {
+        MPILogDebug(@"Set Opt Out: %d", optOut);
+    } else {
+        MPILogDebug(@"Set Opt Out Failed: %lu", (unsigned long)execStatus);
+    }
+}
+
 - (void)setOptOut:(BOOL)optOut {
     if (self.stateMachine.optOut == optOut) {
         return;
@@ -277,13 +285,10 @@ static NSString *const kMPStateKey = @"state";
                                                    userInfo:@{kMPStateKey:@(optOut)}
      ];
     
+    __weak typeof(self) weakSelf = self;
     [self.backendController setOptOut:optOut
                     completionHandler:^(BOOL optOut, MPExecStatus execStatus) {
-                        if (execStatus == MPExecStatusSuccess) {
-                            MPILogDebug(@"Set Opt Out: %d", optOut);
-                        } else {
-                            MPILogDebug(@"Set Opt Out Failed: %lu", (unsigned long)execStatus);
-                        }
+                        [weakSelf setOptOutCompletion:execStatus optOut:optOut];
                     }];
 }
 

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -367,6 +367,39 @@ static NSString *const kMPStateKey = @"state";
     }
 }
 
+- (void)configureWithOptions:(MParticleOptions * _Nonnull)options {
+    if (self.configSettings) {
+        if (self.configSettings[kMPConfigSessionTimeout] && !options.isSessionTimeoutSet) {
+            self.backendController.sessionTimeout = [self.configSettings[kMPConfigSessionTimeout] doubleValue];
+        }
+        
+        if (self.configSettings[kMPConfigUploadInterval] && !options.isUploadIntervalSet) {
+            self.backendController.uploadInterval = [self.configSettings[kMPConfigUploadInterval] doubleValue];
+        }
+        
+        if (self.configSettings[kMPConfigCustomUserAgent] && !options.customUserAgent) {
+            self->_customUserAgent = self.configSettings[kMPConfigCustomUserAgent];
+        }
+        
+        if (self.configSettings[kMPConfigCollectUserAgent] && !options.isCollectUserAgentSet) {
+            self->_collectUserAgent = [self.configSettings[kMPConfigCollectUserAgent] boolValue];
+        }
+        
+        if (self.configSettings[kMPConfigTrackNotifications] && !options.isTrackNotificationsSet) {
+            self->_trackNotifications = [self.configSettings[kMPConfigTrackNotifications] boolValue];
+        }
+#if TARGET_OS_IOS == 1
+#ifndef MPARTICLE_LOCATION_DISABLE
+        if ([self.configSettings[kMPConfigLocationTracking] boolValue]) {
+            CLLocationAccuracy accuracy = [self.configSettings[kMPConfigLocationAccuracy] doubleValue];
+            CLLocationDistance distanceFilter = [self.configSettings[kMPConfigLocationDistanceFilter] doubleValue];
+            [self beginLocationTracking:accuracy minDistance:distanceFilter];
+        }
+#endif
+#endif
+    }
+}
+
 - (void)startWithOptions:(MParticleOptions *)options {
     if (sdkInitialized) {
         return;
@@ -490,36 +523,7 @@ static NSString *const kMPStateKey = @"state";
                            
                            strongSelf->_optOut = [MParticle sharedInstance].stateMachine.optOut;
                            
-                           if (strongSelf.configSettings) {
-                               if (strongSelf.configSettings[kMPConfigSessionTimeout] && !options.isSessionTimeoutSet) {
-                                   strongSelf.backendController.sessionTimeout = [strongSelf.configSettings[kMPConfigSessionTimeout] doubleValue];
-                               }
-                               
-                               if (strongSelf.configSettings[kMPConfigUploadInterval] && !options.isUploadIntervalSet) {
-                                   strongSelf.backendController.uploadInterval = [strongSelf.configSettings[kMPConfigUploadInterval] doubleValue];
-                               }
-                               
-                               if (strongSelf.configSettings[kMPConfigCustomUserAgent] && !options.customUserAgent) {
-                                   self->_customUserAgent = strongSelf.configSettings[kMPConfigCustomUserAgent];
-                               }
-                               
-                               if (strongSelf.configSettings[kMPConfigCollectUserAgent] && !options.isCollectUserAgentSet) {
-                                   self->_collectUserAgent = [strongSelf.configSettings[kMPConfigCollectUserAgent] boolValue];
-                               }
-                               
-                               if (strongSelf.configSettings[kMPConfigTrackNotifications] && !options.isTrackNotificationsSet) {
-                                   self->_trackNotifications = [strongSelf.configSettings[kMPConfigTrackNotifications] boolValue];
-                               }
-#if TARGET_OS_IOS == 1
-#ifndef MPARTICLE_LOCATION_DISABLE
-                               if ([strongSelf.configSettings[kMPConfigLocationTracking] boolValue]) {
-                                   CLLocationAccuracy accuracy = [strongSelf.configSettings[kMPConfigLocationAccuracy] doubleValue];
-                                   CLLocationDistance distanceFilter = [strongSelf.configSettings[kMPConfigLocationDistanceFilter] doubleValue];
-                                   [strongSelf beginLocationTracking:accuracy minDistance:distanceFilter];
-                               }
-#endif
-#endif
-                           }
+                           [strongSelf configureWithOptions:options];
                            
                            strongSelf.initialized = YES;
                            strongSelf.configSettings = nil;

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -354,12 +354,10 @@ static NSString *const kMPStateKey = @"state";
     NSArray<NSDictionary *> *deferredKitConfiguration = self.deferredKitConfiguration_PRIVATE;
     
     if (deferredKitConfiguration != nil && [deferredKitConfiguration isKindOfClass:[NSArray class]]) {
-        
         dispatch_async(dispatch_get_main_queue(), ^{
             [[MParticle sharedInstance].kitContainer_PRIVATE configureKits:deferredKitConfiguration];
             self.deferredKitConfiguration_PRIVATE = nil;
         });
-        
     }
     
     if (options.onIdentifyComplete) {
@@ -482,9 +480,7 @@ static NSString *const kMPStateKey = @"state";
                            }
                            
                            [strongSelf.identity identifyNoDispatch:identifyRequest completion:^(MPIdentityApiResult * _Nullable apiResult, NSError * _Nullable error) {
-                               [self identifyNoDispatchCallback:apiResult
-                                                          error:error
-                                                        options:options];
+                               [self identifyNoDispatchCallback:apiResult error:error options:options];
                            }];
                            
                            if (firstRun) {


### PR DESCRIPTION
 ## Summary
- This is the first PR in the series.
- In this PR, the callback logic has been extracted into a separate method and is now covered with tests.
- I suggest reviewing the PR commit by commit for clarity.
- It was also checked with both the Example and Higgs apps

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Part of https://rokt.atlassian.net/browse/SDKE-61
