### PR TITLE
test: Add test coverage for log custom event

### DIFF
--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -12,6 +12,7 @@
 - (void)startWithKeyCallback:(BOOL)firstRun options:(MParticleOptions * _Nonnull)options userDefaults:(id<MPUserDefaultsProtocol>)userDefaults;
 - (void)beginTimedEventCompletionHandler:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
 - (void)logEventCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
+- (void)logCustomEvent:(MPEvent *)event;
 - (void)logScreenCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
 - (void)leaveBreadcrumbCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
 - (void)logErrorCallback:(NSDictionary<NSString *,id> * _Nullable)eventInfo execStatus:(MPExecStatus)execStatus message:(NSString *)message;

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -885,4 +885,53 @@ class MParticleTestsSwift: XCTestCase {
 #endif
 #endif
     }
+    
+    
+    func testLogCustomEventWithNilEvent_logsError() {
+        mparticle.logCustomEvent(nil)
+        XCTAssertEqual(receivedMessage, "mParticle -> Cannot log nil event!")
+    }
+    
+    func testLogCustomEventWithFilterReturningNil_blocksEvent() {
+        let event = MPEvent(name: "blocked", type: .other)!
+        
+        // TODO: add expected execution for other methods within logCustomEvent
+        
+        let executor = ExecutorMock()
+        mparticle.setExecutor(executor)
+        
+        let dataPlanFilter = MPDataPlanFilterMock()
+        dataPlanFilter.transformEventReturnValue = nil
+        mparticle.dataPlanFilter = dataPlanFilter
+        
+        mparticle.logCustomEvent(event)
+        
+        XCTAssertTrue(executor.executeOnMessageQueueAsync)
+        XCTAssertTrue(dataPlanFilter.transformEventCalled)
+        XCTAssertTrue(dataPlanFilter.transformEventEventParam === event)
+        XCTAssertEqual(receivedMessage, "mParticle -> Blocked custom event from kits: \(event)")
+    }
+
+//
+//    func testLogCustomEventWithFilterReturningEvent_forwardsTransformedEvent() {
+//        let event = MPEvent(name: "original", type: .other)
+//        let transformedEvent = MPEvent(name: "transformed", type: .other)
+//        
+//        let filter = MPDataPlanFilterMock()
+//        filter.stubbedEvent = transformedEvent
+//        mparticle.dataPlanFilter = filter
+//        
+//        let kitContainer = MPKitContainerMock()
+//        kitContainer.forwardSDKCallExpectation = XCTestExpectation()
+//        mparticle.setKitContainer(kitContainer)
+//        
+//        mparticle.logCustomEvent(event)
+//        wait(for: [kitContainer.forwardSDKCallExpectation!], timeout: 1.0)
+//        
+//        XCTAssertTrue(filter.transformEventCalled)
+//        XCTAssertEqual(kitContainer.forwardSDKCallEventParam?.name, "transformed")
+//    }
+
+    
+    
 }

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -895,10 +895,11 @@ class MParticleTestsSwift: XCTestCase {
     func testLogCustomEventWithFilterReturningNil_blocksEvent() {
         let event = MPEvent(name: "blocked", type: .other)!
         
-        // TODO: add expected execution for other methods within logCustomEvent
-        
         let executor = ExecutorMock()
         mparticle.setExecutor(executor)
+        
+        let backendController = MPBackendControllerMock()
+        mparticle.backendController = backendController
         
         let dataPlanFilter = MPDataPlanFilterMock()
         dataPlanFilter.transformEventReturnValue = nil
@@ -906,6 +907,12 @@ class MParticleTestsSwift: XCTestCase {
         
         mparticle.logCustomEvent(event)
         
+        XCTAssertNil(event.endTime)
+        XCTAssertEqual(listenerController.onAPICalledApiName?.description, "logCustomEvent:")
+        XCTAssertTrue(listenerController.onAPICalledParameter1 === event)
+        XCTAssertTrue(backendController.logEventCalled)
+        XCTAssertTrue(backendController.logEventEventParam === event)
+        XCTAssertNotNil(backendController.logEventCompletionHandler)
         XCTAssertTrue(executor.executeOnMessageQueueAsync)
         XCTAssertTrue(dataPlanFilter.transformEventCalled)
         XCTAssertTrue(dataPlanFilter.transformEventEventParam === event)

--- a/mParticle-Apple-SDK/Include/MPBackendController.h
+++ b/mParticle-Apple-SDK/Include/MPBackendController.h
@@ -128,7 +128,6 @@ extern const NSInteger kInvalidKey;
 - (void)logError:(nullable NSString *)message exception:(nullable NSException *)exception topmostContext:(nullable id)topmostContext eventInfo:(nullable NSDictionary *)eventInfo completionHandler:(void (^ _Nonnull)(NSString * _Nullable message, MPExecStatus execStatus))completionHandler;
 - (void)logCrash:(nullable NSString *)message stackTrace:(nullable NSString *)stackTrace plCrashReport:(nonnull NSString *)plCrashReport completionHandler:(void (^ _Nonnull)(NSString * _Nullable message, MPExecStatus execStatus)) completionHandler;
 - (void)logBaseEvent:(nonnull MPBaseEvent *)event completionHandler:(void (^ _Nonnull)(MPBaseEvent * _Nonnull event, MPExecStatus execStatus))completionHandler;
-- (void)logEvent:(nonnull MPEvent *)event completionHandler:(void (^ _Nonnull)(MPEvent * _Nonnull event, MPExecStatus execStatus))completionHandler;
 - (void)logCommerceEvent:(nonnull MPCommerceEvent *)commerceEvent completionHandler:(void (^ _Nonnull)(MPCommerceEvent * _Nonnull commerceEvent, MPExecStatus execStatus))completionHandler;
 - (void)logNetworkPerformanceMeasurement:(nonnull MPNetworkPerformance *)networkPerformance completionHandler:(void (^ _Nullable)(MPNetworkPerformance * _Nonnull networkPerformance, MPExecStatus execStatus))completionHandler;
 - (void)logScreen:(nonnull MPEvent *)event completionHandler:(void (^ _Nonnull)(MPEvent * _Nonnull event, MPExecStatus execStatus))completionHandler;


### PR DESCRIPTION
 ## Summary
 - Added full test coverage for `logCustomEvent`

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - All tests pass locally in Xcode and coverage reported by Xcode for the method is **100%**

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-232
