### PR TITLE
feat: SDKE-119 Create protocols for testability. Part 3

### DIFF
--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -37,5 +37,6 @@
 @property (nonatomic, strong, nonnull) id<MPListenerControllerProtocol> listenerController;
 @property (nonatomic, strong) id<MPStateMachineProtocol> stateMachine;
 @property (nonatomic, strong) id<MPKitContainerProtocol> kitContainer;
+@property (nonatomic, strong) id<MPPersistenceControllerProtocol> persistenceController;
 @end
     

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -667,5 +667,30 @@ class MParticleTestsSwift: XCTestCase {
         XCTAssertNil(kitContainer.forwardSDKCallParametersParam)
         XCTAssertNil(kitContainer.forwardSDKCallUserInfoParam)
     }
+    
+    func testResetForSwitchingWorkspaces() {
+        let expectation = XCTestExpectation()
+        
+        let kitContainer = MPKitContainerMock()
+        
+        let persistenceController = MPPersistenceControllerMock()
+        
+        let backendController = MPBackendControllerMock()
+        
+        mparticle.kitContainer = kitContainer
+        mparticle.persistenceController = persistenceController
+        mparticle.backendController = backendController
+        
+        mparticle.reset {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertTrue(kitContainer.flushSerializedKitsCalled)
+        XCTAssertTrue(kitContainer.removeAllSideloadedKitsCalled)
+        XCTAssertEqual(persistenceController.resetDatabaseCalled, true)
+        XCTAssertTrue(backendController.unproxyOriginalAppDelegateCalled)
+    }
 }
 

--- a/UnitTests/Mocks/MPPersistenceControllerMock.swift
+++ b/UnitTests/Mocks/MPPersistenceControllerMock.swift
@@ -1,0 +1,54 @@
+import XCTest
+#if MPARTICLE_LOCATION_DISABLE
+import mParticle_Apple_SDK_NoLocation
+#else
+import mParticle_Apple_SDK
+#endif
+
+class MPPersistenceControllerMock: MPPersistenceControllerProtocol {
+    var resetDatabaseForWorkspaceSwitchingCalled = false
+    
+    func resetDatabaseForWorkspaceSwitching() {
+        resetDatabaseForWorkspaceSwitchingCalled = true
+    }
+    
+    var resetDatabaseCalled = false
+    
+    func resetDatabase() {
+        resetDatabaseCalled = true
+    }
+    
+    var saveCelled = false
+    var saveForwardRecordParam: MPForwardRecord?
+    
+    func save(_ forwardRecord: MPForwardRecord) {
+        saveCelled = true
+        saveForwardRecordParam = forwardRecord
+    }
+    
+    
+    var saveIntegrationAttributesParam: MPIntegrationAttributes?
+    
+    func save(_ integrationAttributes: MPIntegrationAttributes) {
+        saveCelled = true
+        saveIntegrationAttributesParam = integrationAttributes
+    }
+    
+    var deleteIntegrationAttributesCalled = false
+    var deleteIntegrationAttributesIntegrationIdParam: NSNumber?
+    
+    func deleteIntegrationAttributes(forIntegrationId integrationId: NSNumber) {
+        deleteIntegrationAttributesCalled = true
+        deleteIntegrationAttributesIntegrationIdParam = integrationId
+    }
+    
+    var fetchIntegrationAttributesCalled = false
+    var fetchIntegrationAttributesIntegrationIdParam: NSNumber?
+    var fetchIntegrationAttributesReturnValue: [AnyHashable : Any]?
+    
+    func fetchIntegrationAttributes(forId integrationId: NSNumber) -> [AnyHashable : Any]? {
+        fetchIntegrationAttributesCalled = true
+        fetchIntegrationAttributesIntegrationIdParam = integrationId
+        return fetchIntegrationAttributesReturnValue
+    }
+}

--- a/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
+++ b/UnitTests/mParticle_iOS_SDKTests-Bridging-Header.h
@@ -15,3 +15,5 @@
 #import "MPBaseEvent.h"
 #import "MPKitProtocol.h"
 #import "MPKitConfiguration.h"
+#import "MPForwardRecord.h"
+#import "MPIntegrationAttributes.h"

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		3513081F2E6729DA002A3AD6 /* MPKitContainerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3513081E2E6729D0002A3AD6 /* MPKitContainerMock.swift */; };
 		351308202E6729DA002A3AD6 /* MPKitContainerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3513081E2E6729D0002A3AD6 /* MPKitContainerMock.swift */; };
+		351308242E676F18002A3AD6 /* MPPersistenceControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351308232E676F12002A3AD6 /* MPPersistenceControllerMock.swift */; };
+		351308252E676F18002A3AD6 /* MPPersistenceControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351308232E676F12002A3AD6 /* MPPersistenceControllerMock.swift */; };
 		35329FE92E54C38C009AC4FD /* MPNetworkOptions+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35329FE82E54C38C009AC4FD /* MPNetworkOptions+MParticlePrivate.m */; };
 		35329FEA2E54C38C009AC4FD /* MPNetworkOptions+MParticlePrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35329FE82E54C38C009AC4FD /* MPNetworkOptions+MParticlePrivate.m */; };
 		35329FEC2E54C483009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35329FEB2E54C480009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift */; };
