### PR TITLE
ci: upgrade and pin actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew runIos
       - name: Archive Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-test-results
           path: Users/runner/Library/Developer/Xcode/DerivedData

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-test-artifacts
           path: ${{ env.WORKING_DIRECTORY }}/artifacts/

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -200,7 +200,7 @@ jobs:
           rm -rf archives
 
       - name: Upload xcframework artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcframework-${{ matrix.kit.name }}
           path: xcframeworks/*.xcframework.zip


### PR DESCRIPTION
## Summary

- Upgrades `actions/upload-artifact` from `@v4` (Node.js 20) to SHA-pinned `@v7.0.1` (Node.js 24) across all three workflow files that use it
- Pins the two existing unpinned `@v7` references to the same SHA for supply-chain security
- Eliminates GitHub's deprecated Node.js 20 runner warnings on affected jobs

## Affected files

- `.github/workflows/release-publish.yml` — upgraded from `@v4` to `@v7.0.1` (SHA-pinned)
- `.github/workflows/integration-tests.yml` — pinned existing `@v7` to SHA
- `.github/workflows/cross-platform-tests.yml` — pinned existing `@v7` to SHA

## Test plan

- [ ] CI passes on all three affected workflows — no Node.js deprecation warnings for upload-artifact steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)