### PR TITLE
feat: device-based consent

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,9 +8,10 @@ permissions:
   contents: read
 
 env:
-  XCODE_VERSION: 16.4
+  XCODE_VERSION: "26.2"
   WORKING_DIRECTORY: IntegrationTests
   WIREMOCK_VERSION: 3.9.1
+  TOOLCHAINS: com.apple.dt.toolchain.XcodeDefault
 
 jobs:
   integration-tests:
@@ -23,10 +24,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+          echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-6.2/macosx" >> "$GITHUB_ENV"
 
       - name: Install Tuist
         run: brew install tuist
+
+      - name: Verify Tuist
+        run: tuist version
 
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 #### Added
 
+- Add device-level consent via `MParticleOptions.deviceConsentState` and `MParticle.sharedInstance.deviceConsentState`. When set, it supersedes user/MPID-level consent everywhere consent is evaluated (kit enablement, consent forwarding to kits, and the consent included in uploads for all MPIDs), is persisted device-wide independent of the active user, and triggers the same kit refresh as a user consent change. Set it to `nil` to clear and revert to user/MPID-level consent.
 - Add `MPRokt.handleURLCallback:` for forwarding Afterpay/PayPal redirect URLs to the registered Rokt payment extension. Call from `application:openURL:options:` (AppDelegate) or `scene:openURLContexts:` / `.onOpenURL` (Scene/SwiftUI).
 
 #### Changed

--- a/UnitTests/ObjCTests/MPKitContainerTests.m
+++ b/UnitTests/ObjCTests/MPKitContainerTests.m
@@ -2572,6 +2572,42 @@
     XCTAssertTrue(isDisabled);
 }
 
+- (void)testIsDisabledByConsentKitFilterUsesDeviceConsent {
+    MPConsentKitFilter *filter = [[MPConsentKitFilter alloc] init];
+    filter.shouldIncludeOnMatch = YES;
+
+    MPConsentKitFilterItem *item = [[MPConsentKitFilterItem alloc] init];
+    item.consented = YES;
+    item.javascriptHash = -1729075708;
+    filter.filterItems = @[item];
+
+    // User-level consent does NOT match the filter (not consented) -> kit disabled.
+    MPConsentState *userState = [[MPConsentState alloc] init];
+    MPGDPRConsent *userConsent = [[MPGDPRConsent alloc] init];
+    userConsent.consented = NO;
+    userConsent.document = @"user-document";
+    [userState addGDPRConsentState:userConsent purpose:@"Processing"];
+
+    [MPPersistenceController_PRIVATE setConsentState:userState forMpid:[MPPersistenceController_PRIVATE mpId]];
+    MParticle.sharedInstance.identity.currentUser.consentState = userState;
+
+    XCTAssertTrue([[MParticle sharedInstance].kitContainer_PRIVATE isDisabledByConsentKitFilter:filter]);
+
+    // Device-level consent matches the filter (consented) -> supersedes user, kit enabled.
+    MPConsentState *deviceState = [[MPConsentState alloc] init];
+    MPGDPRConsent *deviceConsent = [[MPGDPRConsent alloc] init];
+    deviceConsent.consented = YES;
+    deviceConsent.document = @"device-document";
+    [deviceState addGDPRConsentState:deviceConsent purpose:@"Processing"];
+    [MParticle sharedInstance].deviceConsentState = deviceState;
+
+    XCTAssertFalse([[MParticle sharedInstance].kitContainer_PRIVATE isDisabledByConsentKitFilter:filter]);
+
+    // Clearing device consent reverts to user-level behavior.
+    [MParticle sharedInstance].deviceConsentState = nil;
+    XCTAssertTrue([[MParticle sharedInstance].kitContainer_PRIVATE isDisabledByConsentKitFilter:filter]);
+}
+
 - (void)testInitializeKitsWhenNilSupportedKits {
     MPKitContainer_PRIVATE *kitContainer = [[MPKitContainer_PRIVATE alloc] init];
     MPKitContainer_PRIVATE *mockKitContainer = OCMPartialMock(kitContainer);

--- a/UnitTests/ObjCTests/MPPersistenceControllerTests.m
+++ b/UnitTests/ObjCTests/MPPersistenceControllerTests.m
@@ -17,6 +17,8 @@
 #import "MPBaseTestCase.h"
 #import "MPStateMachine.h"
 #import "MPKitFilter.h"
+#import "MPConsentState.h"
+#import "MPCCPAConsent.h"
 #import "UploadSettingsUtils.h"
 #import "MPUploadSettings.h"
 
@@ -82,6 +84,44 @@
     });
     workBlock();
     [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+}
