### PR TITLE
fix: align identity.deviceApplicationStamp with wire value (TRIAGE-713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 - Bump minimum `RoktContracts` to 2.0.0 (adds `PaymentMethodType.paypal` and totals on `PaymentPreparation`).
 
+#### Fixed
+
+- `MParticle.sharedInstance.identity.deviceApplicationStamp` now returns the same value sent on the wire as `device_application_stamp` (`mp_deviceid`). Previously it returned the unrelated `MPDevice.deviceIdentifier` used for ramp bucketing.
+
 ### Kits
 
 #### Added

--- a/UnitTests/ObjCTests/MPIdentityTests.m
+++ b/UnitTests/ObjCTests/MPIdentityTests.m
@@ -10,6 +10,7 @@
 #import "MPBaseTestCase.h"
 #import "MPIdentityApi.h"
 #import "MPIdentityApiManager.h"
+#import "MPConsumerInfo.h"
 #import "MPKitContainer.h"
 #import "MPPersistenceController.h"
 #import "MPStateMachine.h"
@@ -59,6 +60,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;
 @property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 
 @end
 
@@ -1095,6 +1097,14 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     XCTAssertEqualObjects(dictionary[@"data"][@"start_unixtime_ms"], @100000);
     XCTAssertEqualObjects(dictionary[@"data"][@"end_unixtime_ms"], @200000);
     XCTAssertNotNil(dictionary[@"request_id"]);
+}
+
+- (void)testDeviceApplicationStampMatchesConsumerInfo {
+    MPConsumerInfo *consumerInfo = [MParticle sharedInstance].stateMachine.consumerInfo;
+    NSString *expected = consumerInfo.deviceApplicationStamp;
+
+    XCTAssertNotNil(expected);
+    XCTAssertEqualObjects([MParticle sharedInstance].identity.deviceApplicationStamp, expected);
 }
 
 @end

--- a/mParticle-Apple-SDK/Identity/MPIdentityApi.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApi.m
@@ -365,16 +365,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 }
 
 - (NSString *)deviceApplicationStamp {
-    MParticle* mparticle = MParticle.sharedInstance;
-    MPLog* logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue:mparticle.logLevel]];
-    logger.customLogger = mparticle.customLogger;
-    MPUserDefaults* userDefaults = MPUserDefaultsConnector.userDefaults;
-    MPDevice *device = [[MPDevice alloc] initWithStateMachine:(id<MPStateMachineMPDeviceProtocol>)mparticle.stateMachine
-                                                 userDefaults:(id<MPIdentityApiMPUserDefaultsProtocol>)userDefaults
-                                                     identity:(id<MPIdentityApiMPDeviceProtocol>)mparticle.identity
-                                                       logger:logger];
-
-    return device.deviceIdentifier;
+    return [MParticle sharedInstance].stateMachine.consumerInfo.deviceApplicationStamp;
 }
 
 - (void)identifyNoDispatch:(MPIdentityApiRequest *)identifyRequest completion:(nullable MPIdentityApiResultCallback)completion {


### PR DESCRIPTION
MParticle.sharedInstance.identity.deviceApplicationStamp returned MPDevice.deviceIdentifier (a separate UUID used for ramp bucketing) instead of the value actually sent on the wire as
device_application_stamp (a.k.a. mp_deviceid), which the SDK sources from MPConsumerInfo.deviceApplicationStamp in identity requests (MPIdentityDTO) and event uploads (MPUploadBuilder).

Return the consumer-info value so the public getter matches the wire payload customers see in UAV.
