### PR TITLE
feat: Simplify collection of email and mobile sha256

### DIFF
--- a/UnitTests/ObjCTests/MPIdentityApiRequestTests.m
+++ b/UnitTests/ObjCTests/MPIdentityApiRequestTests.m
@@ -71,10 +71,57 @@
     request.customerId = @"some id";
     XCTAssertEqualObjects(@"some id", request.customerId);
     XCTAssertEqualObjects(@"some id", request.mutableIdentities[@(MPIdentityCustomerId)]);
-    
+
     request.customerId = nil;
     XCTAssertNil(request.customerId);
     XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityCustomerId)], [NSNull null]);
+}
+
+- (void)testSetEmailSha256 {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    XCTAssertNil(request.emailSha256);
+    request.emailSha256 = @"abc123hash";
+    XCTAssertEqualObjects(@"abc123hash", request.emailSha256);
+    XCTAssertEqualObjects(@"abc123hash", request.mutableIdentities[@(MPIdentityOther)]);
+
+    request.emailSha256 = nil;
+    XCTAssertNil(request.emailSha256);
+    XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityOther)], [NSNull null]);
+}
+
+- (void)testEmailSha256DelegatesToSetIdentityOther {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    request.emailSha256 = @"sha256hash";
+    XCTAssertEqualObjects(@"sha256hash", [request.identities objectForKey:@(MPIdentityOther)]);
+}
+
+- (void)testSetMobileSha256 {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    XCTAssertNil(request.mobileSha256);
+    request.mobileSha256 = @"mobilehash456";
+    XCTAssertEqualObjects(@"mobilehash456", request.mobileSha256);
+    XCTAssertEqualObjects(@"mobilehash456", request.mutableIdentities[@(MPIdentityOther)]);
+
+    request.mobileSha256 = nil;
+    XCTAssertNil(request.mobileSha256);
+    XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityOther)], [NSNull null]);
+}
+
+- (void)testMobileSha256DelegatesToSetIdentityOther {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    request.mobileSha256 = @"mobilehash";
+    XCTAssertEqualObjects(@"mobilehash", [request.identities objectForKey:@(MPIdentityOther)]);
+}
+
+- (void)testEmailSha256AndMobileSha256ShareOtherSlot {
+    MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
+    request.emailSha256 = @"emailhash";
+    XCTAssertEqualObjects(@"emailhash", request.emailSha256);
+    XCTAssertEqualObjects(@"emailhash", request.mobileSha256);
+
+    request.mobileSha256 = @"mobilehash";
+    XCTAssertEqualObjects(@"mobilehash", request.mobileSha256);
+    XCTAssertEqualObjects(@"mobilehash", request.emailSha256);
 }
 
 @end

--- a/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
@@ -71,6 +71,30 @@
     [self setIdentity:customerId identityType:MPIdentityCustomerId];
 }
 
+- (NSString *)emailSha256 {
+    NSObject *result = _mutableIdentities[@(MPIdentityOther)];
+    if ([result isKindOfClass:[NSString class]]) {
+        return (NSString *)result;
+    }
+    return nil;
+}
+
+- (void)setEmailSha256:(NSString *)emailSha256 {
+    [self setIdentity:emailSha256 identityType:MPIdentityOther];
+}
+
+- (NSString *)mobileSha256 {
+    NSObject *result = _mutableIdentities[@(MPIdentityOther)];
+    if ([result isKindOfClass:[NSString class]]) {
+        return (NSString *)result;
+    }
+    return nil;
+}
+
+- (void)setMobileSha256:(NSString *)mobileSha256 {
+    [self setIdentity:mobileSha256 identityType:MPIdentityOther];
+}
+
 - (NSDictionary<NSNumber*, NSObject*> *)identities {
     return [_mutableIdentities copy];
 }

--- a/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
+++ b/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
@@ -21,6 +21,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSString *email;
 @property (nonatomic, strong, nullable) NSString *customerId;
+
+/**
+ SHA-256 hashed email address for privacy-safe identity resolution.
+ Maps to the `other` identity type (@c MPIdentityOther).
+ */
+@property (nonatomic, strong, nullable) NSString *emailSha256;
+
+/**
+ SHA-256 hashed mobile number for privacy-safe identity resolution.
+ Maps to the `other` identity type (@c MPIdentityOther).
+ */
+@property (nonatomic, strong, nullable) NSString *mobileSha256;
+
 @property (nonatomic, strong, nullable, readonly) NSDictionary<NSNumber*, NSObject*> *identities;
 
 @end


### PR DESCRIPTION
## Background
- Currently to set sha256 identities clients have to call `identifyRequest.setIdentity("sha256 hashed email goes here", identityType: .other)` which is more verbose than other identity methods such as email
- Given mobile and email sha256 are now more first party attributes we want to collect these with dedicated methods

## What Has Changed
- Add dedicated `mobileSha256` and `emailSha256`

## Screenshots/Video
- N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
Before:
`identifyRequest.setIdentity("sha256 hashed email goes here", identityType: .other)`

After:
`identifyRequest.emailSha256 = "hash"`

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes N/A
