### PR TITLE
fix: map mobileSha256 to MPIdentityOther2 instead of MPIdentityOther

### DIFF
--- a/UnitTests/ObjCTests/MPIdentityApiRequestTests.m
+++ b/UnitTests/ObjCTests/MPIdentityApiRequestTests.m
@@ -100,28 +100,27 @@
     XCTAssertNil(request.mobileSha256);
     request.mobileSha256 = @"mobilehash456";
     XCTAssertEqualObjects(@"mobilehash456", request.mobileSha256);
-    XCTAssertEqualObjects(@"mobilehash456", request.mutableIdentities[@(MPIdentityOther)]);
+    XCTAssertEqualObjects(@"mobilehash456", request.mutableIdentities[@(MPIdentityOther2)]);
 
     request.mobileSha256 = nil;
     XCTAssertNil(request.mobileSha256);
-    XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityOther)], [NSNull null]);
+    XCTAssertEqualObjects(request.mutableIdentities[@(MPIdentityOther2)], [NSNull null]);
 }
 
-- (void)testMobileSha256DelegatesToSetIdentityOther {
+- (void)testMobileSha256DelegatesToSetIdentityOther2 {
     MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
     request.mobileSha256 = @"mobilehash";
-    XCTAssertEqualObjects(@"mobilehash", [request.identities objectForKey:@(MPIdentityOther)]);
+    XCTAssertEqualObjects(@"mobilehash", [request.identities objectForKey:@(MPIdentityOther2)]);
 }
 
-- (void)testEmailSha256AndMobileSha256ShareOtherSlot {
+- (void)testEmailSha256AndMobileSha256UseDistinctSlots {
     MPIdentityApiRequest *request = [[MPIdentityApiRequest alloc] init];
     request.emailSha256 = @"emailhash";
-    XCTAssertEqualObjects(@"emailhash", request.emailSha256);
-    XCTAssertEqualObjects(@"emailhash", request.mobileSha256);
-
     request.mobileSha256 = @"mobilehash";
+    XCTAssertEqualObjects(@"emailhash", request.emailSha256);
     XCTAssertEqualObjects(@"mobilehash", request.mobileSha256);
-    XCTAssertEqualObjects(@"mobilehash", request.emailSha256);
+    XCTAssertEqualObjects(@"emailhash", request.mutableIdentities[@(MPIdentityOther)]);
+    XCTAssertEqualObjects(@"mobilehash", request.mutableIdentities[@(MPIdentityOther2)]);
 }
 
 @end

--- a/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
@@ -84,7 +84,7 @@
 }
 
 - (NSString *)mobileSha256 {
-    NSObject *result = _mutableIdentities[@(MPIdentityOther)];
+    NSObject *result = _mutableIdentities[@(MPIdentityOther2)];
     if ([result isKindOfClass:[NSString class]]) {
         return (NSString *)result;
     }
@@ -92,7 +92,7 @@
 }
 
 - (void)setMobileSha256:(NSString *)mobileSha256 {
-    [self setIdentity:mobileSha256 identityType:MPIdentityOther];
+    [self setIdentity:mobileSha256 identityType:MPIdentityOther2];
 }
 
 - (NSDictionary<NSNumber*, NSObject*> *)identities {

--- a/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
+++ b/mParticle-Apple-SDK/Include/MPIdentityApiRequest.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  SHA-256 hashed mobile number for privacy-safe identity resolution.
- Maps to the `other` identity type (@c MPIdentityOther).
+ Maps to the `other2` identity type (@c MPIdentityOther2).
  */
 @property (nonatomic, strong, nullable) NSString *mobileSha256;
 


### PR DESCRIPTION
## Summary
- `mobileSha256` was added in #756 mapping to `MPIdentityOther`, same as `emailSha256`
- Change `mobileSha256` to map to `MPIdentityOther2` so each property has a dedicated identity slot

## Test plan
- Updated `testSetMobileSha256` to assert against `MPIdentityOther2`
- Renamed `testMobileSha256DelegatesToSetIdentityOther` → `testMobileSha256DelegatesToSetIdentityOther2`
- Replaced `testEmailSha256AndMobileSha256ShareOtherSlot` with `testEmailSha256AndMobileSha256UseDistinctSlots` which verifies the two properties write to independent slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)