### PR TITLE
fix: replace non-modular header imports in Firebase kit headers

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -50,7 +50,6 @@ jobs:
           for attempt in 1 2 3; do
             pod lib lint "${{ matrix.kit.podspec }}" \
               --allow-warnings \
-              --skip-import-validation \
               --include-podspecs="{mParticle-Apple-SDK-Swift.podspec,mParticle-Apple-SDK-ObjC.podspec,mParticle-Apple-SDK.podspec}" \
               && break
             [ $attempt -lt 3 ] && echo "Attempt $attempt failed, retrying in 60s..." && sleep 60 || exit 1

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-11/Sources/mParticle-FirebaseGA4/include/MPKitFirebaseGA4Analytics.h
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-11/Sources/mParticle-FirebaseGA4/include/MPKitFirebaseGA4Analytics.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#if __has_feature(modules)
+@import mParticle_Apple_SDK_ObjC;
+#else
 #import "mParticle.h"
+#endif
 
 @interface MPKitFirebaseGA4Analytics : NSObject <MPKitProtocol>
 

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-12/Sources/mParticle-FirebaseGA4/include/MPKitFirebaseGA4Analytics.h
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-12/Sources/mParticle-FirebaseGA4/include/MPKitFirebaseGA4Analytics.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#if __has_feature(modules)
+@import mParticle_Apple_SDK_ObjC;
+#else
 #import "mParticle.h"
+#endif
 
 @interface MPKitFirebaseGA4Analytics : NSObject <MPKitProtocol>
 

--- a/Kits/google-analytics-firebase/firebase-11/Sources/mParticle-Firebase/include/MPKitFirebase.h
+++ b/Kits/google-analytics-firebase/firebase-11/Sources/mParticle-Firebase/include/MPKitFirebase.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#if __has_feature(modules)
+@import mParticle_Apple_SDK_ObjC;
+#else
 #import "mParticle.h"
+#endif
 
 @interface MPKitFirebase : NSObject <MPKitProtocol>
 

--- a/Kits/google-analytics-firebase/firebase-12/Sources/mParticle-Firebase/include/MPKitFirebase.h
+++ b/Kits/google-analytics-firebase/firebase-12/Sources/mParticle-Firebase/include/MPKitFirebase.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#if __has_feature(modules)
+@import mParticle_Apple_SDK_ObjC;
+#else
 #import "mParticle.h"
+#endif
 
 @interface MPKitFirebase : NSObject <MPKitProtocol>
 


### PR DESCRIPTION
## Summary

- Firebase kit headers (Firebase-11, Firebase-12, FirebaseGA4-11, FirebaseGA4-12) used `#import "mParticle.h"` -- a textual include of a core SDK header. This causes a "non-modular header inside framework module" error during `pod trunk push` import validation, preventing these 4 kits from publishing to CocoaPods.
- Replaced with `@import mParticle_Apple_SDK_ObjC;` (module import), matching the pattern used by all other kits that publish successfully.
- Removed `--skip-import-validation` from `pod lib lint` in CI so this class of error is caught during PR validation rather than at release time.

## Why this wasn't caught before

The `pod lib lint` command in `build-kits.yml` used `--skip-import-validation`, which skips the exact validation step that catches non-modular header errors. `pod trunk push` does **not** accept this flag, so the error only surfaced at release time.

## Affected files

- `Kits/google-analytics-firebase/firebase-11/Sources/mParticle-Firebase/include/MPKitFirebase.h`
- `Kits/google-analytics-firebase/firebase-12/Sources/mParticle-Firebase/include/MPKitFirebase.h`
- `Kits/google-analytics-firebase-ga4/firebase-ga4-11/Sources/mParticle-FirebaseGA4/include/MPKitFirebaseGA4Analytics.h`
- `Kits/google-analytics-firebase-ga4/firebase-ga4-12/Sources/mParticle-FirebaseGA4/include/MPKitFirebaseGA4Analytics.h`
- `.github/workflows/build-kits.yml`

## Test plan

- [ ] CI passes -- `pod lib lint` now runs **without** `--skip-import-validation`, validating that the module import fix works
- [ ] After merge, `pod trunk push` succeeds for the 4 Firebase kits