### PR TITLE
perf: Migrate to static linking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD041 -->
+
+## Background
+
+- {Explain the context of the change, including the problem it addresses or relevant background information}
+
+## What Has Changed
+
+- {Describe the changes introduced by this PR}
+
+## Screenshots/Video
+
+- {Include any screenshots or video demonstrating the new feature or fix, if applicable}
+
+## Checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have tested this locally.
+
+## Additional Notes
+
+- {Any additional information or context relevant to this PR}
+
+## Reference Issue (For employees only. Ignore if you are an outside contributor)
+
+- Closes [ticket](https://go/j/[ticket-number])

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -2364,20 +2364,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ./Framework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK.modulemap";
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
@@ -2401,20 +2391,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ./Framework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK.modulemap";
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
@@ -2484,9 +2464,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"MPARTICLE_LOCATION_DISABLE=1",
 					"$(inherited)",
@@ -2494,15 +2471,9 @@
 				INFOPLIST_FILE = ./Framework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK-NoLocation.modulemap";
+				SKIP_INSTALL = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK-NoLocation";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -2527,9 +2498,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"MPARTICLE_LOCATION_DISABLE=1",
 					"$(inherited)",
@@ -2537,15 +2505,9 @@
 				INFOPLIST_FILE = ./Framework/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK-NoLocation.modulemap";
+				SKIP_INSTALL = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK-NoLocation";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- mParticle Apple SDK was previously configured for dynamic linking
- Dynamic linking was causing issues for downstream wrapper SDKs
- Static linking provides better performance by eliminating dynamic library loading overhead at runtime
- This change aligns with industry best practices for performance-critical SDKs

## What Has Changed

- Updated Xcode project build settings to use static linking (`MACH_O_TYPE = staticlib`)
- Removed dynamic library specific settings (`DYLIB_*` and `LD_RUNPATH_SEARCH_PATHS` configurations)
- Verified XCFramework builds produce static libraries instead of dynamic libraries using scripts/xcframework.sh
- Additionally added new PR template

## Screenshots/Video

- **Before**: `file` command shows `dynamically linked shared library`
- **After**: `file` command shows `current ar archive` (static library)
- XCFramework build logs now show `MACH_O_TYPE=staticlib` and static framework signing

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- **Binary Compatibility**: XCFrameworks are rebuilt as static libraries but maintain same API surface
- **Integration**: No changes required for existing CocoaPods or SPM integrations
- **Testing**: Successfully built and verified static XCFrameworks for both iOS and tvOS platforms

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes N/A