### PR TITLE
feat: SDKE-61 Extract and test callback logic. Part 2

### DIFF
--- a/UnitTests/MPUserDefaultsMock.swift
+++ b/UnitTests/MPUserDefaultsMock.swift
@@ -1,0 +1,27 @@
+import XCTest
+#if MPARTICLE_LOCATION_DISABLE
+import mParticle_Apple_SDK_NoLocation
+#else
+import mParticle_Apple_SDK
+#endif
+
+
+class MPUserDefaultsMock: MPUserDefaultsProtocol {
+    var setMPObjectCalled = false
+    var setMPObjectValueParam: Any?
+    var setMPObjectKeyParam: String?
+    var setMPObjectUserIdParam: NSNumber?
+    
+    func setMPObject(_ value: Any?, forKey key: String, userId: NSNumber) {
+        setMPObjectCalled = true
+        setMPObjectValueParam = value
+        setMPObjectKeyParam = key
+        setMPObjectUserIdParam = userId
+    }
+    
+    var synchronizeCalled = false
+    
+    func synchronize() {
+        synchronizeCalled = true
+    }
+}

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -1,3 +1,5 @@
+#import "SettingsProvider.h"
+
 @interface MParticle (Tests)
 - (void)setOptOutCompletion:(MPExecStatus)execStatus optOut:(BOOL)optOut;
 - (void)identifyNoDispatchCallback:(MPIdentityApiResult * _Nullable)apiResult
@@ -5,4 +7,5 @@
                            options:(MParticleOptions * _Nonnull)options;
 - (void)configureWithOptions:(MParticleOptions * _Nonnull)options;
 @property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
+@property (nonatomic, strong) id<SettingsProviderProtocol> settingsProvider;
 @end

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -1,4 +1,5 @@
 #import "SettingsProvider.h"
+#import "MParticleSwift.h"
 
 @interface MParticle (Tests)
 - (void)setOptOutCompletion:(MPExecStatus)execStatus optOut:(BOOL)optOut;
@@ -6,6 +7,8 @@
                              error:(NSError * _Nullable)error
                            options:(MParticleOptions * _Nonnull)options;
 - (void)configureWithOptions:(MParticleOptions * _Nonnull)options;
+- (void)startWithKeyCallback:(BOOL)firstRun options:(MParticleOptions * _Nonnull)options userDefaults:(id<MPUserDefaultsProtocol>)userDefaults;
+
 @property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
 @property (nonatomic, strong) id<SettingsProviderProtocol> settingsProvider;
 @end

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -108,4 +108,36 @@ class MParticleTestsSwift: XCTestCase {
         XCTAssertEqual(mparticle.collectUserAgent, false)
         XCTAssertEqual(mparticle.trackNotifications, false)
     }
