### PR TITLE
test: repurpose mp swift tests swift and cover MPEvent

### DIFF
--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -159,7 +159,24 @@ class MPEventsMParticlePrivateTests: XCTestCase {
     
     // MARK: - Public accessors
     
+    func testSetCategory_withValidCategory_setsCategory() {
+        sut.category = "validCategory"
+        XCTAssertEqual(sut.category, "validCategory")
+    }
     
+    func testSetCategory_withTooLongCategory_discardsAndLogs() {
+        let logger = MParticle.sharedInstance().getLogger()!
+        logger.logLevel = .verbose
+        logger.customLogger = { message in
+           self.receivedMessage = message
+        }
+       
+        let tooLongCategory = String(repeating: "X", count: 4097)
+        sut.category = tooLongCategory
+       
+        XCTAssertEqual(receivedMessage, "mParticle -> The category length is too long. Discarding category.")
+        XCTAssertNil(sut.category)
+   }
     
     
     // MARK: - Public category methods

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -288,5 +288,21 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertEqual(attrs["key"] as? String, "value")
     }
     
+    func testEndTiming_whenStartTimeIsNil() {
+        sut.startTime = Date(timeIntervalSince1970: 0)
+        
+        sut.endTiming()
+        
+        XCTAssertNotNil(sut.endTime)
+        XCTAssertNotNil(sut.duration)
+    }
     
+    func testEndTiming_withoutStartTime_clearsEndTimeAndDuration() {
+        sut.startTime = nil
+        
+        sut.endTiming()
+        
+        XCTAssertNil(sut.endTime)
+        XCTAssertNil(sut.duration)
+    }
 }

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -146,26 +146,24 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertNotEqual(event1.hash, event2.hash)
     }
     
-    // MARK: - Copying
+    // MARK: - NSCopying
     
-//    func testCopy_createsDeepCopy() {
-//        let event1 = MPEvent(name: "Original", type: .other)!
-//        event1.duration = 123
-//        event1.startTime = Date(timeIntervalSince1970: 1000)
-//        event1.endTime = Date(timeIntervalSince1970: 2000)
-//        event1.category = "Category"
-//        
-//        let event2 = event1.copy() as! MPEvent
-//        
-//        // Values are copied
-//        XCTAssertEqual(event1.name, event2.name)
-//        XCTAssertEqual(event1.duration, event2.duration)
-//        XCTAssertEqual(event1.startTime, event2.startTime)
-//        XCTAssertEqual(event1.endTime, event2.endTime)
-//        XCTAssertEqual(event1.category, event2.category)
-//        
-//        // Objects are not the same instance
-//        XCTAssertFalse(event1 === event2)
-//    }
+    func testCopyWithZone_createsDeepCopy() {
+        event1.addCustomFlag("flagValue", withKey: "flagKey")
+        let event2 = event1.copy() as! MPEvent
+        XCTAssertEqual(event1, event2)
+        
+        // Objects are not the same instance
+        XCTAssertFalse(event1 === event2)
+    }
+    
+    // MARK: - Public accessors
+    
+    
+    
+    
+    // MARK: - Public category methods
+    
+    
     
 }

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -10,6 +10,10 @@ class MPEventsMParticlePrivateTests: XCTestCase {
     var receivedMessage: String?
     var mparticle: MParticle!
     
+    var event1: MPEvent!
+    var event1Copy: MPEvent!
+    var event2: MPEvent!
+    
     func customLogger(_ message: String) {
         receivedMessage = message
     }
@@ -20,6 +24,23 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         mparticle.logLevel = .verbose
         mparticle.customLogger = customLogger
         sut = MPEvent()
+        
+        // Default setup for event1 and event2
+        event1 = MPEvent(name: "Event1", type: .other)
+        event1Copy = MPEvent(name: "Event1", type: .other)
+        event2 = MPEvent(name: "Event2", type: .other)
+        
+        event1.duration = 100
+        event1.category = "Category"
+        event1.customAttributes = ["key": "value"]
+        
+        event1Copy.duration = 100
+        event1Copy.category = "Category"
+        event1Copy.customAttributes = ["key": "value"]
+        
+        event2.duration = 100
+        event2.category = "Category2"
+        event2.customAttributes = ["key": "value"]
     }
     
     // MARK: - MPEvent Initialization
@@ -86,4 +107,65 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertTrue(sut.customFlags!.count == 1)
         XCTAssertTrue(description.contains("key"))
     }
