### PR TITLE
test: SDKE-255 Add test coverage for add test coverage for leave breadcrumb method

### DIFF
--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -1169,5 +1169,12 @@ class MParticleTestsSwift: XCTestCase {
             """
         )
     }
+    
+    func testLeaveBreadcrumbCallback_execStatusFail_noLoggedMessages() {
+        let expectedEvent = MPEvent()
+        mparticle.leaveBreadcrumbCallback(expectedEvent, execStatus: .fail)
+
+        XCTAssertNil(receivedMessage)
+    }
 
 }

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -9,6 +9,7 @@ class MParticleTestsSwift: XCTestCase {
     var receivedMessage: String?
     var mparticle: MParticle!
     var listenerController: MPListenerControllerMock!
+    var kitContainer: MPKitContainerMock!
     
     func customLogger(_ message: String) {
         receivedMessage = message
@@ -23,6 +24,9 @@ class MParticleTestsSwift: XCTestCase {
         listenerController = MPListenerControllerMock()
         listenerController.onAPICalledExpectation = XCTestExpectation()
         mparticle.listenerController = listenerController
+        
+        kitContainer = MPKitContainerMock()
+        mparticle.setKitContainer(kitContainer)
     }
     
     override func tearDown() {
@@ -566,11 +570,8 @@ class MParticleTestsSwift: XCTestCase {
     }
     
     func testSessionDidBegin() {
-        let kitContainer = MPKitContainerMock()
         kitContainer.forwardSDKCallExpectation = XCTestExpectation()
-        mparticle.setKitContainer(kitContainer)
         mparticle.sessionDidBegin(MPSession())
-        
         
         wait(for: [kitContainer.forwardSDKCallExpectation!], timeout: 1.0)
         
@@ -583,11 +584,8 @@ class MParticleTestsSwift: XCTestCase {
     }
     
     func testSessionDidEnd() {
-        let kitContainer = MPKitContainerMock()
         kitContainer.forwardSDKCallExpectation = XCTestExpectation()
-        mparticle.setKitContainer(kitContainer)
         mparticle.sessionDidEnd(MPSession())
-        
         
         wait(for: [kitContainer.forwardSDKCallExpectation!], timeout: 1.0)
         
@@ -602,13 +600,10 @@ class MParticleTestsSwift: XCTestCase {
     func testResetForSwitchingWorkspaces() {
         let expectation = XCTestExpectation()
         
-        let kitContainer = MPKitContainerMock()
-        
         let persistenceController = MPPersistenceControllerMock()
         
         let backendController = MPBackendControllerMock()
-        
-        mparticle.setKitContainer(kitContainer)
+    
         mparticle.persistenceController = persistenceController
         mparticle.backendController = backendController
         
@@ -683,8 +678,6 @@ class MParticleTestsSwift: XCTestCase {
     func testForwardLogInstall() {
         let executor = ExecutorMock()
         mparticle.setExecutor(executor)
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
         mparticle.forwardLogInstall()
         XCTAssertEqual(executor.executeOnMainAsync, true)
         XCTAssertTrue(kitContainer.forwardSDKCallCalled)
@@ -698,8 +691,6 @@ class MParticleTestsSwift: XCTestCase {
     func testForwardLogUpdate() {
         let executor = ExecutorMock()
         mparticle.setExecutor(executor)
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
         mparticle.forwardLogUpdate()
         XCTAssertEqual(executor.executeOnMainAsync, true)
         XCTAssertTrue(kitContainer.forwardSDKCallCalled)
@@ -883,9 +874,6 @@ class MParticleTestsSwift: XCTestCase {
         dataPlanFilter.transformEventForBaseEventReturnValue = transformedEvent
         mparticle.dataPlanFilter = dataPlanFilter
         
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
-        
         mparticle.logEvent(event)
         
         // Verify listener was called
@@ -973,9 +961,6 @@ class MParticleTestsSwift: XCTestCase {
         let dataPlanFilter = MPDataPlanFilterMock()
         dataPlanFilter.transformEventReturnValue = transformedEvent
         mparticle.dataPlanFilter = dataPlanFilter
-        
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
         
         mparticle.logCustomEvent(event)
         
@@ -1082,9 +1067,6 @@ class MParticleTestsSwift: XCTestCase {
         let dataPlanFilter = MPDataPlanFilterMock()
         dataPlanFilter.transformEventForCommerceEventReturnValue = transformedCommerceEvent
         mparticle.dataPlanFilter = dataPlanFilter
-        
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
         
         mparticle.logCommerceEvent(commerceEvent)
         
@@ -1193,9 +1175,6 @@ class MParticleTestsSwift: XCTestCase {
         dataPlanFilter.transformEventReturnValue = nil
         mparticle.dataPlanFilter = dataPlanFilter
 
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
-
         mparticle.logLTVIncreaseCallback(event, execStatus: .success)
         
         XCTAssertTrue(dataPlanFilter.transformEventCalled)
@@ -1214,9 +1193,6 @@ class MParticleTestsSwift: XCTestCase {
         
         let executor = ExecutorMock()
         mparticle.setExecutor(executor)
-
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
 
         mparticle.logLTVIncreaseCallback(event, execStatus: .success)
         
@@ -1238,9 +1214,6 @@ class MParticleTestsSwift: XCTestCase {
     
     func testLeaveBreadcrumbCallback_withDataFilterNotSet_forwardsTransformedEvent() {
         XCTAssertNil(mparticle.dataPlanFilter)
-        
-        let kitContainer = MPKitContainerMock()
-        mparticle.setKitContainer(kitContainer)
         
         let executor = ExecutorMock()
         mparticle.setExecutor(executor)

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -10,6 +10,7 @@ class MParticleTestsSwift: XCTestCase {
     var mparticle: MParticle!
     var listenerController: MPListenerControllerMock!
     var kitContainer: MPKitContainerMock!
+    var executor: ExecutorMock!
     
     func customLogger(_ message: String) {
         receivedMessage = message
@@ -27,6 +28,9 @@ class MParticleTestsSwift: XCTestCase {
         
         kitContainer = MPKitContainerMock()
         mparticle.setKitContainer(kitContainer)
+        
+        executor = ExecutorMock()
+        mparticle.setExecutor(executor)
     }
     
     override func tearDown() {
@@ -641,8 +645,6 @@ class MParticleTestsSwift: XCTestCase {
         let backendController = MPBackendControllerMock()
         backendController.session = nil
         backendController.tempSessionReturnValue = nil
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         mparticle.backendController = backendController
         mparticle.beginSession()
         XCTAssertTrue(executor.executeOnMessageQueueAsync)
@@ -655,8 +657,6 @@ class MParticleTestsSwift: XCTestCase {
     func testEndSessionNoSession() {
         let backendController = MPBackendControllerMock()
         backendController.session = nil
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         mparticle.backendController = backendController
         mparticle.endSession()
         XCTAssertEqual(executor.executeOnMessageQueueAsync, true)
@@ -666,8 +666,6 @@ class MParticleTestsSwift: XCTestCase {
     func testEndSessionWithSession() {
         let backendController = MPBackendControllerMock()
         backendController.session = MPSession()
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         mparticle.backendController = backendController
         mparticle.endSession()
         XCTAssertEqual(executor.executeOnMessageQueueAsync, true)
@@ -676,8 +674,6 @@ class MParticleTestsSwift: XCTestCase {
     }
     
     func testForwardLogInstall() {
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         mparticle.forwardLogInstall()
         XCTAssertEqual(executor.executeOnMainAsync, true)
         XCTAssertTrue(kitContainer.forwardSDKCallCalled)
@@ -689,8 +685,6 @@ class MParticleTestsSwift: XCTestCase {
     }
     
     func testForwardLogUpdate() {
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         mparticle.forwardLogUpdate()
         XCTAssertEqual(executor.executeOnMainAsync, true)
         XCTAssertTrue(kitContainer.forwardSDKCallCalled)
@@ -826,9 +820,6 @@ class MParticleTestsSwift: XCTestCase {
     func testLogEventWithFilterReturningNil_blocksEvent() {
         let event = MPBaseEvent(eventType: .other)!
         
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
-        
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
         
@@ -863,9 +854,6 @@ class MParticleTestsSwift: XCTestCase {
     func testLogBaseEventWithFilterReturningEvent_forwardsTransformedEvent() {
         let event = MPBaseEvent(eventType: .other)!
         let transformedEvent = MPBaseEvent(eventType: .addToCart)!
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
@@ -912,10 +900,7 @@ class MParticleTestsSwift: XCTestCase {
     
     func testLogCustomEventWithFilterReturningNil_blocksEvent() {
         let event = MPEvent(name: "blocked", type: .other)!
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
-        
+                
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
         
@@ -951,9 +936,6 @@ class MParticleTestsSwift: XCTestCase {
     func testLogCustomEventWithFilterReturningEvent_forwardsTransformedEvent() {
         let event = MPEvent(name: "original", type: .other)!
         let transformedEvent = MPEvent(name: "transformed", type: .other)!
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
@@ -996,10 +978,6 @@ class MParticleTestsSwift: XCTestCase {
     func testLogCommerceEvent_assignsTimestampWhenNil() {
         let commerceEvent = MPCommerceEvent(action: .purchase)!
         commerceEvent.setTimestamp(nil)
-
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
@@ -1015,10 +993,7 @@ class MParticleTestsSwift: XCTestCase {
     
     func testLogCommerceEventWithFilterReturningNil_blocksEvent() {
         let commerceEvent = MPCommerceEvent(eventType: .other)!
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
-        
+                
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
         
@@ -1057,9 +1032,6 @@ class MParticleTestsSwift: XCTestCase {
     func testLogCommerceEventWithFilterReturningEvent_forwardsTransformedEvent() {
         let commerceEvent = MPCommerceEvent(eventType: .other)!
         let transformedCommerceEvent = MPCommerceEvent(eventType: .viewDetail)!
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
         
         let backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
@@ -1190,9 +1162,6 @@ class MParticleTestsSwift: XCTestCase {
         let dataPlanFilter = MPDataPlanFilterMock()
         dataPlanFilter.transformEventReturnValue = transformedEvent
         mparticle.dataPlanFilter = dataPlanFilter
-        
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
 
         mparticle.logLTVIncreaseCallback(event, execStatus: .success)
         
@@ -1215,10 +1184,6 @@ class MParticleTestsSwift: XCTestCase {
     func testLeaveBreadcrumbCallback_withDataFilterNotSet_forwardsTransformedEvent() {
         XCTAssertNil(mparticle.dataPlanFilter)
         
-        let executor = ExecutorMock()
-        mparticle.setExecutor(executor)
-        
-        let expectedEvent = MPEvent()
         mparticle.leaveBreadcrumbCallback(MPEvent(), execStatus: .success)
         
         // Verify executor usage

--- a/UnitTests/MParticleTestsSwift.swift
+++ b/UnitTests/MParticleTestsSwift.swift
@@ -12,6 +12,7 @@ class MParticleTestsSwift: XCTestCase {
     var kitContainer: MPKitContainerMock!
     var executor: ExecutorMock!
     var backendController: MPBackendControllerMock!
+    var state: MPStateMachineMock!
     
     func customLogger(_ message: String) {
         receivedMessage = message
@@ -35,6 +36,9 @@ class MParticleTestsSwift: XCTestCase {
         
         backendController = MPBackendControllerMock()
         mparticle.backendController = backendController
+        
+        state = MPStateMachineMock()
+        mparticle.stateMachine = state
     }
     
     override func tearDown() {
@@ -54,8 +58,6 @@ class MParticleTestsSwift: XCTestCase {
     }
     
     func testSetOptOutOptOutValueIsDifferentItShouldBeChangedAndDeliveredToBackendController() {
-        let state = MPStateMachineMock()
-        mparticle.stateMachine = state
         XCTAssertFalse(state.optOut)
         mparticle.optOut = true
         XCTAssertTrue(state.optOut)
@@ -161,7 +163,7 @@ class MParticleTestsSwift: XCTestCase {
 
         let userDefaults = MPUserDefaultsMock()
         
-        mparticle.start(withKeyCallback: false, options: options, userDefaults: userDefaults as! MPUserDefaultsProtocol)
+        mparticle.start(withKeyCallback: false, options: options, userDefaults: userDefaults as MPUserDefaultsProtocol)
         
         XCTAssertTrue(mparticle.initialized)
         XCTAssertNil(mparticle.settingsProvider.configSettings)

--- a/UnitTests/Mocks/MPBackendControllerMock.swift
+++ b/UnitTests/Mocks/MPBackendControllerMock.swift
@@ -110,8 +110,11 @@ class MPBackendControllerMock: NSObject, MPBackendControllerProtocol {
         logEventEventParam = event
         logEventCompletionHandler = completionHandler
     }
+    
+    var eventWithNameEventNameParam: String?
 
     func event(withName eventName: String) -> MPEvent? {
+        eventWithNameEventNameParam = eventName
         guard let set = eventSet else { return nil }
         for case let evt as MPEvent in set {
             if evt.name == eventName { return evt }


### PR DESCRIPTION
 ## Summary
- Refactored tests to make them simpler.
- Added tests for the breadcrumb method.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-255