+    
+    func testStartWithKeyCallbackFirstRun() {
+        let options = MParticleOptions()
+        let userDefaults = MPUserDefaultsMock()
+        XCTAssertFalse(mparticle.initialized)
+        
+        mparticle.start(withKeyCallback: true, options: options, userDefaults: userDefaults)
+        
+        XCTAssertTrue(mparticle.initialized)
+        XCTAssertNil(mparticle.settingsProvider.configSettings)
+        
+        XCTAssertNotNil(userDefaults.setMPObjectValueParam)
+        XCTAssertEqual(userDefaults.setMPObjectKeyParam, "firstrun")
+        XCTAssertEqual(userDefaults.setMPObjectUserIdParam, 0)
+        XCTAssertTrue(userDefaults.synchronizeCalled)
+    }
+    
+    func testStartWithKeyCallbackNotFirstRunWithIdentityRequest() {
+        let options = MParticleOptions()
+        let user = mparticle.identity.currentUser
+        options.identifyRequest = MPIdentityApiRequest(user: user!)
+
+        let userDefaults = MPUserDefaultsMock()
+        
+        mparticle.start(withKeyCallback: false, options: options, userDefaults: userDefaults)
+        
+        XCTAssertTrue(mparticle.initialized)
+        XCTAssertNil(mparticle.settingsProvider.configSettings)
+
+        XCTAssertFalse(userDefaults.setMPObjectCalled)
+        XCTAssertFalse(userDefaults.synchronizeCalled)
+    }
 }

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -75,11 +75,37 @@ class MParticleTestsSwift: XCTestCase {
     
     func testConfigureDefaultConfigurationExistOptionParametersAreNotSet() {
         let options = MParticleOptions()
+        mparticle.backendController = MPBackendController_PRIVATE()
         mparticle.configure(with: options)
         XCTAssertEqual(mparticle.backendController.sessionTimeout, 0.0)
-        XCTAssertEqual(mparticle.backendController.uploadInterval, 0.0)
+        XCTAssertEqual(mparticle.backendController.uploadInterval, 60.0)
         XCTAssertEqual(mparticle.customUserAgent, nil)
         XCTAssertEqual(mparticle.collectUserAgent, true)
         XCTAssertEqual(mparticle.trackNotifications, true)
+    }
+    
+    func testConfigureWhenDefaultConfigurationExists() {
+        let settingsProvider = SettingsProviderMock()
+        let settings: NSMutableDictionary = [
+            "session_timeout": NSNumber(value: 2.0),
+            "upload_interval": NSNumber(value: 3.0),
+            "custom_user_agent": "custom_user_agent",
+            "collect_user_agent": false,
+            "track_notifications": false,
+            "enable_location_tracking": true,
+            "location_tracking_accuracy": 100.0,
+            "location_tracking_distance_filter": 10.0
+        ]
+        settingsProvider.configSettings = settings
+        mparticle.settingsProvider = settingsProvider
+        mparticle.backendController = MPBackendController_PRIVATE()
+        let options = MParticleOptions()
+        mparticle.configure(with: options)
+        
+        XCTAssertEqual(mparticle.backendController.sessionTimeout, 2.0)
+        XCTAssertEqual(mparticle.backendController.uploadInterval, 3.0)
+        XCTAssertEqual(mparticle.customUserAgent, "custom_user_agent")
+        XCTAssertEqual(mparticle.collectUserAgent, false)
+        XCTAssertEqual(mparticle.trackNotifications, false)
     }
 }

--- a/UnitTests/SettingsProviderMock.h
+++ b/UnitTests/SettingsProviderMock.h
@@ -1,0 +1,5 @@
+#import "SettingsProvider.h"
+
+@interface SettingsProviderMock : NSObject<SettingsProviderProtocol>
+@property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, id> *configSettings;
+@end

--- a/UnitTests/SettingsProviderMock.m
+++ b/UnitTests/SettingsProviderMock.m
@@ -1,0 +1,4 @@
+#import "SettingsProviderMock.h"
+
+@implementation SettingsProviderMock
+@end

--- a/UnitTests/SettingsProviderTests.swift
+++ b/UnitTests/SettingsProviderTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+#if MPARTICLE_LOCATION_DISABLE
+import mParticle_Apple_SDK_NoLocation
+#else
+import mParticle_Apple_SDK
+#endif
+
+class SettingsProviderTests: XCTestCase {
+    
+    func testDefaultConfiguration() {
+        let settingsProvider = SettingsProvider()
+        
+        let config = settingsProvider.configSettings
+        XCTAssertEqual(config, nil)
+    }
+}

--- a/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
+++ b/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
@@ -5,3 +5,4 @@
 #import "MParticleSession+MParticlePrivate.h"
 #import "MParticleOptions+MParticlePrivate.h"
 #import "MParticle+PrivateMethods.h"
+#import "SettingsProvider.h"

--- a/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
+++ b/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
@@ -6,3 +6,4 @@
 #import "MParticleOptions+MParticlePrivate.h"
 #import "MParticle+PrivateMethods.h"
 #import "SettingsProvider.h"
+#import "SettingsProviderMock.h"

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		359BB0002E575B0300A8A704 /* SettingsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */; };
 		359BB0032E57769E00A8A704 /* SettingsProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BB0022E57769E00A8A704 /* SettingsProviderMock.m */; };
 		359BB0042E57769E00A8A704 /* SettingsProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BB0022E57769E00A8A704 /* SettingsProviderMock.m */; };
+		359BB0062E57A56800A8A704 /* MPUserDefaultsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BB0052E57A56300A8A704 /* MPUserDefaultsMock.swift */; };
+		359BB0072E57A56800A8A704 /* MPUserDefaultsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BB0052E57A56300A8A704 /* MPUserDefaultsMock.swift */; };
 		35E3FCC02E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC12E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC32E53B5C600DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */; };