+    
+    // MARK: - NSObject
+    
+    func testIsEqual_withSameValues_returnsTrue() {
+        XCTAssertTrue(event1.isEqual(event1Copy))
+    }
+    
+    func testIsEqual_withDifferentName_returnsFalse() {
+        XCTAssertFalse(event1.isEqual(event2))
+    }
+    
+    func testIsEqual_withDifferentDuration_returnsFalse() {
+        event1Copy.duration = 200
+        
+        XCTAssertFalse(event1.isEqual(event1Copy))
+    }
+    
+    func testIsEqual_withCategoryMismatch_returnsFalse() {
+        event1.category = "Category1"
+        event1Copy.category = "Category2"
+        
+        XCTAssertFalse(event1.isEqual(event1Copy))
+    }
+    
+    func testIsEqual_withNilCategoryOnOneSide_returnsFalse() {
+        event1.category = nil
+        event1Copy.category = "Category"
+        
+        XCTAssertFalse(event1.isEqual(event1Copy))
+    }
+    
+    func testHash_isConsistentForSameValues() {
+        XCTAssertEqual(event1.hash, event1Copy.hash)
+    }
+    
+    func testHash_changesWhenNameChanges() {
+        XCTAssertNotEqual(event1.hash, event2.hash)
+    }
+    
+    // MARK: - Copying
+    
+//    func testCopy_createsDeepCopy() {
+//        let event1 = MPEvent(name: "Original", type: .other)!
+//        event1.duration = 123
+//        event1.startTime = Date(timeIntervalSince1970: 1000)
+//        event1.endTime = Date(timeIntervalSince1970: 2000)
+//        event1.category = "Category"
+//        
+//        let event2 = event1.copy() as! MPEvent
+//        
+//        // Values are copied
+//        XCTAssertEqual(event1.name, event2.name)
+//        XCTAssertEqual(event1.duration, event2.duration)
+//        XCTAssertEqual(event1.startTime, event2.startTime)
+//        XCTAssertEqual(event1.endTime, event2.endTime)
+//        XCTAssertEqual(event1.category, event2.category)
+//        
+//        // Objects are not the same instance
+//        XCTAssertFalse(event1 === event2)
+//    }
+    
 }

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -278,6 +278,15 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertNil(sut.endTime)
     }
     
+    func testBreadcrumbDictionaryRepresentation_withAttributes() {
+        event1.customAttributes = ["key": "value"]
+        
+        let dict = event1.breadcrumbDictionaryRepresentation()!
+        XCTAssertEqual(dict["l"] as? String, "Event1") // kMPLeaveBreadcrumbsKey
+        XCTAssertLessThanOrEqual(dict["est"] as! Int, Int(Date().timeIntervalSince1970 * 1000)) // kMPEventStartTimestamp
+        let attrs = dict["attrs"] as! [String: Any]
+        XCTAssertEqual(attrs["key"] as? String, "value")
+    }
     
     
 }

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -305,4 +305,45 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertNil(sut.endTime)
         XCTAssertNil(sut.duration)
     }
+    
+    func testScreenDictionaryRepresentation_withNoDuration_setsEventLengthZero() {
+        event1.duration = nil
+        
+        let dict = event1.screenDictionaryRepresentation()!
+        
+        XCTAssertEqual(dict["n"] as? String, "Event1") // kMPEventNameKey
+        XCTAssertLessThanOrEqual(dict["est"] as! Int, Int(Date().timeIntervalSince1970 * 1000)) // kMPEventStartTimestamp
+        XCTAssertEqual(dict["el"] as? Int, 0) // kMPEventLength
+        XCTAssertNil(dict["flags"]) // kMPEventCustomFlags
+        let attrs = dict["attrs"] as! [String: Any]
+        XCTAssertEqual(attrs["key"] as? String, "value")
+    }
+
+    func testScreenDictionaryRepresentation_withDurationAndCustomAttributes_mergesAttributesAndSetsEventLength() {
+        let dict = event1.screenDictionaryRepresentation()!
+        
+        XCTAssertEqual(dict["n"] as? String, "Event1") // kMPEventNameKey
+        XCTAssertLessThanOrEqual(dict["est"] as! Int, Int(Date().timeIntervalSince1970 * 1000)) // kMPEventStartTimestamp
+        XCTAssertEqual(dict["el"] as? Int, 100) // kMPEventLength
+        XCTAssertNil(dict["flags"]) // kMPEventCustomFlags
+        let attrs = dict["attrs"] as! [String: Any]
+        XCTAssertEqual(attrs["EventLength"] as? Int, 100) // kMPAttrsEventLengthKey
+        XCTAssertEqual(attrs["key"] as? String, "value")
+    }
+
+    func testScreenDictionaryRepresentation_withCustomFlags_includesFlags() {
+        event1.addCustomFlag("flagValue", withKey: "flagKey")
+        
+        let dict = event1.screenDictionaryRepresentation()!
+        
+        XCTAssertEqual(dict["n"] as? String, "Event1") // kMPEventNameKey
+        XCTAssertLessThanOrEqual(dict["est"] as! Int, Int(Date().timeIntervalSince1970 * 1000)) // kMPEventStartTimestamp
+        XCTAssertEqual(dict["el"] as? Int, 100) // kMPEventLength
+        let attrs = dict["attrs"] as! [String: Any]
+        XCTAssertEqual(attrs["EventLength"] as? Int, 100) // kMPAttrsEventLengthKey
+        XCTAssertEqual(attrs["key"] as? String, "value")
+        let flags = dict["flags"] as! [String: Any]
+        XCTAssertEqual(flags["flagKey"] as? [String], ["flagValue"])
+    }
+
 }

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+#if MPARTICLE_LOCATION_DISABLE
+import mParticle_Apple_SDK_NoLocation
+#else
+import mParticle_Apple_SDK
+#endif
+
+class MPEventsMParticlePrivateTests: XCTestCase {
+    var sut: MPEvent!
+    var receivedMessage: String?
+    var mparticle: MParticle!
+    
+    func customLogger(_ message: String) {
+        receivedMessage = message
+    }
+    
+    override func setUp() {
+        super.setUp()
+        mparticle = MParticle()
+        mparticle.logLevel = .verbose
+        mparticle.customLogger = customLogger
+        sut = MPEvent()
+    }
+    
+    // MARK: - MPEvent Initialization
+    
+    func testInit() {
+        // MPEvent properties
+        XCTAssertNotNil(sut)
+        XCTAssertEqual(sut.name, "<<Event With No Name>>")
+        XCTAssertEqual(sut.duration, 0)
+        XCTAssertNil(sut.info)
+        XCTAssertNil(sut.category)
+        XCTAssertNil(sut.endTime)
+        XCTAssertNil(sut.startTime)
+        
+        
+        // MPBaseEvent properties
+        XCTAssertNotNil(sut.timestamp)
+        XCTAssertEqual(sut.messageType, .event)
+        XCTAssertNil(sut.customAttributes)
+        XCTAssertNil(sut.customFlags)
+        XCTAssertTrue(sut.shouldBeginSession)
+        XCTAssertTrue(sut.shouldUploadEvent)
+        XCTAssertEqual(sut.type, .other)
+        XCTAssertEqual(sut.typeName(), "Other")
+    }
+    
+    func testInit_withEmptyName_returnsNil() {
+        let logger = MParticle.sharedInstance().getLogger()!
+        logger.logLevel = .verbose
+        logger.customLogger = { message in
+            self.receivedMessage = message
+        }
+        
+        XCTAssertNil(MPEvent(name: "", type: .other))
+        XCTAssertEqual(receivedMessage, "mParticle -> 'name' is required for MPEvent")
+    }
+    
+    func testInitWithTooLongName_returnsNil() {
+        let logger = MParticle.sharedInstance().getLogger()!
+        logger.logLevel = .verbose
+        logger.customLogger = { message in
+            self.receivedMessage = message
+        }
+        
+        let tooLongName = String(repeating: "X", count: 257)
+        XCTAssertNil(MPEvent(name: tooLongName, type: .other))
+        XCTAssertEqual(receivedMessage, "mParticle -> The event name is too long.")
+        
+    }
+    
+    // MARK: - Description
+        
+    func testDescription() {
+        sut.name = "Desc Test"
+        sut.duration = 10
+        sut.customAttributes = ["mode": "debug"]
+        sut.addCustomFlag("flag", withKey: "key")
+        
+        let description = sut.description
+        XCTAssertTrue(description.contains("Desc Test"))
+        XCTAssertTrue(description.contains("Other"))
+        XCTAssertTrue(description.contains("Duration"))
+        XCTAssertTrue(description.contains("mode"))
+        XCTAssertTrue(sut.customFlags!.count == 1)
+        XCTAssertTrue(description.contains("key"))
+    }
+}

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -288,7 +288,7 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertEqual(attrs["key"] as? String, "value")
     }
     
