### PR TITLE
fix: Add startup logging for OneTrust and Adobe kits

### DIFF
--- a/Kits/adobe/adobe-5/Sources/mParticle-Adobe/MPKitAdobe.m
+++ b/Kits/adobe/adobe-5/Sources/mParticle-Adobe/MPKitAdobe.m
@@ -102,6 +102,7 @@ static __weak MPKitAdobe *_sharedInstance = nil;
     
     _organizationId = [configuration[organizationIdConfigurationKey] copy];
     if (!_organizationId.length) {
+        NSLog(@"mParticle -> Adobe config wasn't received yet.");
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeRequirementsNotMet];
         return execStatus;
     }
@@ -130,6 +131,7 @@ static __weak MPKitAdobe *_sharedInstance = nil;
                                                             object:nil
                                                           userInfo:userInfo];
     });
+    NSLog(@"mParticle -> Adobe configured");
     
     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;

--- a/Kits/onetrust/onetrust/Sources/mParticle-OneTrust/MPKitOneTrust.m
+++ b/Kits/onetrust/onetrust/Sources/mParticle-OneTrust/MPKitOneTrust.m
@@ -42,6 +42,11 @@
 }
 
 - (void)start {
+    if (!_configuration) {
+        NSLog(@"mParticle -> OneTrust config wasn't received yet.");
+        return;
+    }
+
     static dispatch_once_t kitPredicate;
     
     dispatch_once(&kitPredicate, ^{
@@ -60,6 +65,7 @@
         [[NSUserDefaults standardUserDefaults] setObject:vendorGeneralMappingDict forKey:@"OT_Vendor_General_mP_Mapping"];
         
         self->_started = YES;
+        NSLog(@"mParticle -> OneTrust configured");
         
         // READ consent data mapping
         NSString *mpConsentMapping = [[NSUserDefaults standardUserDefaults] stringForKey:@"OT_mP_Mapping"];


### PR DESCRIPTION
## Background
Startup diagnostics in OneTrust and Adobe kits did not clearly indicate when required configuration was missing or when initialization completed.
This update adds explicit logs to make kit startup behavior easier to troubleshoot.

## What Has Changed
- Added an early-return log in OneTrust when startup is triggered before configuration is available.
- Added a success log in OneTrust after initialization completes.
- Added a missing-configuration log in Adobe when required launch configuration is not present.
- Added a success log in Adobe after kit initialization finishes.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
N/A