@@ -567,6 +569,7 @@
 		359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProviderTests.swift; sourceTree = "<group>"; };
 		359BB0012E57769600A8A704 /* SettingsProviderMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsProviderMock.h; sourceTree = "<group>"; };
 		359BB0022E57769E00A8A704 /* SettingsProviderMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsProviderMock.m; sourceTree = "<group>"; };
+		359BB0052E57A56300A8A704 /* MPUserDefaultsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPUserDefaultsMock.swift; sourceTree = "<group>"; };
 		35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPAttributionResult+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPAttributionResult+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		35E3FCC52E53B70100DB5B18 /* MPAttributionResult+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPAttributionResult+MParticlePrivate.h"; sourceTree = "<group>"; };
@@ -1240,6 +1243,7 @@
 		53A79C6729CE019E00E7489F /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				359BB0052E57A56300A8A704 /* MPUserDefaultsMock.swift */,
 				359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */,
 				359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */,
 				359BB0022E57769E00A8A704 /* SettingsProviderMock.m */,
@@ -1761,6 +1765,7 @@
 				534CD29429CE2CE1008452B3 /* MPKitContainerTests.m in Sources */,
 				534CD29529CE2CE1008452B3 /* MPBase_Attribute_Event_ProjectionTests.m in Sources */,
 				534CD29629CE2CE1008452B3 /* MPConsumerInfoTests.m in Sources */,
+				359BB0062E57A56800A8A704 /* MPUserDefaultsMock.swift in Sources */,
 				7E15B2062D94617900C1FF3E /* MPRoktTests.m in Sources */,
 				534CD29729CE2CE1008452B3 /* MPURLRequestBuilderTests.m in Sources */,
 				534CD29829CE2CE1008452B3 /* MPForwardQueueItemTests.m in Sources */,
@@ -1946,6 +1951,7 @@
 				53A79CD529CE019F00E7489F /* MPKitContainerTests.m in Sources */,
 				53A79CBC29CE019F00E7489F /* MPBase_Attribute_Event_ProjectionTests.m in Sources */,
 				53A79CEA29CE019F00E7489F /* MPConsumerInfoTests.m in Sources */,
+				359BB0072E57A56800A8A704 /* MPUserDefaultsMock.swift in Sources */,
 				7E15B2072D94617900C1FF3E /* MPRoktTests.m in Sources */,
 				53A79CDD29CE019F00E7489F /* MPURLRequestBuilderTests.m in Sources */,
 				53A79CDE29CE019F00E7489F /* MPForwardQueueItemTests.m in Sources */,

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		359BAFFA2E56330200A8A704 /* SettingsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 359BAFF82E56330200A8A704 /* SettingsProvider.h */; };
 		359BAFFC2E56335300A8A704 /* SettingsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFB2E56335300A8A704 /* SettingsProvider.m */; };
 		359BAFFD2E56335300A8A704 /* SettingsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFB2E56335300A8A704 /* SettingsProvider.m */; };
+		359BAFFF2E575B0300A8A704 /* SettingsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */; };
+		359BB0002E575B0300A8A704 /* SettingsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */; };
 		35E3FCC02E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC12E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC32E53B5C600DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */; };
@@ -560,6 +562,7 @@
 		359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MParticle+PrivateMethods.h"; sourceTree = "<group>"; };
 		359BAFF82E56330200A8A704 /* SettingsProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsProvider.h; sourceTree = "<group>"; };
 		359BAFFB2E56335300A8A704 /* SettingsProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsProvider.m; sourceTree = "<group>"; };
+		359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProviderTests.swift; sourceTree = "<group>"; };
 		35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPAttributionResult+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPAttributionResult+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		35E3FCC52E53B70100DB5B18 /* MPAttributionResult+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPAttributionResult+MParticlePrivate.h"; sourceTree = "<group>"; };
@@ -1233,6 +1236,7 @@
 		53A79C6729CE019E00E7489F /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */,
 				359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */,
 				359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */,
 				35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */,
