### PR TITLE
Feat: SDKE-255 Add test coverage for add test coverage for leave breadcrumb method

### DIFF
--- a/UnitTests/Mocks/MPBackendControllerMock.swift
+++ b/UnitTests/Mocks/MPBackendControllerMock.swift
@@ -110,8 +110,11 @@ class MPBackendControllerMock: NSObject, MPBackendControllerProtocol {
         logEventEventParam = event
         logEventCompletionHandler = completionHandler
     }
+    
+    var eventWithNameEventNameParam: String?
 
     func event(withName eventName: String) -> MPEvent? {
+        eventWithNameEventNameParam = eventName
         guard let set = eventSet else { return nil }
         for case let evt as MPEvent in set {
             if evt.name == eventName { return evt }


### PR DESCRIPTION
 ## Summary
- Refactored tests to make them simpler.
- Added tests for the breadcrumb method.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-255