-    func testEndTiming_whenStartTimeIsNil() {
+    func testEndTiming_withStartTime_setsEndTimeAndDuration() {
         sut.startTime = Date(timeIntervalSince1970: 0)
         
         sut.endTiming()
@@ -297,7 +297,7 @@ class MPEventsMParticlePrivateTests: XCTestCase {
         XCTAssertNotNil(sut.duration)
     }
     
-    func testEndTiming_withoutStartTime_clearsEndTimeAndDuration() {
+    func testEndTiming_whenStartTimeIsNil_clearsEndTimeAndDuration() {
         sut.startTime = nil
         
         sut.endTiming()

--- a/UnitTests/MPEvents+MParticlePrivateTests.swift
+++ b/UnitTests/MPEvents+MParticlePrivateTests.swift
@@ -268,6 +268,16 @@ class MPEventsMParticlePrivateTests: XCTestCase {
     
     // MARK: - Public category methods
     
+    func testBeginTiming_whenEndTimeIsNotNil() {
+        sut.endTime = Date(timeIntervalSince1970: 0)
+        sut.beginTiming()
+        
+        // make sure duration is nil
+        XCTAssertNotNil(sut.startTime)
+        XCTAssertNil(sut.duration)
+        XCTAssertNil(sut.endTime)
+    }
+    
     
     
 }

--- a/UnitTests/MPIdentity+MParticlePrivateTests.swift
+++ b/UnitTests/MPIdentity+MParticlePrivateTests.swift
@@ -5,7 +5,14 @@ import mParticle_Apple_SDK_NoLocation
 import mParticle_Apple_SDK
 #endif
 
-class mParticle_Swift_SDKTests: XCTestCase {
+class MPIdentityMParticlePrivateTests: XCTestCase {
+    var sut: MPIdentity!
+    var mparticle: MParticle!
+    
+    override func setUp() {
+        super.setUp()
+        sut = MPIdentity(rawValue: 0)
+    }
     
     func testNewMPIdentityResponseErrorCodes() {
         XCTAssertNotNil(MPIdentityErrorResponseCode(rawValue: 500))

--- a/UnitTests/MPSwiftTests.swift
+++ b/UnitTests/MPSwiftTests.swift
@@ -6,59 +6,6 @@ import mParticle_Apple_SDK
 #endif
 
 class mParticle_Swift_SDKTests: XCTestCase {
-
-    override func setUp() {
-    }
-
-    override func tearDown() {
-    }
-
-    func testMPEventInit() {
-        var event = MPEvent.init(name: "Dinosaur Run", type: .other)
-        
-        XCTAssertNotNil(event)
-        XCTAssertEqual(event!.typeName(), "Other", "Type name should have been 'other.'")
-        
-        let typeNames = ["Reserved - Not Used", "Navigation", "Location", "Search", "Transaction", "UserContent", "UserPreference", "Social", "Other"]
-        
-        var type = UInt(1)
-        while type < UInt(MPEventType.other.rawValue) {
-            event!.type = MPEventType(rawValue: type)!
-            XCTAssertEqual(event!.typeName(), typeNames[Int(type)], "Type name does not correspond to type enum.")
-            type += 1
-        }
-        
-        let eventInfo: [String : Any] = ["speed": 25,
-                                         "modality":"sprinting"]
-        
-        event!.customAttributes = eventInfo
-        event!.category = "Olympic Games"
-        
-        let copyEvent = event?.copy() as! MPEvent
-        XCTAssertEqual(copyEvent, event, "Copied event object should not have been different.")
-        
-        copyEvent.type = .navigation
-        XCTAssertNotEqual(copyEvent, event, "Copied event object should have been different.")
-        
-        copyEvent.type = event!.type
-        copyEvent.name = "Run Dinosaur"
-        XCTAssertNotEqual(copyEvent, event, "Copied event object should have been different.")
-        
-        copyEvent.name = event!.name
-        copyEvent.customAttributes = nil
-        XCTAssertNotEqual(copyEvent, event, "Copied event object should have been different.")
-        
-        copyEvent.customAttributes = event!.customAttributes
-        copyEvent.duration = 1
-        XCTAssertNotEqual(copyEvent, event, "Copied event object should have been different.")
-
-        copyEvent.duration = event!.duration
-        copyEvent.category = nil
-        XCTAssertNotEqual(copyEvent, event, "Copied event object should have been different.")
-        
-        event = MPEvent.init()
-        XCTAssertNotNil(event)
-    }
     
     func testNewMPIdentityResponseErrorCodes() {
         XCTAssertNotNil(MPIdentityErrorResponseCode(rawValue: 500))

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -42,6 +42,8 @@
 - (NSTimeInterval)uploadInterval;
 - (NSDictionary<NSString *, id> *)userAttributesForUserId:(NSNumber *)userId;
 
+- (MPLog*)getLogger;
+
 @property (nonatomic, strong, nonnull) id<MPBackendControllerProtocol> backendController;
 @property (nonatomic, strong) id<SettingsProviderProtocol> settingsProvider;
 @property (nonatomic, strong, nullable) id<MPDataPlanFilterProtocol> dataPlanFilter;

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -12,6 +12,7 @@
 - (void)startWithKeyCallback:(BOOL)firstRun options:(MParticleOptions * _Nonnull)options userDefaults:(id<MPUserDefaultsProtocol>)userDefaults;
 - (void)beginTimedEventCompletionHandler:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
 - (void)logEventCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
+- (void)logEvent:(MPBaseEvent *)event;
 - (void)logCustomEvent:(MPEvent *)event;
 - (void)logScreenCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
 - (void)leaveBreadcrumbCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
@@ -19,6 +20,7 @@
 - (void)logExceptionCallback:(NSException * _Nonnull)exception execStatus:(MPExecStatus)execStatus message:(NSString *)message topmostContext:(id _Nullable)topmostContext;
 - (void)logCrashCallback:(MPExecStatus)execStatus message:(NSString * _Nullable)message;
 - (void)logCommerceEventCallback:(MPCommerceEvent *)commerceEvent execStatus:(MPExecStatus)execStatus;
+- (void)logCommerceEvent:(MPCommerceEvent *)commerceEvent;
 - (void)logLTVIncreaseCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
 - (void)logNetworkPerformanceCallback:(MPExecStatus)execStatus;
 + (void)setSharedInstance:(MParticle *)instance;

--- a/UnitTests/Mocks/MPDataPlanFilterMock.swift
+++ b/UnitTests/Mocks/MPDataPlanFilterMock.swift
@@ -5,6 +5,7 @@ import mParticle_Apple_SDK_NoLocation
 import mParticle_Apple_SDK
 #endif
 
+@objcMembers
 class MPDataPlanFilterMock: NSObject, MPDataPlanFilterProtocol {
     var isBlockedUserIdentityTypeCalled = false
     var isBlockedUserIdentityTypeUserIdentityTypeParam: MPIdentity?
@@ -44,5 +45,25 @@ class MPDataPlanFilterMock: NSObject, MPDataPlanFilterProtocol {
         transformEventForScreenEventCalled = true
         transformEventForScreenEventScreenEventParam = screenEvent
         return transformEventForScreenEventReturnValue
+    }
+    
+    var transformEventForCommerceEventCalled = false
+    var transformEventForCommerceEventParam: MPCommerceEvent?
+    var transformEventForCommerceEventReturnValue: MPCommerceEvent?
+    
+    func transformEvent(forCommerceEvent commerceEvent: MPCommerceEvent) -> MPCommerceEvent? {
+        transformEventForCommerceEventCalled = true
+        transformEventForCommerceEventParam = commerceEvent
+        return transformEventForCommerceEventReturnValue
+    }
+    
+    var transformEventForBaseEventCalled = false
+    var transformEventForBaseEventParam: MPBaseEvent?
+    var transformEventForBaseEventReturnValue: MPBaseEvent?
+    
+    func transformEvent(forBaseEvent baseEvent: MPBaseEvent) -> MPBaseEvent? {
+        transformEventForBaseEventCalled = true
+        transformEventForBaseEventParam = baseEvent
+        return transformEventForBaseEventReturnValue
     }
 }

--- a/UnitTests/Mocks/MPKitContainerMock.swift
+++ b/UnitTests/Mocks/MPKitContainerMock.swift
@@ -42,14 +42,14 @@ class MPKitContainerMock: MPKitContainerProtocol {
         forwardSDKCallExpectation?.fulfill()
     }
     
-    var forwardSDKCallBathParam: [AnyHashable : Any]?
+    var forwardSDKCallBatchParam: [AnyHashable : Any]?
     
     func forwardSDKCall(_ selector: Selector,
                         batch: [AnyHashable : Any],
                         kitHandler: @escaping (any MPKitProtocol, [AnyHashable : Any], MPKitConfiguration) -> Void) {
         forwardSDKCallCalled = true
         forwardSDKCallSelectorParam = selector
-        forwardSDKCallBathParam = batch
+        forwardSDKCallBatchParam = batch
         forwardSDKCallKitHandlerParam = kitHandler
         forwardSDKCallExpectation?.fulfill()
     }

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -140,7 +140,6 @@
 		534CD2A429CE2CE1008452B3 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79C8829CE019F00E7489F /* OCMock.xcframework */; };
 		534CD2A629CE2CE1008452B3 /* sample_dataplan2.json in Resources */ = {isa = PBXBuildFile; fileRef = 53A79C9829CE019F00E7489F /* sample_dataplan2.json */; };
 		534CD2AC29CE2CF1008452B3 /* mParticle_Apple_SDK_NoLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79DC629CE23F700E7489F /* mParticle_Apple_SDK_NoLocation.framework */; };
-		534CD2AD29CE2E8F008452B3 /* MPSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9229CE019F00E7489F /* MPSwiftTests.swift */; };
 		5399DDB82CA727E5006526E1 /* MPZip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5399DDB72CA727E1006526E1 /* MPZip.swift */; };
 		5399DDB92CA727E5006526E1 /* MPZip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5399DDB72CA727E1006526E1 /* MPZip.swift */; };
 		53A6A9EC2B88EDD9007ABD7A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D3BA75152B614E3D008C3C65 /* PrivacyInfo.xcprivacy */; };
@@ -325,7 +324,6 @@
 		53A79CD929CE019F00E7489F /* MPResponseEventsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C8F29CE019F00E7489F /* MPResponseEventsTest.m */; };
 		53A79CDA29CE019F00E7489F /* MPDataPlanFilterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9029CE019F00E7489F /* MPDataPlanFilterTests.m */; };
 		53A79CDB29CE019F00E7489F /* MPStateMachineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9129CE019F00E7489F /* MPStateMachineTests.m */; };