@@ -1695,6 +1699,7 @@
 				534CD26529CE2CE1008452B3 /* MPKitAPITests.m in Sources */,
 				534CD26629CE2CE1008452B3 /* MPUserIdentityChangeTests.m in Sources */,
 				534CD26729CE2CE1008452B3 /* MPConsentKitFilterTests.m in Sources */,
+				359BAFFF2E575B0300A8A704 /* SettingsProviderTests.swift in Sources */,
 				534CD26829CE2CE1008452B3 /* MPConnectorTests.m in Sources */,
 				534CD26929CE2CE1008452B3 /* MPSurrogateAppDelegateTests.m in Sources */,
 				534CD26A29CE2CE1008452B3 /* MPGDPRConsentTests.m in Sources */,
@@ -1878,6 +1883,7 @@
 				53A79CE629CE019F00E7489F /* MPKitAPITests.m in Sources */,
 				53A79CC229CE019F00E7489F /* MPUserIdentityChangeTests.m in Sources */,
 				53A79CC129CE019F00E7489F /* MPConsentKitFilterTests.m in Sources */,
+				359BB0002E575B0300A8A704 /* SettingsProviderTests.swift in Sources */,
 				53A79CD029CE019F00E7489F /* MPConnectorTests.m in Sources */,
 				53A79CD129CE019F00E7489F /* MPSurrogateAppDelegateTests.m in Sources */,
 				53A79CE729CE019F00E7489F /* MPGDPRConsentTests.m in Sources */,

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		35329FF62E54CB8C009AC4FD /* MParticleOptions+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */; };
 		359BAFE82E55ED8900A8A704 /* MParticleTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */; };
 		359BAFE92E55ED8900A8A704 /* MParticleTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */; };
+		359BAFF92E56330200A8A704 /* SettingsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 359BAFF82E56330200A8A704 /* SettingsProvider.h */; };
+		359BAFFA2E56330200A8A704 /* SettingsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 359BAFF82E56330200A8A704 /* SettingsProvider.h */; };
+		359BAFFC2E56335300A8A704 /* SettingsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFB2E56335300A8A704 /* SettingsProvider.m */; };
+		359BAFFD2E56335300A8A704 /* SettingsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFB2E56335300A8A704 /* SettingsProvider.m */; };
 		35E3FCC02E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC12E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC32E53B5C600DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */; };
@@ -554,6 +558,8 @@
 		35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MParticleOptions+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MParticleTestsSwift.swift; sourceTree = "<group>"; };
 		359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MParticle+PrivateMethods.h"; sourceTree = "<group>"; };
+		359BAFF82E56330200A8A704 /* SettingsProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsProvider.h; sourceTree = "<group>"; };
+		359BAFFB2E56335300A8A704 /* SettingsProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsProvider.m; sourceTree = "<group>"; };
 		35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPAttributionResult+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPAttributionResult+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		35E3FCC52E53B70100DB5B18 /* MPAttributionResult+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPAttributionResult+MParticlePrivate.h"; sourceTree = "<group>"; };
@@ -891,6 +897,8 @@
 			children = (
 				53A79C2229CDFB4800E7489F /* Include */,
 				53A79B3629CDFB1F00E7489F /* mParticle.m */,
+				359BAFF82E56330200A8A704 /* SettingsProvider.h */,
+				359BAFFB2E56335300A8A704 /* SettingsProvider.m */,
 				35329FF12E54CA78009AC4FD /* MParticleOptions+MParticlePrivate.m */,
 				35329FEE2E54CA49009AC4FD /* MParticleOptions+MParticlePrivate.h */,
 				35329FE82E54C38C009AC4FD /* MPNetworkOptions+MParticlePrivate.m */,
@@ -1378,6 +1386,7 @@
 				53A79BF329CDFB2000E7489F /* MPCustomModulePreference.h in Headers */,
 				53A79B8C29CDFB2000E7489F /* MPDataModelProtocol.h in Headers */,
 				53A79BFB29CDFB2100E7489F /* MPAppDelegateProxy.h in Headers */,
+				359BAFFA2E56330200A8A704 /* SettingsProvider.h in Headers */,
 				53A79B9929CDFB2000E7489F /* MPIConstants.h in Headers */,
 				53A79B7129CDFB2000E7489F /* MPBackendController.h in Headers */,
 				35E3FCCC2E54975C00DB5B18 /* MParticleSession+MParticlePrivate.h in Headers */,
