### PR TITLE
fix: call start on kits configured from cache

### DIFF
--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -2072,9 +2072,9 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
             
             MPILogDebug(@"configureKits - configuring kit %@ (existing instance: %@)", integrationId, kitInstance ? @"YES" : @"NO");
             
+            BOOL disabled = [self isKitDisabled:kitRegister.code];
+
             if (kitInstance) {
-                
-                BOOL disabled = [self isKitDisabled:kitRegister.code];
                 if (disabled) {
                     kitRegister.wrapperInstance = nil;
                 } else {
@@ -2093,26 +2093,27 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
                 
                 if (kitInstance) {
                     [self updateBracketsWithConfiguration:kitConfiguration.bracketConfiguration integrationId:integrationId];
-                    if (![kitInstance started]) {
-                        if ([kitInstance respondsToSelector:@selector(setLaunchOptions:)]) {
-                            [kitInstance performSelector:@selector(setLaunchOptions:) withObject:stateMachine.launchOptions];
-                        }
-                        
-                        if ([kitInstance respondsToSelector:@selector(start)]) {
-                            @try {
-                                [kitInstance start];
-                            }
-                            @catch (NSException *exception) {
-                                MPILogError(@"Exception thrown while starting kit (%@): %@", kitInstance, exception);
-                            }
-                        }
-                    }
                 }
                 
                 [self updateBracketsWithConfiguration:kitConfiguration.bracketConfiguration integrationId:integrationId];
             }
             
             if (kitInstance) {
+                if (![kitInstance started] && !disabled) {
+                    if ([kitInstance respondsToSelector:@selector(setLaunchOptions:)]) {
+                        [kitInstance performSelector:@selector(setLaunchOptions:) withObject:stateMachine.launchOptions];
+                    }
+                    
+                    if ([kitInstance respondsToSelector:@selector(start)]) {
+                        @try {
+                            [kitInstance start];
+                        }
+                        @catch (NSException *exception) {
+                            MPILogError(@"Exception thrown while starting kit (%@): %@", kitInstance, exception);
+                        }
+                    }
+                }
+                
                 NSArray *alreadySynchedUserAttributes = userDefaults[kMPSynchedUserAttributesKey];
                 if (userAttributes && ![alreadySynchedUserAttributes containsObject:integrationId]) {
                     NSMutableArray *synchedUserAttributes = [[NSMutableArray alloc] initWithCapacity:alreadySynchedUserAttributes.count + 1];


### PR DESCRIPTION
## Background
- Kits configured by cached cofigurations did not have start called on them. This was not a problem with the majority of the kits as they no longer use a start method, but Braze, when initialization was not handled by the customer, did fail to start in this scenario

## What Has Changed
- This change ensures that no matter the path for receiving a configuration we attempt to call start on all kits.


## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://github.com/mParticle/mparticle-apple-sdk/pull/771
