### PR TITLE
fix: cap OneTrust SDK versions to avoid ObjC selector mismatch

### DIFF
--- a/Kits/onetrust/onetrust/Package.swift
+++ b/Kits/onetrust/onetrust/Package.swift
@@ -33,13 +33,13 @@ let package = Package(
         // iOS OneTrust
         .package(
             url: "https://github.com/Zentrust/OTPublishersHeadlessSDK",
-            "0.0.0"..<"202503.0.0"
+            "202502.1.0"..<"202503.0.0"
         ),
 
         // tvOS OneTrust
         .package(
             url: "https://github.com/Zentrust/OTPublishersHeadlessSDKtvOS",
-            "0.0.0"..<"202503.0.0"
+            "202502.1.0"..<"202503.0.0"
         )
     ],
     targets: [

--- a/Kits/onetrust/onetrust/Package.swift
+++ b/Kits/onetrust/onetrust/Package.swift
@@ -33,13 +33,13 @@ let package = Package(
         // iOS OneTrust
         .package(
             url: "https://github.com/Zentrust/OTPublishersHeadlessSDK",
-            "202502.1.0"..<"202503.0.0"
+            "0.0.0"..<"202503.0.0"
         ),
 
         // tvOS OneTrust
         .package(
             url: "https://github.com/Zentrust/OTPublishersHeadlessSDKtvOS",
-            "202502.1.0"..<"202503.0.0"
+            "0.0.0"..<"202503.0.0"
         )
     ],
     targets: [

--- a/Kits/onetrust/onetrust/Package.swift
+++ b/Kits/onetrust/onetrust/Package.swift
@@ -33,13 +33,13 @@ let package = Package(
         // iOS OneTrust
         .package(
             url: "https://github.com/Zentrust/OTPublishersHeadlessSDK",
-            "0.0.0"..<"999999.0.0"
+            "0.0.0"..<"202503.0.0"
         ),
 
         // tvOS OneTrust
         .package(
             url: "https://github.com/Zentrust/OTPublishersHeadlessSDKtvOS",
-            "0.0.0"..<"999999.0.0"
+            "0.0.0"..<"202503.0.0"
         )
     ],
     targets: [

--- a/Kits/onetrust/onetrust/mParticle-OneTrust.podspec
+++ b/Kits/onetrust/onetrust/mParticle-OneTrust.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
     s.source_files      = 'Sources/mParticle-OneTrust/**/*.{h,m}'
     s.resource_bundles  = { 'mParticle-OneTrust-Privacy' => ['Sources/mParticle-OneTrust/PrivacyInfo.xcprivacy'] }
     s.dependency 'mParticle-Apple-SDK', '~> 9.0'
-    s.ios.dependency 'OneTrust-CMP-XCFramework'
-    s.tvos.dependency 'OneTrust-CMP-tvOS-XCFramework'
+    s.ios.dependency 'OneTrust-CMP-XCFramework', '>= 202502.1.0', '< 202503.0.0'
+    s.tvos.dependency 'OneTrust-CMP-tvOS-XCFramework', '>= 202502.1.0', '< 202503.0.0'
 end

--- a/Kits/onetrust/onetrust/mParticle-OneTrust.podspec
+++ b/Kits/onetrust/onetrust/mParticle-OneTrust.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
     s.source_files      = 'Sources/mParticle-OneTrust/**/*.{h,m}'
     s.resource_bundles  = { 'mParticle-OneTrust-Privacy' => ['Sources/mParticle-OneTrust/PrivacyInfo.xcprivacy'] }
     s.dependency 'mParticle-Apple-SDK', '~> 9.0'
-    s.ios.dependency 'OneTrust-CMP-XCFramework', '>= 202502.1.0', '< 202503.0.0'
-    s.tvos.dependency 'OneTrust-CMP-tvOS-XCFramework', '>= 202502.1.0', '< 202503.0.0'
+    s.ios.dependency 'OneTrust-CMP-XCFramework', '< 202503.0.0'
+    s.tvos.dependency 'OneTrust-CMP-tvOS-XCFramework', '< 202503.0.0'
 end


### PR DESCRIPTION
## Background
CI started failing after newer OneTrust SDK releases were resolved by default.
Those versions no longer expose the Objective-C selector expected by the OneTrust kit integration.

## What Has Changed
- Added an upper-only cap for OneTrust SPM dependencies (`< 202503.0.0`) in the kit package manifest.
- Added an upper-only cap for CocoaPods OneTrust dependencies (`< 202503.0.0`) in the kit podspec.
- Kept runtime integration code unchanged and scoped the fix to dependency constraints only.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
This update is intended to stabilize CI by preventing automatic resolution to OneTrust SDK versions where the ObjC selector mismatch occurs.