@@ -1472,6 +1481,7 @@
 				53A79D2929CE23F700E7489F /* MPDataModelProtocol.h in Headers */,
 				53A79D2A29CE23F700E7489F /* MPAppDelegateProxy.h in Headers */,
 				53A79D2C29CE23F700E7489F /* MPIConstants.h in Headers */,
+				359BAFF92E56330200A8A704 /* SettingsProvider.h in Headers */,
 				53A79D2E29CE23F700E7489F /* MPBackendController.h in Headers */,
 				7E0387812DB913D2003B7D5E /* MPRokt.h in Headers */,
 				35E3FCCD2E54975C00DB5B18 /* MParticleSession+MParticlePrivate.h in Headers */,
@@ -1831,6 +1841,7 @@
 				53A79C1A29CDFB2100E7489F /* MPKitAPI.m in Sources */,
 				53A79BFF29CDFB2100E7489F /* MPAppNotificationHandler.m in Sources */,
 				53A79BF829CDFB2000E7489F /* MPNotificationController.m in Sources */,
+				359BAFFD2E56335300A8A704 /* SettingsProvider.m in Sources */,
 				53A79C0829CDFB2100E7489F /* MPEvent.m in Sources */,
 				53A79B6729CDFB2000E7489F /* MPAliasResponse.m in Sources */,
 				7E0387842DB913D2003B7D5E /* MPRokt.m in Sources */,
@@ -2013,6 +2024,7 @@
 				53A79DA729CE23F700E7489F /* MPStateMachine.m in Sources */,
 				53A79DA829CE23F700E7489F /* MPKitAPI.m in Sources */,
 				53A79DA929CE23F700E7489F /* MPAppNotificationHandler.m in Sources */,
+				359BAFFC2E56335300A8A704 /* SettingsProvider.m in Sources */,
 				53A79DAA29CE23F700E7489F /* MPNotificationController.m in Sources */,
 				53A79DAB29CE23F700E7489F /* MPEvent.m in Sources */,
 				7E0387822DB913D2003B7D5E /* MPRokt.m in Sources */,

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		359BAFFD2E56335300A8A704 /* SettingsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFB2E56335300A8A704 /* SettingsProvider.m */; };
 		359BAFFF2E575B0300A8A704 /* SettingsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */; };
 		359BB0002E575B0300A8A704 /* SettingsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */; };
+		359BB0032E57769E00A8A704 /* SettingsProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BB0022E57769E00A8A704 /* SettingsProviderMock.m */; };
+		359BB0042E57769E00A8A704 /* SettingsProviderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 359BB0022E57769E00A8A704 /* SettingsProviderMock.m */; };
 		35E3FCC02E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC12E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */; };
 		35E3FCC32E53B5C600DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */; };
@@ -563,6 +565,8 @@
 		359BAFF82E56330200A8A704 /* SettingsProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsProvider.h; sourceTree = "<group>"; };
 		359BAFFB2E56335300A8A704 /* SettingsProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsProvider.m; sourceTree = "<group>"; };
 		359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProviderTests.swift; sourceTree = "<group>"; };
+		359BB0012E57769600A8A704 /* SettingsProviderMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsProviderMock.h; sourceTree = "<group>"; };
+		359BB0022E57769E00A8A704 /* SettingsProviderMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsProviderMock.m; sourceTree = "<group>"; };
 		35E3FCBF2E53B55900DB5B18 /* MPAttributionResult+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPAttributionResult+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPAttributionResult+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		35E3FCC52E53B70100DB5B18 /* MPAttributionResult+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPAttributionResult+MParticlePrivate.h"; sourceTree = "<group>"; };
@@ -1238,6 +1242,8 @@
 			children = (
 				359BAFFE2E575AF500A8A704 /* SettingsProviderTests.swift */,
 				359BAFEA2E55EE0C00A8A704 /* MParticle+PrivateMethods.h */,
+				359BB0022E57769E00A8A704 /* SettingsProviderMock.m */,
+				359BB0012E57769600A8A704 /* SettingsProviderMock.h */,
 				359BAFE72E55ED7D00A8A704 /* MParticleTestsSwift.swift */,
 				35329FF42E54CB84009AC4FD /* MParticleOptions+MParticlePrivateTests.swift */,
 				35329FEB2E54C480009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift */,
