### PR TITLE
ci: Update CocoaPods Release Script to Handle Duplicate Entry

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -327,12 +327,35 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           PUSH_FLAGS=(--allow-warnings --synchronous)
+
+          trunk_push_with_retries() {
+            local podspec="$1"
+            local attempt status
+            for attempt in 1 2 3; do
+              pod trunk push "$podspec" "${PUSH_FLAGS[@]}" 2>&1 | tee pod_trunk_push.log
+              status=${PIPESTATUS[0]}
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+              if grep -qiF 'duplicate entry' pod_trunk_push.log; then
+                echo "✅ ${podspec}: already on trunk; treating push as successful."
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "Attempt $attempt failed for $podspec, retrying in 3 minutes..."
+                sleep 180
+              else
+                return 1
+              fi
+            done
+          }
+
           # Order matters: Swift pod → ObjC core (depends on Swift) → umbrella (depends on ObjC).
-          pod trunk push mParticle-Apple-SDK-Swift.podspec "${PUSH_FLAGS[@]}"
-          pod trunk push mParticle-Apple-SDK-ObjC.podspec "${PUSH_FLAGS[@]}"
-          pod trunk push mParticle-Apple-SDK.podspec "${PUSH_FLAGS[@]}"
+          trunk_push_with_retries mParticle-Apple-SDK-Swift.podspec
+          trunk_push_with_retries mParticle-Apple-SDK-ObjC.podspec
+          trunk_push_with_retries mParticle-Apple-SDK.podspec
 
   publish-kit-cocoapods:
     name: Publish ${{ matrix.kit.name }} to CocoaPods
@@ -376,7 +399,30 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          for attempt in 1 2 3; do
-            pod trunk push ${{ matrix.kit.podspec }} --allow-warnings --synchronous && break
-            [ $attempt -lt 3 ] && echo "Attempt $attempt failed, retrying in 3 minutes..." && sleep 180 || exit 1
-          done
+          set -uo pipefail
+          PODSPEC="${{ matrix.kit.podspec }}"
+          PUSH_FLAGS=(--allow-warnings --synchronous)
+
+          trunk_push_with_retries() {
+            local podspec="$1"
+            local attempt status
+            for attempt in 1 2 3; do
+              pod trunk push "$podspec" "${PUSH_FLAGS[@]}" 2>&1 | tee pod_trunk_push.log
+              status=${PIPESTATUS[0]}
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+              if grep -qiF 'duplicate entry' pod_trunk_push.log; then
+                echo "✅ ${podspec}: already on trunk; treating push as successful."
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "Attempt $attempt failed for $podspec, retrying in 3 minutes..."
+                sleep 180
+              else
+                return 1
+              fi
+            done
+          }
+
+          trunk_push_with_retries "$PODSPEC"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -327,32 +327,10 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          # Default run shell is bash -e: a failed `pod | tee` exits before PIPESTATUS / duplicate handling.
+          # Default run shell is bash -e; disable errexit so retry / duplicate handling in Scripts/pod_push.sh runs.
           set +e
           set -uo pipefail
-          PUSH_FLAGS=(--allow-warnings --synchronous)
-
-          trunk_push_with_retries() {
-            local podspec="$1"
-            local attempt status
-            for attempt in 1 2 3; do
-              pod trunk push "$podspec" "${PUSH_FLAGS[@]}" 2>&1 | tee pod_trunk_push.log
-              status=${PIPESTATUS[0]}
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-              if grep -qiF 'duplicate entry' pod_trunk_push.log; then
-                echo "✅ ${podspec}: already on trunk; treating push as successful."
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                echo "Attempt $attempt failed for $podspec, retrying in 3 minutes..."
-                sleep 180
-              else
-                return 1
-              fi
-            done
-          }
+          . Scripts/pod_push.sh
 
           # Order matters: Swift pod → ObjC core (depends on Swift) → umbrella (depends on ObjC).
           # With set +e, propagate failures so later pushes do not run after an earlier failure.
@@ -402,32 +380,10 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          # Default run shell is bash -e: a failed `pod | tee` exits before PIPESTATUS / duplicate handling.
+          # Default run shell is bash -e; disable errexit so retry / duplicate handling in Scripts/pod_push.sh runs.
           set +e
           set -uo pipefail
