### PR TITLE
fix: replace real Braze instances with OCMClassMock in SPM tests

### DIFF
--- a/Kits/braze/braze-12/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m
+++ b/Kits/braze/braze-12/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m
@@ -107,7 +107,9 @@
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance reject] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -136,7 +138,9 @@
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -165,7 +169,9 @@
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -185,9 +191,7 @@
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -216,9 +220,7 @@
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -249,9 +251,7 @@
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -479,9 +479,8 @@
 }
 
 - (void)testSetBrazeInstance {
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    
+    id testClient = OCMClassMock([Braze class]);
+
     XCTAssertEqualObjects([MPKitBraze brazeInstance], nil);
 
     [MPKitBraze setBrazeInstance:testClient];
@@ -549,9 +548,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @0};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -591,9 +588,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -636,9 +631,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @0};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -685,9 +678,7 @@
     kit.configuration = @{@"bundleCommerceEventData" : @0,
                           @"replaceSkuWithProductName": @"True"};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -733,9 +724,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -811,9 +800,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -900,9 +887,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -944,9 +929,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -1039,9 +1022,7 @@
 - (void)testEventWithEmptyProperties {
     MPKitBraze *kit = [[MPKitBraze alloc] init];
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);

--- a/Kits/braze/braze-13/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m
+++ b/Kits/braze/braze-13/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m
@@ -107,7 +107,9 @@
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance reject] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -136,7 +138,9 @@
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -165,7 +169,9 @@
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -185,9 +191,7 @@
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -216,9 +220,7 @@
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -249,9 +251,7 @@
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -479,9 +479,8 @@
 }
 
 - (void)testSetBrazeInstance {
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    
+    id testClient = OCMClassMock([Braze class]);
+
     XCTAssertEqualObjects([MPKitBraze brazeInstance], nil);
 
     [MPKitBraze setBrazeInstance:testClient];
@@ -549,9 +548,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @0};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -591,9 +588,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -636,9 +631,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @0};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -685,9 +678,7 @@
     kit.configuration = @{@"bundleCommerceEventData" : @0,
                           @"replaceSkuWithProductName": @"True"};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -733,9 +724,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -811,9 +800,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -900,9 +887,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -944,9 +929,7 @@
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -1039,9 +1022,7 @@
 - (void)testEventWithEmptyProperties {
     MPKitBraze *kit = [[MPKitBraze alloc] init];
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);

--- a/Kits/braze/braze-14/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m
+++ b/Kits/braze/braze-14/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m
@@ -119,7 +119,9 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance reject] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -148,7 +150,9 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -177,7 +181,9 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     id mockKitApi = OCMClassMock([MPKitAPI class]);
     OCMStub([mockKitApi getCurrentUserWithKit:kitInstance]).andReturn(filteredUser);
     kitInstance.kitApi = mockKitApi;
-    
+
+    id mockBraze = OCMClassMock([Braze class]);
+    [kitInstance setBrazeInstanceLocal:mockBraze];
     id mockKitInstance = OCMPartialMock(kitInstance);
     [[mockKitInstance expect] updateUser:[OCMArg any] request:[OCMArg any]];
     [kitInstance start];
@@ -197,9 +203,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -228,9 +232,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     
@@ -261,9 +263,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kitInstance = [[MPKitBraze alloc] init];
     [kitInstance didFinishLaunchingWithConfiguration:kitConfiguration];
     
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kitInstance setBrazeInstanceLocal:mockClient];
     XCTAssertEqualObjects(mockClient, [kitInstance brazeInstanceLocal]);
     // subscriptionGroupMapping is applied in -start only; without -start mapped keys are handled as custom attributes (invalid subscription values would incorrectly return success).
@@ -491,9 +491,8 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
 }
 
 - (void)testSetBrazeInstance {
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    
+    id testClient = OCMClassMock([Braze class]);
+
     XCTAssertEqualObjects([MPKitBraze brazeInstance], nil);
 
     [MPKitBraze setBrazeInstance:testClient];
@@ -561,9 +560,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @0};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -603,9 +600,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -648,9 +643,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @0};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -697,9 +690,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     kit.configuration = @{@"bundleCommerceEventData" : @0,
                           @"replaceSkuWithProductName": @"True"};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -745,9 +736,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -823,9 +812,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -912,9 +899,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -956,9 +941,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
     MPKitBraze *kit = [[MPKitBraze alloc] init];
     kit.configuration = @{@"bundleCommerceEventData" : @1};
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);
@@ -1051,9 +1034,7 @@ static NSString *const kMPBrazeConfigAutomaticLocationCollection = @"automaticLo
 - (void)testEventWithEmptyProperties {
     MPKitBraze *kit = [[MPKitBraze alloc] init];
 
-    BRZConfiguration *configuration = [[BRZConfiguration alloc] init];
-    Braze *testClient = [[Braze alloc] initWithConfiguration:configuration];
-    id mockClient = OCMPartialMock(testClient);
+    id mockClient = OCMClassMock([Braze class]);
     [kit setBrazeInstanceLocal:mockClient];
 
     XCTAssertEqualObjects(mockClient, [kit brazeInstanceLocal]);


### PR DESCRIPTION
## Summary

- Braze SPM tests in braze-12, braze-13, and braze-14 created real `Braze` instances using `[[BRZConfiguration alloc] init]` (no API key) and wrapped them with `OCMPartialMock`. Instantiating the Braze SDK with a nil API key causes intermittent crashes in CI.
- `testMpidForwarding*` tests called `[kitInstance start]` without a pre-injected Braze instance, causing `start` to attempt real Braze initialization with a nil endpoint.
- Replaced all real `Braze` instance creation with `OCMClassMock([Braze class])` — a pure mock that passes `isKindOfClass:` checks, supports `expect`/`verify`, and never touches the Braze SDK initialization path.
- Pre-injected a mock Braze via `setBrazeInstanceLocal:` in `testMpidForwarding*` tests before calling `start`.

## Affected files

- `Kits/braze/braze-12/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m`
- `Kits/braze/braze-13/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m`
- `Kits/braze/braze-14/Tests/mParticle-BrazeTests/mParticle_BrazeTests.m`

## Test plan

- [ ] CI Braze SPM test jobs pass (braze-12, braze-13, braze-14)
- [ ] No test assertions changed — only the mock strategy