-		53A79CDC29CE019F00E7489F /* MPSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9229CE019F00E7489F /* MPSwiftTests.swift */; };
 		53A79CDD29CE019F00E7489F /* MPURLRequestBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9329CE019F00E7489F /* MPURLRequestBuilderTests.m */; };
 		53A79CDE29CE019F00E7489F /* MPForwardQueueItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9529CE019F00E7489F /* MPForwardQueueItemTests.m */; };
 		53A79CDF29CE019F00E7489F /* MPDateFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C9629CE019F00E7489F /* MPDateFormatterTests.m */; };
@@ -510,6 +508,8 @@
 		53FDD1BE2AE871AF003D5FA1 /* MPIHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */; };
 		72D356532E84601A0012A0C2 /* MPEvents+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */; };
 		72D356542E84601A0012A0C2 /* MPEvents+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */; };
+		72FEBD172E86FE3B00B8341F /* MPIdentity+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FEBD162E86FE2D00B8341F /* MPIdentity+MParticlePrivateTests.swift */; };
+		72FEBD182E86FE3B00B8341F /* MPIdentity+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FEBD162E86FE2D00B8341F /* MPIdentity+MParticlePrivateTests.swift */; };
 		7E0387812DB913D2003B7D5E /* MPRokt.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E03877F2DB913D2003B7D5E /* MPRokt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E0387822DB913D2003B7D5E /* MPRokt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0387802DB913D2003B7D5E /* MPRokt.m */; };
 		7E0387832DB913D2003B7D5E /* MPRokt.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E03877F2DB913D2003B7D5E /* MPRokt.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -801,7 +801,6 @@
 		53A79C8F29CE019F00E7489F /* MPResponseEventsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPResponseEventsTest.m; sourceTree = "<group>"; };
 		53A79C9029CE019F00E7489F /* MPDataPlanFilterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDataPlanFilterTests.m; sourceTree = "<group>"; };
 		53A79C9129CE019F00E7489F /* MPStateMachineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPStateMachineTests.m; sourceTree = "<group>"; };
-		53A79C9229CE019F00E7489F /* MPSwiftTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPSwiftTests.swift; sourceTree = "<group>"; };
 		53A79C9329CE019F00E7489F /* MPURLRequestBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPURLRequestBuilderTests.m; sourceTree = "<group>"; };
 		53A79C9429CE019F00E7489F /* MPKitSecondTestClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitSecondTestClass.h; sourceTree = "<group>"; };
 		53A79C9529CE019F00E7489F /* MPForwardQueueItemTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPForwardQueueItemTests.m; sourceTree = "<group>"; };
@@ -845,6 +844,7 @@
 		53E20DC62CBFFCD200146A97 /* NSArray+MPCaseInsensitiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSArray+MPCaseInsensitiveTests.swift"; sourceTree = "<group>"; };
 		53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPIHasher.swift; sourceTree = "<group>"; };
 		72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPEvents+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
+		72FEBD162E86FE2D00B8341F /* MPIdentity+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPIdentity+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		7E03877F2DB913D2003B7D5E /* MPRokt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPRokt.h; sourceTree = "<group>"; };
 		7E0387802DB913D2003B7D5E /* MPRokt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPRokt.m; sourceTree = "<group>"; };
 		7E15B2052D94617900C1FF3E /* MPRoktTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPRoktTests.m; sourceTree = "<group>"; };
@@ -1298,12 +1298,12 @@
 				35329FEB2E54C480009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift */,
 				35E3FCD12E549AED00DB5B18 /* MParticleSession+MParticlePrivateTests.swift */,
 				35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */,
