### PR TITLE
ci: Swift Packages do not emit xcframeworks

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -151,6 +151,15 @@ jobs:
 
           mkdir -p archives xcframeworks
 
+          SKIP_XCF="${{ matrix.kit.skip_xcframework }}"
+          if [ "$SKIP_XCF" = "true" ]; then
+            MODULE=$(echo "$SCHEMES_JSON" | jq -r '.[0].module')
+            echo "Skipping xcframework: Swift package archives for this target do not emit Products/Library/Frameworks/*.framework (object files only). Use SwiftPM/CocoaPods from the tag." \
+              >"xcframeworks/${MODULE}-distribution.txt"
+            (cd xcframeworks && zip -r "${MODULE}.xcframework.zip" "${MODULE}-distribution.txt")
+            exit 0
+          fi
+
           MODULES=$(echo "$SCHEMES_JSON" | jq -r '.[].module' | sort -u)
 
           for MODULE in $MODULES; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 - **Rokt SDK+ (`RoktSDKPlus`)** — Umbrella Swift package and CocoaPods pod at `Kits/rokt-sdk-plus/rokt-sdk-plus-ios`, versioned with the core SDK and mirrored to [ROKT/rokt-sdk-plus-ios](https://github.com/ROKT/rokt-sdk-plus-ios).
 
+#### Fixed
+
+- **Rokt SDK+** — Release **Build rokt-sdk-plus-ios** no longer runs `xcodebuild -create-xcframework` for this Swift-package-only target (archives do not produce `*.framework` under `Products/Library/Frameworks/`). CI uploads a small placeholder zip so mirror artifact steps still succeed; integrate via SwiftPM or CocoaPods from the tag.
+
 #### Rokt
 
 ##### Changed

--- a/Kits/matrix.json
+++ b/Kits/matrix.json
@@ -400,6 +400,7 @@
     "dest_repo": "rokt-sdk-plus-ios",
     "dest_org": "ROKT",
     "spm_package_only": true,
+    "skip_xcframework": true,
     "skip_example_builds": true,
     "skip_spm_tests": true,
     "pod_lint_include_podspecs": "Kits/rokt/rokt/mParticle-Rokt.podspec",

--- a/Kits/rokt-sdk-plus/rokt-sdk-plus-ios/Package.swift
+++ b/Kits/rokt-sdk-plus/rokt-sdk-plus-ios/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         mParticleRoktDependency,
         .package(
             url: "https://github.com/ROKT/rokt-payment-extension-ios.git",
-            .upToNextMajor(from: "2.0.0")
+            .upToNextMajor(from: "2.0.2")
         )
     ],
     targets: [

--- a/Kits/rokt/rokt/Package.swift
+++ b/Kits/rokt/rokt/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         mParticleAppleSDK,
         .package(
             url: "https://github.com/ROKT/rokt-sdk-ios",
-            .upToNextMajor(from: "5.2.0")
+            .upToNextMajor(from: "5.2.1")
         ),
         .package(
             url: "https://github.com/ROKT/rokt-contracts-apple.git",


### PR DESCRIPTION
## Background
- Release – Publish builds each kit matrix row with xcodebuild archive + xcodebuild -create-xcframework, assuming a Products/Library/Frameworks/<Module>.framework bundle in the archive.
- rokt-sdk-plus-ios is a Swift package only (no .xcodeproj). Archiving it does not produce that framework layout (only intermediate .o / non–framework products), so create-xcframework fails even when archive reports success—blocking the dry run and the rest of the release pipeline. 
- https://github.com/mParticle/mparticle-apple-sdk/actions/runs/25754566228/job/75639504651

## What Has Changed
- Kits/matrix.json: set skip_xcframework: true for rokt-sdk-plus-ios.
- .github/workflows/release-publish.yml: when skip_xcframework is set, skip archive + create-xcframework for that row; write a short distribution note and zip it as RoktSDKPlus.xcframework.zip so upload-artifact, mirror download, and release asset steps still receive a matching *.xcframework.zip artifact.
- CHANGELOG.md: note the fix under Unreleased (Rokt SDK+ / release CI).

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
