### PR TITLE
fix: prevent use-after-free crash in Adobe kit _midOverride

### DIFF
--- a/Kits/adobe/adobe-5/Sources/mParticle-Adobe/MPKitAdobe.m
+++ b/Kits/adobe/adobe-5/Sources/mParticle-Adobe/MPKitAdobe.m
@@ -1,5 +1,6 @@
 #import "MPKitAdobe.h"
 #import "MPIAdobe.h"
+#import <os/lock.h>
 
 static NSString *const marketingCloudIdIntegrationAttributeKey = @"mid";
 static NSString *const blobIntegrationAttributeKey = @"aamb";
@@ -33,6 +34,40 @@ static NSString *const audienceManagerServerConfigurationKey = @"audienceManager
 
 static NSString *_midOverride = nil;
 static BOOL _willOverrideMid = NO;
+static os_unfair_lock _midOverrideLock = OS_UNFAIR_LOCK_INIT;
+
+// Thread-safe accessors for the file-scope statics above.
+// Direct reads/writes of `_midOverride` from multiple threads race on the
+// ARC-managed retain/release of the static, which can cause a value that is
+// about to be released to be captured into an NSDictionary and later trigger
+// a use-after-free when the dictionary is serialized on the mParticle
+// message queue.
+static NSString * _Nullable MPKitAdobeCopyMidOverride(void) {
+    os_unfair_lock_lock(&_midOverrideLock);
+    NSString *snapshot = _midOverride;
+    os_unfair_lock_unlock(&_midOverrideLock);
+    return snapshot;
+}
+
+static void MPKitAdobeSetMidOverride(NSString * _Nullable value) {
+    NSString *copied = [value copy];
+    os_unfair_lock_lock(&_midOverrideLock);
+    _midOverride = copied;
+    os_unfair_lock_unlock(&_midOverrideLock);
+}
+
+static BOOL MPKitAdobeGetWillOverrideMid(void) {
+    os_unfair_lock_lock(&_midOverrideLock);
+    BOOL value = _willOverrideMid;
+    os_unfair_lock_unlock(&_midOverrideLock);
+    return value;
+}
+
+static void MPKitAdobeSetWillOverrideMid(BOOL value) {
+    os_unfair_lock_lock(&_midOverrideLock);
+    _willOverrideMid = value;
+    os_unfair_lock_unlock(&_midOverrideLock);
+}
 
 + (NSNumber *)kitCode {
     return @124;
@@ -47,15 +82,16 @@ static BOOL _willOverrideMid = NO;
 
 static __weak MPKitAdobe *_sharedInstance = nil;
 + (void)overrideMarketingCloudId:(NSString *)mid {
-    _midOverride = mid;
-    if (mid) {
-        [[MParticle sharedInstance] setIntegrationAttributes:@{marketingCloudIdIntegrationAttributeKey: mid} forKit:[[self class] kitCode]];
+    NSString *midSnapshot = [mid copy];
+    MPKitAdobeSetMidOverride(midSnapshot);
+    if (midSnapshot) {
+        [[MParticle sharedInstance] setIntegrationAttributes:@{marketingCloudIdIntegrationAttributeKey: midSnapshot} forKit:[[self class] kitCode]];
     }
     [_sharedInstance performSelectorOnMainThread:@selector(sendNetworkRequest) withObject:nil waitUntilDone:NO];
 }
 
 + (void)willOverrideMarketingCloudId:(BOOL)willOverrideMid {
-    _willOverrideMid = willOverrideMid;
+    MPKitAdobeSetWillOverrideMid(willOverrideMid);
 }
 
 #pragma mark MPKitInstanceProtocol methods
@@ -140,11 +176,12 @@ static __weak MPKitAdobe *_sharedInstance = nil;
 }
 
 - (void)sendNetworkRequest {
-    if (_willOverrideMid && !_midOverride) {
+    NSString *midOverrideSnapshot = MPKitAdobeCopyMidOverride();
+    if (MPKitAdobeGetWillOverrideMid() && !midOverrideSnapshot) {
         return;
     }
     
-    NSString *marketingCloudId = _midOverride;
+    NSString *marketingCloudId = midOverrideSnapshot;
     if (!marketingCloudId) {
         marketingCloudId = [self marketingCloudIdFromIntegrationAttributes];
         if (!marketingCloudId) {
@@ -172,9 +209,10 @@ static __weak MPKitAdobe *_sharedInstance = nil;
             return;
         }
         
+        NSString *midOverrideForCompletion = MPKitAdobeCopyMidOverride();
         NSMutableDictionary *integrationAttributes = [NSMutableDictionary dictionary];
         if (marketingCloudId.length) {
-            [integrationAttributes setObject:(_midOverride ?: marketingCloudId) forKey:marketingCloudIdIntegrationAttributeKey];
+            [integrationAttributes setObject:(midOverrideForCompletion ?: marketingCloudId) forKey:marketingCloudIdIntegrationAttributeKey];
         }
         if (locationHint.length) {
             [integrationAttributes setObject:locationHint forKey:locationHintIntegrationAttributeKey];


### PR DESCRIPTION
## Background
Concurrent access to the `_midOverride` / `_willOverrideMid` file-scope statics in the Adobe kit races on ARC-managed retain/release of the static slot. A reader preempted between loading the pointer and retaining it can end up holding memory that another writer just released, leaving a dangling `NSString` inside the integration-attributes dictionary. When that dictionary is later serialized on mParticle Core's message queue, `NSJSONSerialization` crashes in `_NSIsNSString` / `object_getMethodImplementation` while probing the dead object's isa.

## What Has Changed
- Added file-scope thread-safe accessors for `_midOverride` and `_willOverrideMid`, protected by `os_unfair_lock`.
- Replaced every direct read/write of those statics in `+overrideMarketingCloudId:`, `+willOverrideMarketingCloudId:`, and `-sendNetworkRequest` with the new accessors.
- Setter copies the incoming `NSString` before publishing so a mutable string cannot change out from under the dictionary.
- The `sendRequestWithMarketingCloudId:` completion block reads the override once into a strong local, replacing the double-read in `_midOverride ?: marketingCloudId` that was the primary race window.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
The production crash bottoms out in `NSJSONSerialization` while enumerating an `__NSFrozenDictionaryM` on `com.mparticle.messageQueue`. The frozen (immutable) container rules out a concurrent-mutation exception on the dictionary itself and points to a use-after-free on a value stored inside it — consistent with the unsynchronized access to `_midOverride` addressed here.