+          . Scripts/pod_push.sh
           PODSPEC="${{ matrix.kit.podspec }}"
-          PUSH_FLAGS=(--allow-warnings --synchronous)
-
-          trunk_push_with_retries() {
-            local podspec="$1"
-            local attempt status
-            for attempt in 1 2 3; do
-              pod trunk push "$podspec" "${PUSH_FLAGS[@]}" 2>&1 | tee pod_trunk_push.log
-              status=${PIPESTATUS[0]}
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-              if grep -qiF 'duplicate entry' pod_trunk_push.log; then
-                echo "✅ ${podspec}: already on trunk; treating push as successful."
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                echo "Attempt $attempt failed for $podspec, retrying in 3 minutes..."
-                sleep 180
-              else
-                return 1
-              fi
-            done
-          }
 
           trunk_push_with_retries "$PODSPEC" || exit 1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -327,6 +327,8 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
+          # Default run shell is bash -e: a failed `pod | tee` exits before PIPESTATUS / duplicate handling.
+          set +e
           set -uo pipefail
           PUSH_FLAGS=(--allow-warnings --synchronous)
 
@@ -353,9 +355,10 @@ jobs:
           }
 
           # Order matters: Swift pod → ObjC core (depends on Swift) → umbrella (depends on ObjC).
-          trunk_push_with_retries mParticle-Apple-SDK-Swift.podspec
-          trunk_push_with_retries mParticle-Apple-SDK-ObjC.podspec
-          trunk_push_with_retries mParticle-Apple-SDK.podspec
+          # With set +e, propagate failures so later pushes do not run after an earlier failure.
+          trunk_push_with_retries mParticle-Apple-SDK-Swift.podspec || exit 1
+          trunk_push_with_retries mParticle-Apple-SDK-ObjC.podspec || exit 1
+          trunk_push_with_retries mParticle-Apple-SDK.podspec || exit 1
 
   publish-kit-cocoapods:
     name: Publish ${{ matrix.kit.name }} to CocoaPods
@@ -399,6 +402,8 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
+          # Default run shell is bash -e: a failed `pod | tee` exits before PIPESTATUS / duplicate handling.
+          set +e
           set -uo pipefail
           PODSPEC="${{ matrix.kit.podspec }}"
           PUSH_FLAGS=(--allow-warnings --synchronous)
@@ -425,4 +430,4 @@ jobs:
             done
           }
 
-          trunk_push_with_retries "$PODSPEC"
+          trunk_push_with_retries "$PODSPEC" || exit 1

--- a/Scripts/pod_push.sh
+++ b/Scripts/pod_push.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# CocoaPods trunk push with retries. Treats trunk "duplicate entry" as success (transient 5xx after publish).
+#
+# Source from the repo root:   . Scripts/pod_push.sh
+# On GitHub Actions, run `set +e` before calling—the default run shell uses bash -e; callers rely on
+# explicit status checks inside this function instead of errexit aborting mid-retry.
+#
+
+trunk_push_with_retries() {
+	local podspec="$1"
+	local attempt status
+	local -a push_flags=(--allow-warnings --synchronous)
+
+	for attempt in 1 2 3; do
+		status=0
+		pod trunk push "${podspec}" "${push_flags[@]}" >pod_trunk_push.log 2>&1 || status=$?
+		cat pod_trunk_push.log
+		if [[ ${status} -eq 0 ]]; then
+			return 0
+		fi
+		if grep -qiF 'duplicate entry' pod_trunk_push.log; then
+			echo "✅ ${podspec}: already on trunk; treating push as successful."
+			return 0
+		fi
+		if [[ ${attempt} -lt 3 ]]; then
+			echo "Attempt ${attempt} failed for ${podspec}, retrying in 3 minutes..."
+			sleep 180
+		else
+			return 1
+		fi
+	done
+}


### PR DESCRIPTION
## Background
- If CocoaPods release partially fails then we can't rerun because failing from finding a duplicate entry was being treated as failure

## What Has Changed
- Now we treat duplicate entry as success and we retry until we get a success

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
