### PR TITLE
ci: pin Xcode version for CocoaPods publish jobs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -314,9 +314,14 @@ jobs:
     needs: [mirror-and-release-kits]
     runs-on: macos-15
     if: github.event.inputs.dry_run != 'true'
+    env:
+      XCODE_VERSION: "26.2"
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
       - name: Publish core podspecs
         env:
@@ -334,6 +339,8 @@ jobs:
     needs: [load-matrix, publish-core-cocoapods]
     runs-on: macos-15
     if: github.event.inputs.dry_run != 'true'
+    env:
+      XCODE_VERSION: ${{ matrix.kit.xcode_version || '26.2' }}
     strategy:
       fail-fast: false
       matrix:
@@ -341,6 +348,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
       - name: Wait for core SDK on CocoaPods CDN
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -312,7 +312,7 @@ jobs:
   publish-core-cocoapods:
     name: Publish Core SDK to CocoaPods
     needs: [mirror-and-release-kits]
-    runs-on: macos-15
+    runs-on: macos-latest
     if: github.event.inputs.dry_run != 'true'
     env:
       XCODE_VERSION: "26.2"
@@ -337,7 +337,7 @@ jobs:
   publish-kit-cocoapods:
     name: Publish ${{ matrix.kit.name }} to CocoaPods
     needs: [load-matrix, publish-core-cocoapods]
-    runs-on: macos-15
+    runs-on: macos-latest
     if: github.event.inputs.dry_run != 'true'
     env:
       XCODE_VERSION: ${{ matrix.kit.xcode_version || '26.2' }}


### PR DESCRIPTION
## Background

- The `publish-core-cocoapods` and `publish-kit-cocoapods` jobs ran on the `macos-15` runner without an explicit Xcode selection, using whatever default Xcode ships with the runner image.
- The `macos-15` runner's default Xcode lacks the iOS 26 SDK. Third-party dependencies (e.g. Airship) use `#available(iOS 26.0, *)` guards — Swift still type-checks code inside these blocks even on older toolchains, causing compile errors that don't reproduce locally on Xcode 26.2.
- This caused the `urbanairship-20` kit podspec publish to fail for the v9.0.1 release.

## What Has Changed

- Added `XCODE_VERSION: "26.2"` env and a `Select Xcode` step to `publish-core-cocoapods`.
- Added `XCODE_VERSION: ${{ matrix.kit.xcode_version || '26.2' }}` env and a `Select Xcode` step to `publish-kit-cocoapods`, so kits can override the version via `matrix.json` (e.g. Braze uses `16.4`) with `26.2` as the default.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally