### PR TITLE
fix: Make setSessionId synchronous to prevent race with MPRoktLayout

### DIFF
--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -11,15 +11,20 @@
 // Rokt kit identifier for testing
 static NSNumber * const kTestRoktKitId = @181;
 
-// Test helper class that simulates a kit with getSessionId method
+// Test helper class that simulates a kit with getSessionId and setSessionId methods
 @interface MPRoktTestKitInstance : NSObject
 @property (nonatomic, copy) NSString *sessionIdToReturn;
+@property (nonatomic, copy) NSString *receivedSessionId;
 - (NSString *)getSessionId;
+- (void)setSessionId:(NSString *)sessionId;
 @end
 
 @implementation MPRoktTestKitInstance
 - (NSString *)getSessionId {
     return self.sessionIdToReturn;
+}
+- (void)setSessionId:(NSString *)sessionId {
+    self.receivedSessionId = sessionId;
 }
 @end
 
@@ -864,20 +869,48 @@ static NSNumber * const kTestRoktKitId = @181;
 
 #pragma mark - setSessionId Tests
 
-- (void)testSetSessionIdForwardsToKitContainer {
+- (void)testSetSessionIdSynchronousDoesNotUseForwardSDKCall {
     MParticle *instance = [MParticle sharedInstance];
     self.mockInstance = OCMPartialMock(instance);
     self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
     [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
 
-    // Set up test parameters
+    MPRoktTestKitInstance *kitInstance = [[MPRoktTestKitInstance alloc] init];
+
+    id mockKitRegister = OCMProtocolMock(@protocol(MPExtensionKitProtocol));
+    OCMStub([(id<MPExtensionKitProtocol>)mockKitRegister code]).andReturn(kTestRoktKitId);
+    OCMStub([mockKitRegister wrapperInstance]).andReturn(kitInstance);
+
+    NSArray *activeKits = @[mockKitRegister];
+    OCMStub([self.mockContainer activeKitsRegistry]).andReturn(activeKits);
+
+    OCMReject([self.mockContainer forwardSDKCall:@selector(setSessionId:)
+                                           event:[OCMArg any]
+                                      parameters:[OCMArg any]
+                                     messageType:MPMessageTypeEvent
+                                        userInfo:[OCMArg any]]);
+
+    [self.rokt setSessionId:@"test-session-id-12345"];
+
+    XCTAssertEqualObjects(kitInstance.receivedSessionId, @"test-session-id-12345",
+        @"Should call kit directly without going through forwardSDKCall");
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSetSessionIdFallsBackToForwardSDKCallWhenKitNotAvailable {
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    OCMStub([self.mockContainer activeKitsRegistry]).andReturn(@[]);
+
     NSString *sessionId = @"test-session-id-12345";
 
-    // Set up expectations for kit container
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];
-    SEL roktSelector = @selector(setSessionId:);
-    OCMExpect([self.mockContainer forwardSDKCall:roktSelector
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for fallback forwardSDKCall"];
+    OCMExpect([self.mockContainer forwardSDKCall:@selector(setSessionId:)
                                            event:nil
                                       parameters:[OCMArg checkWithBlock:^BOOL(MPForwardQueueParameters *params) {
         XCTAssertEqualObjects(params[0], sessionId);
@@ -888,14 +921,39 @@ static NSNumber * const kTestRoktKitId = @181;
         [expectation fulfill];
     });
 
-    // Execute method
     [self.rokt setSessionId:sessionId];
 
-    // Wait for async operation
     [self waitForExpectationsWithTimeout:0.2 handler:nil];
-
-    // Verify
     OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSetSessionIdIsReceivedByKitSynchronously {
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    // Set up a kit instance that records the session ID it receives
+    MPRoktTestKitInstance *kitInstance = [[MPRoktTestKitInstance alloc] init];
+
+    id mockKitRegister = OCMProtocolMock(@protocol(MPExtensionKitProtocol));
+    OCMStub([(id<MPExtensionKitProtocol>)mockKitRegister code]).andReturn(kTestRoktKitId);
+    OCMStub([mockKitRegister wrapperInstance]).andReturn(kitInstance);
+
+    NSArray *activeKits = @[mockKitRegister];
+    OCMStub([self.mockContainer activeKitsRegistry]).andReturn(activeKits);
+
+    NSString *sessionId = @"web-session-12345";
+
+    // Call setSessionId
+    [self.rokt setSessionId:sessionId];
+
+    // The kit should have received the session ID SYNCHRONOUSLY (before this line runs).
+    // This test will FAIL with the current async implementation (proving the race condition)
+    // and PASS after the fix makes setSessionId synchronous.
+    XCTAssertEqualObjects(kitInstance.receivedSessionId, sessionId,
+        @"setSessionId must be delivered to the kit synchronously to avoid race conditions with selectPlacements/MPRoktLayout");
 }
 
 #pragma mark - getSessionId Tests

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -309,6 +309,22 @@ static void MPInvokeOnMainThread(void (^work)(void)) {
 ///   - sessionId: The session id to be set. Must be a non-empty string.
 - (void)setSessionId:(NSString * _Nonnull)sessionId {
     MPILogDebug(@"MPRokt setSessionId called - sessionId: %@", sessionId ? @"present" : @"nil");
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits =
+        [[MParticle sharedInstance].kitContainer_PRIVATE activeKitsRegistry];
+
+    for (id<MPExtensionKitProtocol> kitRegister in activeKits) {
+        if ([kitRegister.code integerValue] == kMPRoktKitId) {
+            id kitInstance = kitRegister.wrapperInstance;
+            if (kitInstance && [kitInstance respondsToSelector:@selector(setSessionId:)]) {
+                [kitInstance performSelector:@selector(setSessionId:) withObject:sessionId];
+                MPILogDebug(@"MPRokt setSessionId - forwarded synchronously to kit");
+                return;
+            }
+        }
+    }
+
+    MPILogDebug(@"MPRokt setSessionId - kit not available, queueing for deferred execution");
     dispatch_async(dispatch_get_main_queue(), ^{
         MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
         [queueParameters addParameter:sessionId];


### PR DESCRIPTION
## Background

A race condition in `setSessionId` was causing web-to-native session handoff to fail on iOS. The method was delivered asynchronously via two `dispatch_async(main)` hops through `forwardSDKCall`, while `MPRoktLayout` reads the session synchronously from `UserDefaults` during execute. This meant the session ID was missing when both calls were made in quick succession. Android was unaffected because its `setSessionId` path is synchronous.

## What Has Changed

- Made `setSessionId` use the same direct kit access pattern that `getSessionId` already uses, bypassing `forwardSDKCall` and delivering the session ID synchronously to the kit
- Added fallback to `forwardSDKCall` when kits haven't initialized yet, preserving existing queuing behavior
- Replaced the old async `testSetSessionIdForwardsToKitContainer` test with three new tests covering synchronous delivery, `forwardSDKCall` bypass, and fallback behavior

## Timeline
<details>
  <summary><b>Click to see Sequence Diagram: setSessionId and MPRoktLayout Execute</b></summary>

  <img width="1079" height="632" alt="image" src="https://github.com/user-attachments/assets/0e0f453a-b314-4322-9325-1d11c0cb360c" />

</details>




## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.