+				72FEBD162E86FE2D00B8341F /* MPIdentity+MParticlePrivateTests.swift */,
 				72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */,
 				53A79C8729CE019F00E7489F /* Libraries */,
 				53A79C9729CE019F00E7489F /* JSON */,
 				53A79CB429CE019F00E7489F /* Info.plist */,
 				53A79C7129CE019E00E7489F /* mParticle_iOS_SDKTests-Bridging-Header.h */,
-				53A79C9229CE019F00E7489F /* MPSwiftTests.swift */,
 				53E20DC62CBFFCD200146A97 /* NSArray+MPCaseInsensitiveTests.swift */,
 				D3961CE32CC0C2A0003B3194 /* NSString+MPPercentEscapeTests.swift */,
 				53A79C6829CE019E00E7489F /* MPPersistenceControllerTests.mm */,
@@ -1836,10 +1836,10 @@
 				534CD28F29CE2CE1008452B3 /* MPIdentityApiRequestTests.m in Sources */,
 				534CD29029CE2CE1008452B3 /* MPKitAppsFlyerTest.m in Sources */,
 				534CD29129CE2CE1008452B3 /* MPEventTests.m in Sources */,
-				534CD2AD29CE2E8F008452B3 /* MPSwiftTests.swift in Sources */,
 				534CD29229CE2CE1008452B3 /* MPMessageBuilderTests.m in Sources */,
 				534CD29329CE2CE1008452B3 /* MPKitTestClass.m in Sources */,
 				534CD29429CE2CE1008452B3 /* MPKitContainerTests.m in Sources */,
