### PR TITLE
Fix: SDKE-235 Crash in MPKitAPI.h 

### DIFF
--- a/mParticle-Apple-SDK/MPAttributionResult+MParticlePrivate.m
+++ b/mParticle-Apple-SDK/MPAttributionResult+MParticlePrivate.m
@@ -1,4 +1,5 @@
 #import <mParticle_Apple_SDK/mParticle.h>
+#import "MPAttributionResult+MParticlePrivate.h"
 
 @implementation MPAttributionResult
 


### PR DESCRIPTION
 ## Summary
 - MPAttributionResult wasn't synthesize setter because private header wasn't imported, but the core of the problem was that MPKitAPI class was using private property which wasn't available to them. We should consider to make this property readwrite in public interface instead creating private category or import related header to all places where we create this new private category.
 - create Tech Dept ticket https://rokt.atlassian.net/browse/SDKE-236
 
 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-235
