### PR TITLE
fix: point kit podspec source URLs to mirror repos

### DIFF
--- a/Kits/adjust/adjust-5/mParticle-Adjust-5.podspec
+++ b/Kits/adjust/adjust-5/mParticle-Adjust-5.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-adjust-5.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"
     s.source_files      = 'Sources/mParticle-Adjust/**/*.{h,m}'

--- a/Kits/adobe/adobe-5/mParticle-Adobe-5.podspec
+++ b/Kits/adobe/adobe-5/mParticle-Adobe-5.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-adobe-5.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.swift_version    = '5.0'
     s.ios.deployment_target  = "15.6"

--- a/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer-6.podspec
+++ b/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer-6.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-appsflyer-6.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-AppsFlyer/**/*.{h,m}'

--- a/Kits/apptentive/apptentive-6/mParticle-Apptentive-6.podspec
+++ b/Kits/apptentive/apptentive-6/mParticle-Apptentive-6.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-apptentive-6.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Apptentive/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Apptentive-6-Privacy' => ['Sources/mParticle-Apptentive/PrivacyInfo.xcprivacy'] }

--- a/Kits/apptimize/apptimize-3/mParticle-Apptimize-3.podspec
+++ b/Kits/apptimize/apptimize-3/mParticle-Apptimize-3.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-apptimize-3.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Apptimize/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Apptimize-3-Privacy' => ['Sources/mParticle-Apptimize/PrivacyInfo.xcprivacy'] }

--- a/Kits/branchmetrics/branchmetrics-3/mParticle-BranchMetrics-3.podspec
+++ b/Kits/branchmetrics/branchmetrics-3/mParticle-BranchMetrics-3.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-branchmetrics-3.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-BranchMetrics/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-BranchMetrics-3-Privacy' => ['Sources/mParticle-BranchMetrics/PrivacyInfo.xcprivacy'] }

--- a/Kits/braze/braze-12/mParticle-Braze-12.podspec
+++ b/Kits/braze/braze-12/mParticle-Braze-12.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-braze-12.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.swift_version = "5.5"
     s.ios.deployment_target  = "15.6"

--- a/Kits/braze/braze-13/mParticle-Braze-13.podspec
+++ b/Kits/braze/braze-13/mParticle-Braze-13.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-braze-13.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.swift_version = "5.5"
     s.ios.deployment_target  = "15.6"

--- a/Kits/braze/braze-14/mParticle-Braze-14.podspec
+++ b/Kits/braze/braze-14/mParticle-Braze-14.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-braze-14.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.swift_version = "5.5"
     s.ios.deployment_target  = "15.6"

--- a/Kits/clevertap/clevertap-7/mParticle-CleverTap-7.podspec
+++ b/Kits/clevertap/clevertap-7/mParticle-CleverTap-7.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-clevertap-7.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-CleverTap/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-CleverTap-7-Privacy' => ['Sources/mParticle-CleverTap/PrivacyInfo.xcprivacy'] }

--- a/Kits/comscore/comscore-6/mParticle-ComScore-6.podspec
+++ b/Kits/comscore/comscore-6/mParticle-ComScore-6.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-comscore-6.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"
     s.source_files      = 'Sources/mParticle-ComScore/**/*.{h,m}'

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-11/mParticle-FirebaseGA4-11.podspec
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-11/mParticle-FirebaseGA4-11.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4-11.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-12/mParticle-FirebaseGA4-12.podspec
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-12/mParticle-FirebaseGA4-12.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4-12.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"

--- a/Kits/google-analytics-firebase/firebase-11/mParticle-Firebase-11.podspec
+++ b/Kits/google-analytics-firebase/firebase-11/mParticle-Firebase-11.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-11.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Firebase/**/*.{h,m}'

--- a/Kits/google-analytics-firebase/firebase-12/mParticle-Firebase-12.podspec
+++ b/Kits/google-analytics-firebase/firebase-12/mParticle-Firebase-12.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-12.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Firebase/**/*.{h,m}'

--- a/Kits/iterable/iterable-6/mParticle-Iterable-6.podspec
+++ b/Kits/iterable/iterable-6/mParticle-Iterable-6.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-iterable-6.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Iterable/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Iterable-6-Privacy' => ['Sources/mParticle-Iterable/PrivacyInfo.xcprivacy'] }

--- a/Kits/leanplum/leanplum-6/mParticle-Leanplum-6.podspec
+++ b/Kits/leanplum/leanplum-6/mParticle-Leanplum-6.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-leanplum-6.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Leanplum/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Leanplum-6-Privacy' => ['Sources/mParticle-Leanplum/PrivacyInfo.xcprivacy'] }

--- a/Kits/localytics/localytics-6/mParticle-Localytics-6.podspec
+++ b/Kits/localytics/localytics-6/mParticle-Localytics-6.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-localytics-6.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Localytics/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Localytics-6-Privacy' => ['Sources/mParticle-Localytics/PrivacyInfo.xcprivacy'] }