+				72FEBD182E86FE3B00B8341F /* MPIdentity+MParticlePrivateTests.swift in Sources */,
 				534CD29529CE2CE1008452B3 /* MPBase_Attribute_Event_ProjectionTests.m in Sources */,
 				534CD29629CE2CE1008452B3 /* MPConsumerInfoTests.m in Sources */,
 				359BB0062E57A56800A8A704 /* MPUserDefaultsMock.swift in Sources */,
@@ -1981,7 +1981,6 @@
 				356D4A592E58B09D00CB69FE /* SettingsProviderMock.swift in Sources */,
 				53A79CD229CE019F00E7489F /* MPBackendControllerTests.m in Sources */,
 				53A79CF329CE019F00E7489F /* MPKitConfigurationTests.mm in Sources */,
-				53A79CDC29CE019F00E7489F /* MPSwiftTests.swift in Sources */,
 				53A79CBE29CE019F00E7489F /* MPNetworkCommunicationTests.m in Sources */,
 				53A79CF429CE019F00E7489F /* MPAliasRequestTests.m in Sources */,
 				53A79CF129CE019F00E7489F /* MPAliasResponseTests.m in Sources */,
@@ -2035,6 +2034,7 @@
 				53A79CC429CE019F00E7489F /* MPMessageBuilderTests.m in Sources */,
 				53A79CC329CE019F00E7489F /* MPKitTestClass.m in Sources */,
 				53A79CD529CE019F00E7489F /* MPKitContainerTests.m in Sources */,
+				72FEBD172E86FE3B00B8341F /* MPIdentity+MParticlePrivateTests.swift in Sources */,
 				53A79CBC29CE019F00E7489F /* MPBase_Attribute_Event_ProjectionTests.m in Sources */,
 				53A79CEA29CE019F00E7489F /* MPConsumerInfoTests.m in Sources */,
 				359BB0072E57A56800A8A704 /* MPUserDefaultsMock.swift in Sources */,

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -508,6 +508,8 @@
 		53E20DC82CBFFCD200146A97 /* NSArray+MPCaseInsensitiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E20DC62CBFFCD200146A97 /* NSArray+MPCaseInsensitiveTests.swift */; };
 		53FDD1BD2AE871AF003D5FA1 /* MPIHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */; };
 		53FDD1BE2AE871AF003D5FA1 /* MPIHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */; };
