### PR TITLE
chore: simplify kit CI, mirror push, and AGENTS release notes

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -36,16 +36,6 @@ jobs:
           xcode-version: "26.2"
       - name: Pod Lib Lint
         run: |
-          # Bump local SDK versions to 9.0.0 to satisfy kit ~> 9.0 dependency constraints.
-          # v9.0 is in-progress and not yet on CocoaPods CDN. CocoaPods podspec dependencies
-          # cannot reference git branches (unlike SPM), so we supply local podspecs via
-          # --include-podspecs with a temporary version bump on the ephemeral CI runner.
-          # TODO: Remove the sed bumps and --include-podspecs once mParticle-Apple-SDK v9.0
-          # is published to CocoaPods CDN.
-          sed -i '' 's/s\.version[[:space:]]*=.*/s.version          = "9.0.0"/' mParticle-Apple-SDK.podspec
-          sed -i '' 's/s\.version[[:space:]]*=.*/s.version          = "9.0.0"/' mParticle-Apple-SDK-ObjC.podspec
-          sed -i '' 's/s\.version[[:space:]]*=.*/s.version          = "9.0.0"/' mParticle-Apple-SDK-Swift.podspec
-
           echo "Linting: ${{ matrix.kit.podspec }}"
           for attempt in 1 2 3; do
             pod lib lint "${{ matrix.kit.podspec }}" \

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -264,7 +264,7 @@ jobs:
         id: push
         run: |
           DEST_URL="https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ env.DEST_ORG }}/${{ matrix.kit.dest_repo }}.git"
-          git push "$DEST_URL" "split/${{ matrix.kit.name }}:main" --force
+          git push "$DEST_URL" "split/${{ matrix.kit.name }}:main"
           echo "sha=$(git rev-parse split/${{ matrix.kit.name }})" >> $GITHUB_OUTPUT
 
       - name: Create GitHub release on mirror

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ You are a senior iOS SDK engineer specializing in customer data platform (CDP) S
 - Introduce new third-party dependencies without size/performance justification and approval.
 - Block the main thread (no synchronous network, heavy computation, etc.).
 - Crash on bad input/network — always provide fallback / error callback.
-- Touch CI configs (`.github/`), release scripts (`Scripts/`), or CI YAML without explicit request.
+- Touch CI configs (`.github/`), `Scripts/` utilities, or CI YAML without explicit request.
 - Propose dropping iOS 15.6 / tvOS 15.6 support or raising min deployment target.
 - Break kit/integration compatibility without explicit coordination.
 - Modify vendored libraries in `Libraries/` without explicit request.
@@ -101,8 +101,8 @@ You are a senior iOS SDK engineer specializing in customer data platform (CDP) S
 - `UnitTests/` — Unit tests (ObjCTests, SwiftTests, Mocks).
 - `IntegrationTests/` — Integration tests (Tuist + WireMock).
 - `Example/` — Sample app (11 subdirectories).
-- `Scripts/` — Build, release, and utility scripts.
-  - `xcframework.sh`, `check_coverage.sh`.
+- `Scripts/` — Build and utility scripts (`xcframework.sh`, `check_coverage.sh`, etc.).
+- `VERSION` — Ecosystem version advanced by the Release – Draft workflow; consumed by publish/mirror workflows.
 - `Package.swift` — SPM manifest (swift-tools-version 5.5).
 - `mParticle-Apple-SDK.podspec` — CocoaPods umbrella (Swift sources; consumer-facing pod name `mParticle-Apple-SDK`).
 - `mParticle-Apple-SDK-ObjC.podspec` — CocoaPods ObjC core (`mParticle-Apple-SDK-ObjC`).
@@ -110,7 +110,7 @@ You are a senior iOS SDK engineer specializing in customer data platform (CDP) S
 - `ARCHITECTURE.md` — Architecture documentation with sequence diagrams.
 - `CHANGELOG.md` — Release notes (extensive).
 - `MIGRATING.md` — Migration guides for older versions.
-- `RELEASE.md` — Release process documentation.
+- `RELEASE.md` — Release process (GitHub Actions and root `VERSION` file).
 - `CONTRIBUTING.md` — Contribution guidelines.
 
 ## Code style, quality, and validation


### PR DESCRIPTION
## Background

Kit pod lib lint was rewriting umbrella podspec versions with `sed` even though they already match the repo. Kit mirror pushes always used `--force` on `main`. `AGENTS.md` did not spell out the `VERSION` + Actions release model.

## What Has Changed

- Removed redundant `sed` bumps before kit `pod lib lint` (`build-kits.yml`).
- Mirror push to kit repos no longer uses `--force` (`release-publish.yml`).
- Updated `AGENTS.md` for `VERSION`, `Scripts/`, and `RELEASE.md`.

## Timeline

_Workflow and docs only; no runtime sequence._

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.