--- a/Kits/localytics/localytics-7/mParticle-Localytics-7.podspec
+++ b/Kits/localytics/localytics-7/mParticle-Localytics-7.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-localytics-7.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Localytics/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Localytics-7-Privacy' => ['Sources/mParticle-Localytics/PrivacyInfo.xcprivacy'] }

--- a/Kits/onetrust/onetrust/mParticle-OneTrust.podspec
+++ b/Kits/onetrust/onetrust/mParticle-OneTrust.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mp-apple-integration-onetrust.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"
     s.source_files      = 'Sources/mParticle-OneTrust/**/*.{h,m}'

--- a/Kits/optimizely/optimizely-4/mParticle-Optimizely-4.podspec
+++ b/Kits/optimizely/optimizely-4/mParticle-Optimizely-4.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-optimizely-4.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"
     s.source_files      = 'Sources/mParticle-Optimizely/**/*.{h,m}'

--- a/Kits/optimizely/optimizely-5/mParticle-Optimizely-5.podspec
+++ b/Kits/optimizely/optimizely-5/mParticle-Optimizely-5.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-optimizely-5.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target  = "15.6"
     s.tvos.deployment_target = "15.6"
     s.source_files      = 'Sources/mParticle-Optimizely/**/*.{h,m}'

--- a/Kits/radar/radar-3/mParticle-Radar-3.podspec
+++ b/Kits/radar/radar-3/mParticle-Radar-3.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-radar-3.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Radar/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-Radar-3-Privacy' => ['Sources/mParticle-Radar/PrivacyInfo.xcprivacy'] }

--- a/Kits/rokt/rokt/mParticle-Rokt.podspec
+++ b/Kits/rokt/rokt/mParticle-Rokt.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mp-apple-integration-rokt.git", :tag => "v" + s.version.to_s }
     s.swift_version = "5.5"
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Rokt/**/*.{h,m}', 'Sources/mParticle-Rokt-Swift/**/*.swift'

--- a/Kits/singular/singular-12/mParticle-Singular-12.podspec
+++ b/Kits/singular/singular-12/mParticle-Singular-12.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-singular-12.git", :tag => "v" + s.version.to_s }
     s.static_framework = true
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-Singular/**/*.{h,m}'

--- a/Kits/urbanairship/urbanairship-19/mParticle-UrbanAirship-19.podspec
+++ b/Kits/urbanairship/urbanairship-19/mParticle-UrbanAirship-19.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-urbanairship-19.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "15.6"
     s.ios.source_files      = 'Sources/mParticle-UrbanAirship/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-UrbanAirship-19-Privacy' => ['Sources/mParticle-UrbanAirship/PrivacyInfo.xcprivacy'] }

--- a/Kits/urbanairship/urbanairship-20/mParticle-UrbanAirship-20.podspec
+++ b/Kits/urbanairship/urbanairship-20/mParticle-UrbanAirship-20.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle/mparticle-apple-sdk.git", :tag => "v" + s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-urbanairship-20.git", :tag => "v" + s.version.to_s }
     s.ios.deployment_target = "16.0"
     s.ios.source_files      = 'Sources/mParticle-UrbanAirship/**/*.{h,m}'
     s.ios.resource_bundles  = { 'mParticle-UrbanAirship-20-Privacy' => ['Sources/mParticle-UrbanAirship/PrivacyInfo.xcprivacy'] }


### PR DESCRIPTION
## Summary

- Kit podspecs had their `source` pointing to the monorepo (`mparticle-apple-sdk`), but `source_files` paths are relative to the kit subtree root. This caused `pod trunk push` to fail with `source_files pattern did not match any file` because CocoaPods clones from the `source` URL and the files are nested under `Kits/<vendor>/<track>/` in the monorepo.
- Updated all 27 kit podspecs to point `source` at their respective mirror repos in `mparticle-integrations`, where `git subtree split` places files at the correct relative paths.
- This does **not** affect `pod lib lint` (used in CI), which resolves `source_files` relative to the podspec file location on disk, ignoring the `source` URL entirely.

## Prerequisite for `pod trunk push`

The mirror repos in `mparticle-integrations` must be made **public** before `pod trunk push` will work. CocoaPods Trunk requires public access to the source repo for validation.

## Affected podspecs (all 27 kits)

Adjust, Adobe, AppsFlyer, Apptentive, Apptimize, BranchMetrics, Braze (12/13/14), CleverTap, ComScore, Firebase (11/12), FirebaseGA4 (11/12), Iterable, Leanplum, Localytics (6/7), OneTrust, Optimizely (4/5), Radar, Rokt, Singular, UrbanAirship (19/20)

## Test plan

- [ ] CI passes (`pod lib lint` is unaffected by `source` URL changes)
- [ ] After mirror repos are made public, verify `pod trunk push` succeeds for a kit (e.g., mParticle-ComScore-6)