+		72D356532E84601A0012A0C2 /* MPEvents+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */; };
+		72D356542E84601A0012A0C2 /* MPEvents+MParticlePrivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */; };
 		7E0387812DB913D2003B7D5E /* MPRokt.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E03877F2DB913D2003B7D5E /* MPRokt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E0387822DB913D2003B7D5E /* MPRokt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0387802DB913D2003B7D5E /* MPRokt.m */; };
 		7E0387832DB913D2003B7D5E /* MPRokt.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E03877F2DB913D2003B7D5E /* MPRokt.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -842,6 +844,7 @@
 		53B33E892A4606CD00CC8A19 /* MPSideloadedKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPSideloadedKit.swift; sourceTree = "<group>"; };
 		53E20DC62CBFFCD200146A97 /* NSArray+MPCaseInsensitiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSArray+MPCaseInsensitiveTests.swift"; sourceTree = "<group>"; };
 		53FDD1BC2AE871AF003D5FA1 /* MPIHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPIHasher.swift; sourceTree = "<group>"; };
+		72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MPEvents+MParticlePrivateTests.swift"; sourceTree = "<group>"; };
 		7E03877F2DB913D2003B7D5E /* MPRokt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPRokt.h; sourceTree = "<group>"; };
 		7E0387802DB913D2003B7D5E /* MPRokt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPRokt.m; sourceTree = "<group>"; };
 		7E15B2052D94617900C1FF3E /* MPRoktTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPRoktTests.m; sourceTree = "<group>"; };
@@ -1295,6 +1298,7 @@
 				35329FEB2E54C480009AC4FD /* MPNetworkOptions+MParticlePrivateTests.swift */,
 				35E3FCD12E549AED00DB5B18 /* MParticleSession+MParticlePrivateTests.swift */,
 				35E3FCC22E53B5C200DB5B18 /* MPAttributionResult+MParticlePrivateTests.swift */,
+				72D356522E8460020012A0C2 /* MPEvents+MParticlePrivateTests.swift */,
 				53A79C8729CE019F00E7489F /* Libraries */,
 				53A79C9729CE019F00E7489F /* JSON */,
 				53A79CB429CE019F00E7489F /* Info.plist */,
@@ -1808,6 +1812,7 @@
 				534CD27D29CE2CE1008452B3 /* MPDataModelTests.m in Sources */,
 				534CD27F29CE2CE1008452B3 /* NSNumber+MPFormatterTests.m in Sources */,
 				351779502E706BF8004BF05E /* ExecutorMock.swift in Sources */,
+				72D356542E84601A0012A0C2 /* MPEvents+MParticlePrivateTests.swift in Sources */,
 				351308202E6729DA002A3AD6 /* MPKitContainerMock.swift in Sources */,
 				534CD28029CE2CE1008452B3 /* MPResponseEventsTest.m in Sources */,
 				534CD28129CE2CE1008452B3 /* MPConsentStateTests.m in Sources */,
@@ -2002,6 +2007,7 @@
 				53A79CCC29CE019F00E7489F /* MPIntegrationAttributesTest.m in Sources */,
 				53A79CBD29CE019F00E7489F /* MPDataModelTests.m in Sources */,
 				3517794F2E706BF8004BF05E /* ExecutorMock.swift in Sources */,
+				72D356532E84601A0012A0C2 /* MPEvents+MParticlePrivateTests.swift in Sources */,
 				3513081F2E6729DA002A3AD6 /* MPKitContainerMock.swift in Sources */,
 				53A79CEE29CE019F00E7489F /* NSNumber+MPFormatterTests.m in Sources */,
 				53A79CD929CE019F00E7489F /* MPResponseEventsTest.m in Sources */,

--- a/mParticle-Apple-SDK/Event/MPEvent.m
+++ b/mParticle-Apple-SDK/Event/MPEvent.m
@@ -5,11 +5,50 @@
 #import "MPProduct.h"
 #import "MPProduct+Dictionary.h"
 #import "mParticle.h"
+#import "MParticleSwift.h"
+
+@interface EventBuilder : NSObject
+
+- (instancetype)initWithLogger:(MPLog*)logger;
+
+- (MPEvent*)mpEventWithName:(NSString*)name type:(MPEventType)type;
+
+@end
+
+@implementation EventBuilder
+
+MPLog* _logger;
+
+
+- (instancetype)initWithLogger:(MPLog*)logger {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    _logger = logger;
+    return self;
+}
+
+- (MPEvent*)mpEventWithName:(NSString*)name type:(MPEventType)type {
+    if (name.length == 0) {
+        [_logger error:@"'name' is required for MPEvent"];
+        return nil;
+    }
+    
+    if (name.length > LIMIT_ATTR_KEY_LENGTH) {
+        [_logger error:@"The event name is too long."];
+        return nil;
+    }
+    return [[MPEvent alloc] initWithName:name type:type];
+}
+
+@end
 
 @interface MParticle()
 
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
-
+- (MPLog*)getLogger;
 @end
 
 NSString *const kMPEventCategoryKey = @"$Category";
@@ -33,13 +72,14 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
         return nil;
     }
     