@@ -1705,6 +1711,7 @@
 				534CD26A29CE2CE1008452B3 /* MPGDPRConsentTests.m in Sources */,
 				534CD26B29CE2CE1008452B3 /* MPBackendControllerTests.m in Sources */,
 				534CD26C29CE2CE1008452B3 /* MPKitConfigurationTests.mm in Sources */,
+				359BB0042E57769E00A8A704 /* SettingsProviderMock.m in Sources */,
 				534CD26E29CE2CE1008452B3 /* MPNetworkCommunicationTests.m in Sources */,
 				534CD26F29CE2CE1008452B3 /* MPAliasRequestTests.m in Sources */,
 				534CD27029CE2CE1008452B3 /* MPAliasResponseTests.m in Sources */,
@@ -1889,6 +1896,7 @@
 				53A79CE729CE019F00E7489F /* MPGDPRConsentTests.m in Sources */,
 				53A79CD229CE019F00E7489F /* MPBackendControllerTests.m in Sources */,
 				53A79CF329CE019F00E7489F /* MPKitConfigurationTests.mm in Sources */,
+				359BB0032E57769E00A8A704 /* SettingsProviderMock.m in Sources */,
 				53A79CDC29CE019F00E7489F /* MPSwiftTests.swift in Sources */,
 				53A79CBE29CE019F00E7489F /* MPNetworkCommunicationTests.m in Sources */,
 				53A79CF429CE019F00E7489F /* MPAliasRequestTests.m in Sources */,

--- a/mParticle-Apple-SDK/SettingsProvider.h
+++ b/mParticle-Apple-SDK/SettingsProvider.h
@@ -1,0 +1,13 @@
+@import Foundation;
+
+@protocol SettingsProviderProtocol <NSObject>
+
+@property (nonatomic, strong, nullable) NSMutableDictionary *configSettings;
+
+@end
+
+@interface SettingsProvider : NSObject<SettingsProviderProtocol>
+
+@end
+
+

--- a/mParticle-Apple-SDK/SettingsProvider.m
+++ b/mParticle-Apple-SDK/SettingsProvider.m
@@ -1,0 +1,23 @@
+#import "SettingsProvider.h"
+#import "MPIConstants.h"
+
+
+
+@implementation SettingsProvider
+
+@synthesize configSettings = _configSettings;
+
+- (NSMutableDictionary *)configSettings {
+    if (_configSettings) {
+        return _configSettings;
+    }
+    
+    NSString *path = [[NSBundle mainBundle] pathForResource:kMPConfigPlist ofType:@"plist"];
+    if (path) {
+        _configSettings = [[NSMutableDictionary alloc] initWithContentsOfFile:path];
+    }
+    
+    return _configSettings;
+}
+
+@end

--- a/mParticle-Apple-SDK/Utils/MPUserDefaults.swift
+++ b/mParticle-Apple-SDK/Utils/MPUserDefaults.swift
@@ -26,7 +26,13 @@ private let kMPUserIdentitySharedGroupIdentifier = "sgi"
 private let kMResponseConfigurationKey = "responseConfiguration"
 private let kMResponseConfigurationMigrationKey = "responseConfigurationMigrated"
 
-@objc public class MPUserDefaults : NSObject {
+@objc
+public protocol MPUserDefaultsProtocol {
+    func setMPObject(_ value: Any?, forKey key: String, userId: NSNumber)
+    func synchronize()
+}
+
+@objc public class MPUserDefaults : NSObject, MPUserDefaultsProtocol {
     private var stateMachine: MPStateMachine_PRIVATE?
     private var backendController: MPBackendController_PRIVATE?
     private var identity: MPIdentityApi?


### PR DESCRIPTION
 ## Summary
This PR is second PR from the series. Previous https://github.com/mParticle/mparticle-apple-sdk/pull/394
- startWithKeyCallback logic was extracted to separate method and covered with tests
- add protocol for MPUserDefaults
- add mock for MPUserDefaults
- add mock for SettingsProvider
- affected code was covered with tests

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
- apps were launched and checked that we receive events as expected

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Related to https://rokt.atlassian.net/browse/SDKE-61
