### PR TITLE
feat: Include Payment Extension by Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 ##### Added
 
 - Pass through `handleURLCallback:` to `Rokt.handleURLCallback(with:)` on the Rokt SDK.
+- SwiftPM: declare `rokt-payment-extension-ios`; default product `mParticle-Rokt` links `RoktPaymentExtension`; optional product `mParticle-Rokt-No-Payments` omits it (no Stripe).
+- CocoaPods: default subspec `Payments` adds `RoktPaymentExtension`; subspec `No-Payments` is kit only (`Core`); subspec `Core` holds sources and base Rokt deps.
 
 ## [9.0.1] - 2026-04-22
 

--- a/Kits/rokt/rokt/Package.swift
+++ b/Kits/rokt/rokt/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import Foundation
 import PackageDescription
@@ -25,6 +25,10 @@ let package = Package(
     products: [
         .library(
             name: "mParticle-Rokt",
+            targets: ["mParticle-Rokt-Swift", "mParticle-Rokt-PaymentLinkage"]
+        ),
+        .library(
+            name: "mParticle-Rokt-No-Payments",
             targets: ["mParticle-Rokt-Swift"]
         )
     ],
@@ -36,6 +40,10 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/ROKT/rokt-contracts-apple.git",
+            .upToNextMajor(from: "2.0.0")
+        ),
+        .package(
+            url: "https://github.com/ROKT/rokt-payment-extension-ios.git",
             .upToNextMajor(from: "2.0.0")
         ),
         .package(
@@ -64,6 +72,13 @@ let package = Package(
                 .product(name: "RoktContracts", package: "rokt-contracts-apple")
             ],
             path: "Sources/mParticle-Rokt-Swift"
+        ),
+        .target(
+            name: "mParticle-Rokt-PaymentLinkage",
+            dependencies: [
+                .product(name: "RoktPaymentExtension", package: "rokt-payment-extension-ios")
+            ],
+            path: "Sources/mParticle-Rokt-PaymentLinkage"
         ),
         .testTarget(
             name: "mParticle-RoktObjCTests",

--- a/Kits/rokt/rokt/README.md
+++ b/Kits/rokt/rokt/README.md
@@ -15,14 +15,39 @@ Add the package dependency to your `Package.swift` or via Xcode:
 )
 ```
 
-Then add `mParticle-Rokt` as a dependency of your target.
+Then add a **product** to your target’s dependencies:
+
+- **`mParticle-Rokt`** (default) — includes [`RoktPaymentExtension`](https://github.com/ROKT/rokt-payment-extension-ios) so Shoppable Ads works without declaring that package yourself. Imports stay the same (`mParticle_Rokt`, etc.).
+- **`mParticle-Rokt-No-Payments`** — same kit **without** linking the payment extension (smaller dependency graph, no Stripe). Use this only if you do not need Shoppable Ads / `RoktPaymentExtension`, or you will add `rokt-payment-extension-ios` to your app separately.
+
+```swift
+.target(
+    name: "YourApp",
+    dependencies: [
+        .product(name: "mParticle-Rokt", package: "mp-apple-integration-rokt"),
+        // …
+    ]
+)
+```
+
+No-payments example:
+
+```swift
+.product(name: "mParticle-Rokt-No-Payments", package: "mp-apple-integration-rokt"),
+```
 
 ### CocoaPods
 
-Add the kit dependency to your app's Podfile:
+Default install includes the payment extension (for Shoppable Ads):
 
 ```ruby
 pod 'mParticle-Rokt', '~> 9.0'
+```
+
+To use the kit **without** `RoktPaymentExtension` / Stripe:
+
+```ruby
+pod 'mParticle-Rokt/No-Payments', '~> 9.0'
 ```
 
 ## Verifying the Integration

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt-PaymentLinkage/MPRoktPaymentExtensionLinkage.swift
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt-PaymentLinkage/MPRoktPaymentExtensionLinkage.swift
@@ -1,0 +1,5 @@
+import RoktPaymentExtension
+
+public enum MPRoktPaymentExtensionLinkage {
+    public static let isPaymentExtensionLinked = true
+}

--- a/Kits/rokt/rokt/mParticle-Rokt.podspec
+++ b/Kits/rokt/rokt/mParticle-Rokt.podspec
@@ -11,9 +11,22 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mp-apple-integration-rokt.git", :tag => "v" + s.version.to_s }
     s.swift_version = "5.5"
     s.ios.deployment_target = "15.6"
-    s.ios.source_files      = 'Sources/mParticle-Rokt/**/*.{h,m}', 'Sources/mParticle-Rokt-Swift/**/*.swift'
-    s.ios.resource_bundles  = { 'mParticle-Rokt-Privacy' => ['Sources/mParticle-Rokt/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK', '~> 9.0'
-    s.ios.dependency 'RoktContracts', '~> 2.0'
-    s.ios.dependency 'Rokt-Widget', '~> 5.1'
+    s.default_subspec = "Payments"
+
+    s.subspec "Core" do |ss|
+        ss.ios.source_files      = 'Sources/mParticle-Rokt/**/*.{h,m}', 'Sources/mParticle-Rokt-Swift/**/*.swift'
+        ss.ios.resource_bundles  = { 'mParticle-Rokt-Privacy' => ['Sources/mParticle-Rokt/PrivacyInfo.xcprivacy'] }
+        ss.ios.dependency 'mParticle-Apple-SDK', '~> 9.0'
+        ss.ios.dependency 'RoktContracts', '~> 2.0'
+        ss.ios.dependency 'Rokt-Widget', '~> 5.1'
+    end
+
+    s.subspec "Payments" do |ss|
+        ss.ios.dependency 'mParticle-Rokt/Core', s.version.to_s
+        ss.ios.dependency 'RoktPaymentExtension', '~> 2.0'
+    end
+
+    s.subspec "No-Payments" do |ss|
+        ss.ios.dependency 'mParticle-Rokt/Core', s.version.to_s
+    end
 end


### PR DESCRIPTION
## Background
- Shoppable Ads relies on RoktPaymentExtension; the kit now pulls it in by default. Apps that do not want that stack can use the no-payments variant instead.

## What Has Changed
- Swift Package Manager (Kits/rokt/rokt/Package.swift)

- Declares a dependency on https://github.com/ROKT/rokt-payment-extension-ios.git (from 2.0.0).
- mParticle-Rokt (unchanged product name) now links mParticle-Rokt-Swift plus a small mParticle-Rokt-PaymentLinkage target that depends on RoktPaymentExtension, so the extension is available by default without renaming or changing the primary product.
- Adds mParticle-Rokt-No-Payments, a second library product that depends only on mParticle-Rokt-Swift (no RoktPaymentExtension / Stripe).
- Raises swift-tools-version to 5.9 for alignment with the payment extension toolchain.

- CocoaPods (mParticle-Rokt.podspec)

- Introduces Core (sources, privacy bundle, mParticle-Apple-SDK, RoktContracts, Rokt-Widget).
- Payments is the default_subspec: Core + RoktPaymentExtension ~> 2.0.
- No-Payments: Core only (pod 'mParticle-Rokt/No-Payments').

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.


## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