-    if (!name || name.length == 0) {
-        MPILogError(@"'name' is required for MPEvent")
+    MPLog *logger = MParticle.sharedInstance.getLogger;
+    if (name.length == 0) {
+        [logger error: @"'name' is required for MPEvent"];
         return nil;
     }
     
     if (name.length > LIMIT_ATTR_KEY_LENGTH) {
-        MPILogError(@"The event name is too long.");
+        [logger error: @"The event name is too long."];
         return nil;
     }
     

--- a/mParticle-Apple-SDK/Event/MPEvent.m
+++ b/mParticle-Apple-SDK/Event/MPEvent.m
@@ -193,11 +193,7 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
         }
         
         if (category) {
-            if (category.length <= LIMIT_ATTR_VALUE_LENGTH) {
-                attributes[kMPEventCategoryKey] = category;
-            } else {
-                [_logger error:@"The event category is too long. Discarding category."];
-            }
+            attributes[kMPEventCategoryKey] = category;
         }
     }
     
@@ -221,13 +217,14 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
 }
 
 - (void)setName:(NSString *)name {
+    MPLog *logger = MParticle.sharedInstance.getLogger;
     if (name.length == 0) {
-        [_logger error:@"'name' cannot be nil or empty."];
+        [logger error:@"'name' cannot be nil or empty."];
         return;
     }
     
     if (name.length > LIMIT_ATTR_KEY_LENGTH) {
-        [_logger error:@"The event name is too long."];
+        [logger error:@"The event name is too long."];
         return;
     }
     

--- a/mParticle-Apple-SDK/Event/MPEvent.m
+++ b/mParticle-Apple-SDK/Event/MPEvent.m
@@ -1,7 +1,6 @@
 #import "MPEvent.h"
 #import "MPIConstants.h"
 #import "MPSession.h"
-#import "MPILogger.h"
 #import "MPProduct.h"
 #import "MPProduct+Dictionary.h"
 #import "mParticle.h"
@@ -154,7 +153,7 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
     if (category.length <= LIMIT_ATTR_VALUE_LENGTH) {
         _category = category;
     } else {
-        MPILogError(@"The category length is too long. Discarding category.");
+        [_logger error:@"The category length is too long. Discarding category."];
         _category = nil;
     }
 }
@@ -196,7 +195,7 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
             if (category.length <= LIMIT_ATTR_VALUE_LENGTH) {
                 attributes[kMPEventCategoryKey] = category;
             } else {
-                MPILogError(@"The event category is too long. Discarding category.");
+                [_logger error:@"The event category is too long. Discarding category."];
             }
         }
     }
@@ -222,12 +221,12 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
 
 - (void)setName:(NSString *)name {
     if (name.length == 0) {
-        MPILogError(@"'name' cannot be nil or empty.")
+        [_logger error:@"'name' cannot be nil or empty."];
         return;
     }
     
     if (name.length > LIMIT_ATTR_KEY_LENGTH) {
-        MPILogError(@"The event name is too long.");
+        [_logger error:@"The event name is too long."];
         return;
     }
     

--- a/mParticle-Apple-SDK/Event/MPEvent.m
+++ b/mParticle-Apple-SDK/Event/MPEvent.m
@@ -153,7 +153,8 @@ NSString *const kMPAttrsEventLengthKey = @"EventLength";
     if (category.length <= LIMIT_ATTR_VALUE_LENGTH) {
         _category = category;
     } else {
-        [_logger error:@"The category length is too long. Discarding category."];
+        MPLog *logger = MParticle.sharedInstance.getLogger;
+        [logger error:@"The category length is too long. Discarding category."];
         _category = nil;
     }
 }

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -1242,10 +1242,6 @@ MPLog* logger;
         [eventDictionary addEntriesFromDictionary:eventInfo];
     }
     
-    if (!eventName) {
-        eventName = @"Increase LTV";
-    }
-    
     MPEvent *event = [[MPEvent alloc] initWithName:eventName type:MPEventTypeTransaction];
     event.customAttributes = eventDictionary;
     

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -104,6 +104,10 @@ MPLog* logger;
     }
 }
 
+- (MPLog*)getLogger {
+    return logger;
+}
+
 + (dispatch_queue_t)messageQueue {
     return executor.messageQueue;
 }

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -799,9 +799,7 @@ MPLog* logger;
 }
 
 - (void)logEvent:(MPBaseEvent *)event {
-    if (event == nil) {
-        [logger error:@"Cannot log nil event!"];
-    } else if ([event isKindOfClass:[MPEvent class]]) {
+    if ([event isKindOfClass:[MPEvent class]]) {
         [self logCustomEvent:(MPEvent *)event];
     } else if ([event isKindOfClass:[MPCommerceEvent class]]) {
 #pragma clang diagnostic push
@@ -1188,10 +1186,6 @@ MPLog* logger;
 }
 
 - (void)logCommerceEvent:(MPCommerceEvent *)commerceEvent {
-    if (commerceEvent == nil) {
-        [logger error:@"Cannot log nil commerce event!"];
-        return;
-    }
     if (!commerceEvent.timestamp) {
         commerceEvent.timestamp = [NSDate date];
     }


### PR DESCRIPTION
 ## Summary
 - Reorganized `MPSwiftTests.swift` and added full test coverage for `MPEvent.m` file

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - All new and old tests pass.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-263
