### PR TITLE
docs: add issues redirect notice to all kit READMEs

### DIFF
--- a/Kits/adjust/adjust-5/README.md
+++ b/Kits/adjust/adjust-5/README.md
@@ -49,6 +49,10 @@ Included kits: { Adjust }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Adjust iOS SDK Documentation](https://help.adjust.com/en/sdk/ios)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/adobe/adobe-5/README.md
+++ b/Kits/adobe/adobe-5/README.md
@@ -50,6 +50,10 @@ Included kits: { Adobe }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Adobe Experience Platform SDK Documentation](https://developer.adobe.com/client-sdks/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/appsflyer/appsflyer-6/README.md
+++ b/Kits/appsflyer/appsflyer-6/README.md
@@ -49,6 +49,10 @@ Included kits: { AppsFlyer }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [AppsFlyer iOS SDK Documentation](https://dev.appsflyer.com/hc/docs/integrate-ios-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/apptentive/apptentive-6/README.md
+++ b/Kits/apptentive/apptentive-6/README.md
@@ -48,6 +48,10 @@ Included kits: { Apptentive }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Apptentive iOS SDK Documentation](https://github.com/apptentive/apptentive-kit-ios)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/apptimize/apptimize-3/README.md
+++ b/Kits/apptimize/apptimize-3/README.md
@@ -38,6 +38,10 @@ Included kits: { Apptimize }
 - [mParticle Apptimize Integration Guide](https://docs.mparticle.com/integrations/apptimize/event/)
 - [mParticle Apple SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/branchmetrics/branchmetrics-3/README.md
+++ b/Kits/branchmetrics/branchmetrics-3/README.md
@@ -48,6 +48,10 @@ Included kits: { BranchMetrics }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Branch iOS SDK Documentation](https://help.branch.io/developers-hub/docs/ios-sdk-overview)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/braze/braze-12/README.md
+++ b/Kits/braze/braze-12/README.md
@@ -64,6 +64,10 @@ Included kits: { Braze }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/client-sdks/ios/)
 - [Braze Swift SDK Documentation](https://www.braze.com/docs/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/braze/braze-13/README.md
+++ b/Kits/braze/braze-13/README.md
@@ -64,6 +64,10 @@ Included kits: { Braze }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/client-sdks/ios/)
 - [Braze Swift SDK Documentation](https://www.braze.com/docs/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/braze/braze-14/README.md
+++ b/Kits/braze/braze-14/README.md
@@ -64,6 +64,10 @@ Included kits: { Braze }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/client-sdks/ios/)
 - [Braze Swift SDK Documentation](https://www.braze.com/docs/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/clevertap/clevertap-7/README.md
+++ b/Kits/clevertap/clevertap-7/README.md
@@ -48,6 +48,10 @@ Included kits: { CleverTap }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [CleverTap iOS SDK Documentation](https://developer.clevertap.com/docs/ios-quickstart-guide)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/comscore/comscore-6/README.md
+++ b/Kits/comscore/comscore-6/README.md
@@ -41,6 +41,10 @@ Included kits: { ComScore }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [ComScore SDK Documentation](https://github.com/comScore/Comscore-Swift-Package-Manager)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-11/README.md
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-11/README.md
@@ -35,6 +35,10 @@ Included kits: { FirebaseGA4 }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Firebase iOS SDK Documentation](https://github.com/firebase/firebase-ios-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-12/README.md
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-12/README.md
@@ -35,6 +35,10 @@ Included kits: { FirebaseGA4 }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Firebase iOS SDK Documentation](https://github.com/firebase/firebase-ios-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/google-analytics-firebase/firebase-11/README.md
+++ b/Kits/google-analytics-firebase/firebase-11/README.md
@@ -35,6 +35,10 @@ Included kits: { Firebase }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Firebase iOS SDK Documentation](https://github.com/firebase/firebase-ios-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/google-analytics-firebase/firebase-12/README.md
+++ b/Kits/google-analytics-firebase/firebase-12/README.md
@@ -35,6 +35,10 @@ Included kits: { Firebase }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Firebase iOS SDK Documentation](https://github.com/firebase/firebase-ios-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/iterable/iterable-6/README.md
+++ b/Kits/iterable/iterable-6/README.md
@@ -71,6 +71,10 @@ Included kits: { Iterable }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Iterable iOS SDK Documentation](https://support.iterable.com/hc/en-us/articles/360035018152-Iterable-s-iOS-SDK-)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/kochava/kochava-9/README.md
+++ b/Kits/kochava/kochava-9/README.md
@@ -40,6 +40,10 @@ Included kits: { Kochava }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Kochava iOS SDK Documentation](https://support.kochava.com/sdk-integration/ios-sdk-integration/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/kochava/kochava-no-tracking-9/README.md
+++ b/Kits/kochava/kochava-no-tracking-9/README.md
@@ -41,6 +41,10 @@ Included kits: { Kochava }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Kochava iOS SDK Documentation](https://support.kochava.com/sdk-integration/ios-sdk-integration/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/leanplum/leanplum-6/README.md
+++ b/Kits/leanplum/leanplum-6/README.md
@@ -45,6 +45,10 @@ Included kits: { Leanplum }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Leanplum iOS SDK Documentation](https://docs.leanplum.com/docs/ios-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/localytics/localytics-6/README.md
+++ b/Kits/localytics/localytics-6/README.md
@@ -45,6 +45,10 @@ Included kits: { Localytics }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Localytics iOS SDK Documentation](https://help.uplandsoftware.com/localytics/dev/ios.html)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/localytics/localytics-7/README.md
+++ b/Kits/localytics/localytics-7/README.md
@@ -45,6 +45,10 @@ Included kits: { Localytics }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Localytics iOS SDK Documentation](https://help.uplandsoftware.com/localytics/dev/ios.html)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/onetrust/onetrust/README.md
+++ b/Kits/onetrust/onetrust/README.md
@@ -67,6 +67,10 @@ Included kits: { OneTrust }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [OneTrust Developer Portal: iOS SDK](https://developer.onetrust.com/onetrust/docs/add-sdk-to-app-ios-tvos)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/optimizely/optimizely-4/README.md
+++ b/Kits/optimizely/optimizely-4/README.md
@@ -38,6 +38,10 @@ Included kits: { Optimizely }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/client-sdks/ios/)
 - [Optimizely Swift SDK Documentation](https://docs.developers.optimizely.com/full-stack/docs/swift-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/optimizely/optimizely-5/README.md
+++ b/Kits/optimizely/optimizely-5/README.md
@@ -38,6 +38,10 @@ Included kits: { Optimizely }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/client-sdks/ios/)
 - [Optimizely Swift SDK Documentation](https://docs.developers.optimizely.com/full-stack/docs/swift-sdk)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/radar/radar-3/README.md
+++ b/Kits/radar/radar-3/README.md
@@ -48,6 +48,10 @@ Included kits: { Radar }
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Radar iOS SDK Documentation](https://radar.com/documentation/sdk/ios)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/rokt/rokt/README.md
+++ b/Kits/rokt/rokt/README.md
@@ -92,6 +92,10 @@ For the full event type reference, see [MIGRATING.md](../../MIGRATING.md).
 - [Rokt mParticle Integration](https://docs.rokt.com/developers/integration-guides/rokt-ads/customer-data-platforms/mparticle/)
 - [mParticle Apple SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/singular/singular-12/README.md
+++ b/Kits/singular/singular-12/README.md
@@ -38,6 +38,10 @@ Included kits: { Singular }
 - [Singular mParticle Integration](https://support.singular.net/)
 - [mParticle Apple SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/urbanairship/urbanairship-19/README.md
+++ b/Kits/urbanairship/urbanairship-19/README.md
@@ -92,6 +92,10 @@ private func removeTag(key: String) {
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Airship iOS SDK Documentation](https://docs.airship.com/platform/ios/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/Kits/urbanairship/urbanairship-20/README.md
+++ b/Kits/urbanairship/urbanairship-20/README.md
@@ -93,6 +93,10 @@ private func removeTag(key: String) {
 - [mParticle iOS SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
 - [Airship iOS SDK Documentation](https://docs.airship.com/platform/ios/)
 
+## Issues
+
+Please report bugs and feature requests to the [mparticle-apple-sdk](https://github.com/mParticle/mparticle-apple-sdk/issues) repository. This mirror repository is not actively monitored for issues.
+
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
## Background

Consumers discovering a kit via its mirror repository had no clear signal that issues should be filed in the canonical `mparticle-apple-sdk` repo. Mirror repos are read-only and not monitored for issues or development activity.

## What Has Changed

- Added a brief `## Issues` section to all 29 kit READMEs directing consumers to the [mparticle-apple-sdk issues tab](https://github.com/mParticle/mparticle-apple-sdk/issues)
- Placed the section just before `## License` for consistency across all kits

## Screenshots/Video

N/A — docs only

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [x] Tested locally

## Additional Notes

Docs-only change; no build or test impact.