@@ -568,6 +570,7 @@
 
 /* Begin PBXFileReference section */
 		3513081E2E6729D0002A3AD6 /* MPKitContainerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPKitContainerMock.swift; sourceTree = "<group>"; };
+		351308232E676F12002A3AD6 /* MPPersistenceControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPPersistenceControllerMock.swift; sourceTree = "<group>"; };
 		35329FE82E54C38C009AC4FD /* MPNetworkOptions+MParticlePrivate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPNetworkOptions+MParticlePrivate.m"; sourceTree = "<group>"; };
 		35329FEB2E54C480009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPNetworkOptions+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		35329FEE2E54CA49009AC4FD /* MParticleOptions+MParticlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MParticleOptions+MParticlePrivate.h"; sourceTree = "<group>"; };
@@ -895,6 +898,7 @@
 		356D4A572E58B01100CB69FE /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				351308232E676F12002A3AD6 /* MPPersistenceControllerMock.swift */,
 				3513081E2E6729D0002A3AD6 /* MPKitContainerMock.swift */,
 				356752922E60928500DEEE23 /* MPStateMachineMock.swift */,
 				3567528E2E5F7FF100DEEE23 /* MPBackendControllerMock.swift */,
@@ -1771,6 +1775,7 @@
 				534CD27229CE2CE1008452B3 /* MPConsentSerializationTests.m in Sources */,
 				534CD27329CE2CE1008452B3 /* MPKitTestClassNoStartImmediately.m in Sources */,
 				534CD27429CE2CE1008452B3 /* BracketTests.mm in Sources */,
+				351308242E676F18002A3AD6 /* MPPersistenceControllerMock.swift in Sources */,
 				356752902E5F7FF900DEEE23 /* MPBackendControllerMock.swift in Sources */,
 				534CD27529CE2CE1008452B3 /* MPIdentityTests.m in Sources */,
 				35E3FCD32E549AF500DB5B18 /* MParticleSession+MParticlePrivateTests.swift in Sources */,
@@ -1962,6 +1967,7 @@
 				53A79CC529CE019F00E7489F /* MPKitSecondTestClassNoStartImmediately.m in Sources */,
 				53A79CE429CE019F00E7489F /* MPConsentSerializationTests.m in Sources */,
 				53A79CCA29CE019F00E7489F /* MPKitTestClassNoStartImmediately.m in Sources */,
+				351308252E676F18002A3AD6 /* MPPersistenceControllerMock.swift in Sources */,
 				3567528F2E5F7FF900DEEE23 /* MPBackendControllerMock.swift in Sources */,
 				53A79CF029CE019F00E7489F /* BracketTests.mm in Sources */,
 				35E3FCD22E549AF500DB5B18 /* MParticleSession+MParticlePrivateTests.swift in Sources */,

--- a/mParticle-Apple-SDK/Include/MPPersistenceController.h
+++ b/mParticle-Apple-SDK/Include/MPPersistenceController.h
@@ -14,7 +14,16 @@
     @class MParticleUserNotification;
 #endif
 
-@interface MPPersistenceController_PRIVATE : NSObject
+@protocol MPPersistenceControllerProtocol
+- (void)resetDatabaseForWorkspaceSwitching;
+- (void)resetDatabase;
+- (void)saveForwardRecord:(MPForwardRecord *_Nonnull)forwardRecord;
+- (void)saveIntegrationAttributes:(nonnull MPIntegrationAttributes *)integrationAttributes;
+- (void)deleteIntegrationAttributesForIntegrationId:(nonnull NSNumber *)integrationId;
+- (nullable NSDictionary*)fetchIntegrationAttributesForId:(NSNumber *_Nonnull)integrationId;
+@end
+
+@interface MPPersistenceController_PRIVATE : NSObject<MPPersistenceControllerProtocol>
 
 @property (nonatomic, readonly, getter = isDatabaseOpen) BOOL databaseOpen;
 

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -51,7 +51,7 @@ static NSString *const kMPStateKey = @"state";
     BOOL sdkInitialized;
 }
 
-@property (nonatomic, strong) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong) id<MPPersistenceControllerProtocol> persistenceController;
 @property (nonatomic, strong) MPDataPlanFilter *dataPlanFilter;
 @property (nonatomic, strong) id<MPStateMachineProtocol> stateMachine;
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -701,11 +701,14 @@ static NSString *const kMPStateKey = @"state";
     [MParticle executeOnMessage:^{
         [self.kitContainer flushSerializedKits];
         [self.kitContainer removeAllSideloadedKits];
-        [[MPUserDefaults standardUserDefaultsWithStateMachine:[MParticle sharedInstance].stateMachine backendController:[MParticle sharedInstance].backendController identity:[MParticle sharedInstance].identity] resetDefaults];
+        [[MPUserDefaults standardUserDefaultsWithStateMachine:self.stateMachine
+                                            backendController:self.backendController
+                                                     identity:self.identity] resetDefaults];
         [self.persistenceController resetDatabase];
         [MParticle executeOnMain:^{
             [self.backendController unproxyOriginalAppDelegate];
-            [MParticle setSharedInstance:nil];
+            predicate = 0;
+            _sharedInstance = nil;
             if (completion) {
                 completion();
             }


### PR DESCRIPTION
 ## Summary
This is the second PR in a series focused on improving testability. Its main goal is to decouple testing code from Swift tests and establish a foundation for better testing practices. Previous PR: https://github.com/mParticle/mparticle-apple-sdk/pull/403

Introduced two new protocols and their mock implementations.
Added a test to ensure the mocks behave as expected.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-119