+
+- (void)testDeviceConsentStateRoundTripAndResolver {
+    [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+
+    NSNumber *mpid = [MPPersistenceController_PRIVATE mpId];
+
+    // User-level consent for the current mpid.
+    MPConsentState *userState = [[MPConsentState alloc] init];
+    MPCCPAConsent *userConsent = [[MPCCPAConsent alloc] init];
+    userConsent.consented = NO;
+    userConsent.document = @"user-doc";
+    [userState setCCPAConsentState:userConsent];
+    [MPPersistenceController_PRIVATE setConsentState:userState forMpid:mpid];
+
+    // Without device consent, the resolver falls back to the per-mpid user consent.
+    MPConsentState *effective = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:mpid];
+    XCTAssertNotNil(effective);
+    XCTAssertFalse(effective.ccpaConsentState.consented);
+
+    // Device consent round-trips and supersedes the user consent for any mpid.
+    MPConsentState *deviceState = [[MPConsentState alloc] init];
+    MPCCPAConsent *deviceConsent = [[MPCCPAConsent alloc] init];
+    deviceConsent.consented = YES;
+    deviceConsent.document = @"device-doc";
+    [deviceState setCCPAConsentState:deviceConsent];
+    [MPPersistenceController_PRIVATE setDeviceConsentState:deviceState];
+
+    XCTAssertTrue([MPPersistenceController_PRIVATE deviceConsentState].ccpaConsentState.consented);
+    XCTAssertTrue([MPPersistenceController_PRIVATE effectiveConsentStateForMpid:mpid].ccpaConsentState.consented);
+    XCTAssertTrue([MPPersistenceController_PRIVATE effectiveConsentStateForMpid:@123456].ccpaConsentState.consented);
+
+    // Clearing device consent reverts to the per-mpid user consent.
+    [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+    XCTAssertNil([MPPersistenceController_PRIVATE deviceConsentState]);
+    XCTAssertFalse([MPPersistenceController_PRIVATE effectiveConsentStateForMpid:mpid].ccpaConsentState.consented);
+
+    [MPPersistenceController_PRIVATE setConsentState:nil forMpid:mpid];
 }
 
 - (void)testMigrateMessagesWithNullSessions {

--- a/UnitTests/ObjCTests/MPUploadBuilderTests.m
+++ b/UnitTests/ObjCTests/MPUploadBuilderTests.m
@@ -10,6 +10,10 @@
 #import "MPPersistenceController.h"
 #import "MPBaseTestCase.h"
 #import "mParticle.h"
+#import "MPConsentState.h"
+#import "MPCCPAConsent.h"
+#import "MPConsentSerialization.h"
+#import "MPUploadSettings.h"
 
 @interface MParticle ()
 
@@ -808,6 +812,34 @@
     [uploadBuilder build:^(MPUpload * _Nullable upload) {
         XCTAssert(NO, @"Builder completion should not have been called since batch was blocked by customer");
     }];
+}
+
+- (void)testUploadUsesDeviceConsent {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Upload uses device consent"];
+
+    // The current user has no consent of its own; only the device-level consent is set.
+    [MPPersistenceController_PRIVATE setConsentState:nil forMpid:[MPPersistenceController_PRIVATE mpId]];
+
+    MPConsentState *deviceState = [[MPConsentState alloc] init];
+    MPCCPAConsent *ccpaConsent = [[MPCCPAConsent alloc] init];
+    ccpaConsent.consented = YES;
+    ccpaConsent.document = @"device-ccpa-document";
+    [deviceState setCCPAConsentState:ccpaConsent];
+    [MPPersistenceController_PRIVATE setDeviceConsentState:deviceState];
+
+    MPUploadBuilder *uploadBuilder = [self createTestUploadBuilder];
+
+    [uploadBuilder build:^(MPUpload * _Nullable upload) {
+        XCTAssertNotNil(upload);
+        NSDictionary *uploadDictionary = [(MPUpload *)upload dictionaryRepresentation];
+        NSDictionary *expectedConsent = [MPConsentSerialization serverDictionaryFromConsentState:deviceState];
+        XCTAssertNotNil(uploadDictionary[kMPConsentState]);
+        XCTAssertEqualObjects(uploadDictionary[kMPConsentState], expectedConsent);
+        [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
 

--- a/UnitTests/ObjCTests/MParticleTests.m
+++ b/UnitTests/ObjCTests/MParticleTests.m
@@ -419,7 +419,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
     MParticle *instance = [MParticle sharedInstance];
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-    // options.deviceConsentState intentionally left untouched (NSNull sentinel) -> persisted value survives.
+    // options.deviceConsentState intentionally left untouched -> persisted value survives.
 
     [instance startWithOptions:options];
     dispatch_async([MParticle messageQueue], ^{

--- a/UnitTests/ObjCTests/MParticleTests.m
+++ b/UnitTests/ObjCTests/MParticleTests.m
@@ -383,6 +383,92 @@
     [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
 }
 
+- (void)testOptionsDeviceConsentStateApplied {
+    [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
+    MParticle *instance = [MParticle sharedInstance];
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+
+    MPCCPAConsent *ccpaConsent = [[MPCCPAConsent alloc] init];
+    ccpaConsent.consented = YES;
+    ccpaConsent.document = @"device_ccpa_v1";
+    MPConsentState *deviceConsentState = [[MPConsentState alloc] init];
+    [deviceConsentState setCCPAConsentState:ccpaConsent];
+    options.deviceConsentState = deviceConsentState;
+
+    [instance startWithOptions:options];
+    dispatch_async([MParticle messageQueue], ^{
+        MPConsentState *stored = [MPPersistenceController_PRIVATE deviceConsentState];
+        XCTAssertNotNil(stored);
+        XCTAssertTrue(stored.ccpaConsentState.consented);
+        [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+}
+
+- (void)testOptionsDeviceConsentStateUntouchedPreservesPersisted {
+    MPCCPAConsent *ccpaConsent = [[MPCCPAConsent alloc] init];
+    ccpaConsent.consented = YES;
+    ccpaConsent.document = @"device_ccpa_persisted";
+    MPConsentState *persisted = [[MPConsentState alloc] init];
+    [persisted setCCPAConsentState:ccpaConsent];
+    [MPPersistenceController_PRIVATE setDeviceConsentState:persisted];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
+    MParticle *instance = [MParticle sharedInstance];
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+    // options.deviceConsentState intentionally left untouched (NSNull sentinel) -> persisted value survives.
+
+    [instance startWithOptions:options];
+    dispatch_async([MParticle messageQueue], ^{
+        MPConsentState *stored = [MPPersistenceController_PRIVATE deviceConsentState];
+        XCTAssertNotNil(stored);
+        XCTAssertTrue(stored.ccpaConsentState.consented);
+        [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+}
+
+- (void)testOptionsDeviceConsentStateExplicitNilClears {
+    MPCCPAConsent *ccpaConsent = [[MPCCPAConsent alloc] init];
+    ccpaConsent.consented = YES;
+    MPConsentState *persisted = [[MPConsentState alloc] init];
+    [persisted setCCPAConsentState:ccpaConsent];
+    [MPPersistenceController_PRIVATE setDeviceConsentState:persisted];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
+    MParticle *instance = [MParticle sharedInstance];
+    MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+    options.deviceConsentState = nil; // explicit clear
+
+    [instance startWithOptions:options];
+    dispatch_async([MParticle messageQueue], ^{
+        XCTAssertNil([MPPersistenceController_PRIVATE deviceConsentState]);
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:DEFAULT_TIMEOUT handler:nil];
+}
+
+- (void)testDeviceConsentStateSingletonSetterAndClear {
+    MParticle *instance = [MParticle sharedInstance];
+    [MPPersistenceController_PRIVATE setDeviceConsentState:nil];
+
+    MPCCPAConsent *ccpaConsent = [[MPCCPAConsent alloc] init];
+    ccpaConsent.consented = YES;
+    MPConsentState *deviceState = [[MPConsentState alloc] init];
+    [deviceState setCCPAConsentState:ccpaConsent];
+
+    instance.deviceConsentState = deviceState;
+    XCTAssertNotNil(instance.deviceConsentState);
+    XCTAssertTrue(instance.deviceConsentState.ccpaConsentState.consented);
+
+    instance.deviceConsentState = nil;
+    XCTAssertNil(instance.deviceConsentState);
+}
+
 - (void)handleTestSessionStart:(NSNotification *)notification {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:mParticleSessionDidBeginNotification object:nil];
     lastNotification = notification;

--- a/UnitTests/SwiftTests/MParticleOptions+MParticlePrivateTests.swift
+++ b/UnitTests/SwiftTests/MParticleOptions+MParticlePrivateTests.swift
@@ -39,6 +39,8 @@ class MParticleOptionsMParticlePrivateTests: XCTestCase {
         XCTAssertNil(sut.networkOptions)
 
         XCTAssertNil(sut.consentState)
+        XCTAssertNil(sut.deviceConsentState)
+        XCTAssertFalse(sut.isDeviceConsentStateSet)
         XCTAssertNil(sut.dataPlanId)
         XCTAssertNil(sut.dataPlanVersion)
         XCTAssertNil(sut.dataPlanOptions)
@@ -128,6 +130,22 @@ class MParticleOptionsMParticlePrivateTests: XCTestCase {
 
         XCTAssertEqual(sut.sessionTimeout, 1.0)
         XCTAssertTrue(sut.isSessionTimeoutSet)
+    }
+
+    func testSetDeviceConsentState() {
+        XCTAssertNil(sut.deviceConsentState)
+        XCTAssertFalse(sut.isDeviceConsentStateSet)
+
+        let consentState = MPConsentState()
+        sut.setDeviceConsentState(consentState)
+
+        XCTAssertEqual(sut.deviceConsentState, consentState)
+        XCTAssertTrue(sut.isDeviceConsentStateSet)
+
+        sut.setDeviceConsentState(nil)
+
+        XCTAssertNil(sut.deviceConsentState)
+        XCTAssertTrue(sut.isDeviceConsentStateSet)
     }
 
     func testSetConfigMaxAgeSeconds() {

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -461,8 +461,10 @@
         });
     }
     
+    // Device-level consent supersedes user-level, so forward the effective consent to kits.
+    MPConsentState *effectiveConsentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:self.userId];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:@selector(setConsentState:) consentState:state kitHandler:^(id<MPKitProtocol>  _Nonnull kit, MPConsentState * _Nullable filteredConsentState, MPKitConfiguration * _Nonnull kitConfiguration) {
+        [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:@selector(setConsentState:) consentState:effectiveConsentState kitHandler:^(id<MPKitProtocol>  _Nonnull kit, MPConsentState * _Nullable filteredConsentState, MPKitConfiguration * _Nonnull kitConfiguration) {
             MPKitExecStatus *status = [kit setConsentState:filteredConsentState];
             if (!status.success) {
                 MPILogError(@"Failed to set consent state for kit=%@", status.integrationId);

--- a/mParticle-Apple-SDK/Include/MPPersistenceController.h
+++ b/mParticle-Apple-SDK/Include/MPPersistenceController.h
@@ -31,6 +31,9 @@
 + (void)setMpid:(nonnull NSNumber *)mpId;
 + (nullable MPConsentState *)consentStateForMpid:(nonnull NSNumber *)mpid;
 + (void)setConsentState:(nullable MPConsentState *)state forMpid:(nonnull NSNumber *)mpid;
++ (nullable MPConsentState *)deviceConsentState;
++ (void)setDeviceConsentState:(nullable MPConsentState *)state;
++ (nullable MPConsentState *)effectiveConsentStateForMpid:(nullable NSNumber *)mpid;
 + (NSInteger)maxBytesPerEvent:(nullable NSString *)messageType;
 + (NSInteger)maxBytesPerBatch:(nullable NSString *)messageType;
 - (nullable MPSession *)archiveSession:(nonnull MPSession *)session;

--- a/mParticle-Apple-SDK/Include/mParticle.h
+++ b/mParticle-Apple-SDK/Include/mParticle.h
@@ -360,10 +360,20 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
 
 /**
  Consent state.
- 
+
  Allows you to record one or more consent purposes and whether or not the user agreed to each one.
  */
 @property (nonatomic, strong, nullable) MPConsentState *consentState;
+
+/**
+ Device-level consent state.
+
+ When set, this consent state supersedes any user/MPID-level consent everywhere consent is
+ evaluated: kit enablement, consent forwarding to kits, and the consent included in uploads for
+ all MPIDs. It is persisted device-wide (independent of the active user). Set it to `nil` to clear
+ the device-level consent and revert to user/MPID-level consent.
+ */
+@property (nonatomic, strong, nullable) MPConsentState *deviceConsentState;
 
 /**
  Data Plan ID.
@@ -540,6 +550,17 @@ Defaults to false. Prevents the eventsHost above from overwriting the alias endp
  The default value is NO (opt-in of event tracking)
  */
 @property (nonatomic, readwrite) BOOL optOut;
+
+/**
+ Gets/Sets the device-level consent state.
+
+ When set, this consent state supersedes any user/MPID-level consent everywhere consent is
+ evaluated: kit enablement, consent forwarding to kits, and the consent included in uploads for
+ all MPIDs. It is persisted device-wide (independent of the active user). Set it to `nil` to clear
+ the device-level consent and revert to user/MPID-level consent.
+ @see MParticleOptions
+ */
+@property (nonatomic, strong, nullable) MPConsentState *deviceConsentState;
 
 /**
  A flag indicating whether the mParticle Apple SDK is using

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -453,7 +453,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
             NSString *hashString = @(hash).stringValue;
             BOOL consented = item.consented;
             
-            MPConsentState *state = [MParticle sharedInstance].identity.currentUser.consentState;
+            MPConsentState *state = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:[MParticle sharedInstance].identity.currentUser.userId];
             
             if (state != nil) {
                 NSDictionary<NSString *, MPGDPRConsent *> *gdprConsentState = [state.gdprConsentState copy];

--- a/mParticle-Apple-SDK/MPIConstants.h
+++ b/mParticle-Apple-SDK/MPIConstants.h
@@ -147,6 +147,7 @@ extern NSString * _Nonnull const kMPConsentStateHardwareId;
 
 // Consent serialization
 extern NSString * _Nonnull const kMPConsentStateKey;
+extern NSString * _Nonnull const kMPConsentDeviceStateKey;
 extern NSString * _Nonnull const kMPConsentStateGDPRKey;
 extern NSString * _Nonnull const kMPConsentStateConsentedKey;
 extern NSString * _Nonnull const kMPConsentStateDocumentKey;

--- a/mParticle-Apple-SDK/MPIConstants.m
+++ b/mParticle-Apple-SDK/MPIConstants.m
@@ -80,6 +80,7 @@ NSString *const kMPConsentStateHardwareId = @"h";
 
 // Consent serialization
 NSString *const kMPConsentStateKey = @"consent_state";
+NSString *const kMPConsentDeviceStateKey = @"device_consent_state";
 NSString *const kMPConsentStateGDPRKey = @"gdpr";
 NSString *const kMPConsentStateConsentedKey = @"consented";
 NSString *const kMPConsentStateDocumentKey = @"document";

--- a/mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.h
+++ b/mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.h
@@ -7,6 +7,7 @@
 @property (nonatomic, readwrite) BOOL isStartKitsAsyncSet;
 @property (nonatomic, readwrite) BOOL isUploadIntervalSet;
 @property (nonatomic, readwrite) BOOL isSessionTimeoutSet;
+@property (nonatomic, readwrite) BOOL isDeviceConsentStateSet;
 
 + (id)optionsWithKey:(NSString *)apiKey secret:(NSString *)secret;
 
@@ -17,6 +18,7 @@
 - (void)setStartKitsAsync:(BOOL)startKitsAsync;
 - (void)setUploadInterval:(NSTimeInterval)uploadInterval;
 - (void)setSessionTimeout:(NSTimeInterval)sessionTimeout;
+- (void)setDeviceConsentState:(MPConsentState *)deviceConsentState;
 - (void)setConfigMaxAgeSeconds:(NSNumber *)configMaxAgeSeconds;
 - (void)setPersistenceMaxAgeSeconds:(NSNumber *)persistenceMaxAgeSeconds;
 

--- a/mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.m
+++ b/mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.m
@@ -19,8 +19,6 @@
         _logLevel = MPILogLevelNone;
         _uploadInterval = 0.0;
         _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
-        // Sentinel distinguishes "not provided" (NSNull) from an explicit nil that clears device consent.
-        _deviceConsentState = (MPConsentState *)[NSNull null];
     }
     return self;
 }
@@ -65,6 +63,11 @@
 - (void)setSessionTimeout:(NSTimeInterval)sessionTimeout {
     _sessionTimeout = sessionTimeout;
     _isSessionTimeoutSet = YES;
+}
+
+- (void)setDeviceConsentState:(MPConsentState *)deviceConsentState {
+    _deviceConsentState = deviceConsentState;
+    _isDeviceConsentStateSet = YES;
 }
 
 - (void)setConfigMaxAgeSeconds:(NSNumber *)configMaxAgeSeconds {

--- a/mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.m
+++ b/mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.m
@@ -19,6 +19,8 @@
         _logLevel = MPILogLevelNone;
         _uploadInterval = 0.0;
         _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+        // Sentinel distinguishes "not provided" (NSNull) from an explicit nil that clears device consent.
+        _deviceConsentState = (MPConsentState *)[NSNull null];
     }
     return self;
 }

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.m
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.m
@@ -155,6 +155,43 @@ const int MaxBreadcrumbs = 50;
     [userDefaults synchronize];
 }
 
++ (nullable MPConsentState *)deviceConsentState {
+    MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
+    NSString *string = [userDefaults mpObjectForKey:kMPConsentDeviceStateKey userId:@0];
+    if (!string) {
+        return nil;
+    }
+
+    return [MPConsentSerialization consentStateFromString:string];
+}
+
++ (void)setDeviceConsentState:(nullable MPConsentState *)state {
+    MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
+    if (!state) {
+        [userDefaults removeMPObjectForKey:kMPConsentDeviceStateKey userId:@0];
+        [userDefaults synchronize];
+        return;
+    }
+
+    NSString *string = [MPConsentSerialization stringFromConsentState:state];
+    if (!string) {
+        return;
+    }
+    [userDefaults setMPObject:string forKey:kMPConsentDeviceStateKey userId:@0];
+    [userDefaults synchronize];
+}
+
++ (nullable MPConsentState *)effectiveConsentStateForMpid:(nullable NSNumber *)mpid {
+    MPConsentState *deviceConsentState = [self deviceConsentState];
+    if (deviceConsentState != nil) {
+        return deviceConsentState;
+    }
+    if (mpid == nil) {
+        return nil;
+    }
+    return [self consentStateForMpid:mpid];
+}
+
 + (NSInteger)maxBytesPerEvent:(NSString *)messageType {
     return [messageType isEqualToString:kMPMessageTypeStringCrashReport] ? MAX_BYTES_PER_EVENT_CRASH : MAX_BYTES_PER_EVENT;
 }

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
@@ -229,7 +229,7 @@
         _uploadDictionary[MPIntegrationAttributesKey] = integrationAttributesDictionary;
     }
     
-    MPConsentState *consentState = [MPPersistenceController_PRIVATE consentStateForMpid:_uploadDictionary[kMPRemoteConfigMPIDKey]];
+    MPConsentState *consentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:_uploadDictionary[kMPRemoteConfigMPIDKey]];
     if (consentState) {
         NSDictionary *consentStateDictionary = [MPConsentSerialization serverDictionaryFromConsentState:consentState];
         if (consentStateDictionary) {

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -530,9 +530,9 @@ MPLog* logger;
     
     MPConsentState *consentState = self.options.consentState;
 
-    // NSNull means the developer never set deviceConsentState; an explicit value (incl. nil) is applied
-    // through the shared setter so it persists device-wide and supersedes user/MPID-level consent.
-    if ((NSNull *)self.options.deviceConsentState != [NSNull null]) {
+    // When deviceConsentState was explicitly set (including nil to clear), apply through the shared setter
+    // so it persists device-wide and supersedes user/MPID-level consent.
+    if (self.options.isDeviceConsentStateSet) {
         self.deviceConsentState = self.options.deviceConsentState;
     }
 

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -297,6 +297,31 @@ MPLog* logger;
                     }];
 }
 
+- (MPConsentState *)deviceConsentState {
+    return [MPPersistenceController_PRIVATE deviceConsentState];
+}
+
+- (void)setDeviceConsentState:(MPConsentState *)deviceConsentState {
+    [MPPersistenceController_PRIVATE setDeviceConsentState:deviceConsentState];
+
+    NSArray<NSDictionary *> *kitConfig = [self.kitContainer_PRIVATE.originalConfig copy];
+    if (kitConfig) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.kitContainer_PRIVATE configureKits:kitConfig];
+        });
+    }
+
+    MPConsentState *effectiveConsentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:self.identity.currentUser.userId];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.kitContainer_PRIVATE forwardSDKCall:@selector(setConsentState:) consentState:effectiveConsentState kitHandler:^(id<MPKitProtocol>  _Nonnull kit, MPConsentState * _Nullable filteredConsentState, MPKitConfiguration * _Nonnull kitConfiguration) {
+            MPKitExecStatus *status = [kit setConsentState:filteredConsentState];
+            if (!status.success) {
+                MPILogError(@"Failed to set consent state for kit=%@", status.integrationId);
+            }
+        }];
+    });
+}
+
 - (NSTimeInterval)sessionTimeout {
     return self.backendController.sessionTimeout;
 }
@@ -504,7 +529,13 @@ MPLog* logger;
     self.customLogger = options.customLogger;
     
     MPConsentState *consentState = self.options.consentState;
-    
+
+    // NSNull means the developer never set deviceConsentState; an explicit value (incl. nil) is applied
+    // through the shared setter so it persists device-wide and supersedes user/MPID-level consent.
+    if ((NSNull *)self.options.deviceConsentState != [NSNull null]) {
+        self.deviceConsentState = self.options.deviceConsentState;
+    }
+
     [userDefaults setSharedGroupIdentifier:self.options.sharedGroupID];
 
     if (environment == MPEnvironmentDevelopment) {


### PR DESCRIPTION
# Add device-level consent state

## Summary

Adds a **device-level consent state** that, when set, supersedes user/MPID-level consent everywhere consent is evaluated. Previously consent could only be recorded per-user (per-MPID), meaning consent decisions were lost across identity changes and couldn't represent a single device-wide choice. This adds an optional device-scoped consent that takes precedence over per-user consent.

When `deviceConsentState` is set, it overrides user/MPID-level consent for:
- **Kit enablement** — consent-based kit filtering (`isDisabledByConsentKitFilter:`)
- **Consent forwarding to kits** — `setConsentState:` forwarded calls
- **Uploads** — the consent block included in batches, for all MPIDs

It is persisted device-wide (independent of the active user, stored under `userId:@0`) and setting it triggers the same kit refresh as a user consent change. Set it to `nil` to clear and revert to user/MPID-level consent.

## How it works

A new `+effectiveConsentStateForMpid:` on `MPPersistenceController` is the single resolution point: it returns the device consent if present, otherwise falls back to the per-MPID consent. All consent-evaluation call sites now route through it.

`MParticleOptions.deviceConsentState` uses an `NSNull` sentinel internally to distinguish "developer never set it" from "explicitly set to `nil` to clear" — only an explicit value is applied at `startWithOptions:`.

## Sample code

**Set at startup via options:**

```objc
MParticleOptions *options = [MParticleOptions optionsWithKey:@"KEY" secret:@"SECRET"];

MPConsentState *consent = [[MPConsentState alloc] init];
MPGDPRConsent *gdpr = [[MPGDPRConsent alloc] init];
gdpr.consented = YES;
gdpr.document = @"privacy_policy_v3";
[consent addGDPRConsentState:gdpr purpose:@"data_sharing"];

options.deviceConsentState = consent;

[[MParticle sharedInstance] startWithOptions:options];
```

```swift
let options = MParticleOptions(key: "KEY", secret: "SECRET")

let consent = MPConsentState()
let gdpr = MPGDPRConsent()
gdpr.consented = true
gdpr.document = "privacy_policy_v3"
consent.addGDPRConsentState(gdpr, purpose: "data_sharing")

options.deviceConsentState = consent
MParticle.sharedInstance().start(with: options)
```

**Set / update / clear at runtime:**

```swift
// Set device-wide consent (supersedes any per-user consent)
MParticle.sharedInstance().deviceConsentState = consent

// Clear it — reverts to user/MPID-level consent
MParticle.sharedInstance().deviceConsentState = nil
```

## Testing

Added unit tests covering persistence round-trip and clearing (`MPPersistenceControllerTests`), effective-consent precedence in kit enablement (`MPKitContainerTests`), upload consent block (`MPUploadBuilderTests`), and the public API + kit-refresh behavior (`MParticleTests`).
