### PR TITLE
ci: fix build-kits on the updated macOS runner image

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -155,6 +155,6 @@ jobs:
           for xc in *.xcodeproj; do [ -d "$xc" ] && mv "$xc" "${xc}.bak"; done
           trap 'for xc in *.xcodeproj.bak; do [ -d "$xc" ] && mv "$xc" "${xc%.bak}"; done' EXIT
           xcodebuild test -scheme "$SCHEME" \
-            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -destination "platform=iOS Simulator,name=iPhone 17" \
             -derivedDataPath DerivedData-Test \
             CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

--- a/Kits/matrix.json
+++ b/Kits/matrix.json
@@ -79,7 +79,6 @@
   },
   {
     "name": "braze-12",
-    "xcode_version": "16.4",
     "local_path": "Kits/braze/braze-12",
     "podspec": "Kits/braze/braze-12/mParticle-Braze-12.podspec",
     "dest_repo": "mparticle-apple-integration-braze-12",
@@ -98,7 +97,6 @@
   },
   {
     "name": "braze-13",
-    "xcode_version": "16.4",
     "local_path": "Kits/braze/braze-13",
     "podspec": "Kits/braze/braze-13/mParticle-Braze-13.podspec",
     "dest_repo": "mparticle-apple-integration-braze-13",
@@ -117,7 +115,6 @@
   },
   {
     "name": "braze-14",
-    "xcode_version": "16.4",
     "local_path": "Kits/braze/braze-14",
     "podspec": "Kits/braze/braze-14/mParticle-Braze-14.podspec",
     "dest_repo": "mparticle-apple-integration-braze-14",


### PR DESCRIPTION
### Summary
The `build-kits` matrix started failing after the `macOS-latest` runner image rolled forward (Xcode 26.2, dropped Xcode 16.4 and the `iPhone 16` simulator). Two independent breakages, both fixed here:

1. **Simulator gone.** The SPM test step hard-coded `name=iPhone 16`, which the updated image no longer provides → `Unable to find a device matching the provided destination specifier`.
2. **Stale Xcode pin.** `braze-12/13/14` pinned `xcode_version: "16.4"` in `Kits/matrix.json` → `xcode-select: invalid developer directory '/Applications/Xcode_16.4.app'` (non-deterministic, depending on which runner image the leg landed on).

Together these accounted for all 17 failing kit legs (verified: the simulator fix alone took failures 17 → 2).

### Changes
- `.github/workflows/build-kits.yml` — SPM test destination `name=iPhone 16` → `name=iPhone 17` (no OS pin); `iPhone 17` is listed across all installed runtimes (26.2 / 26.4.1 / 26.5).
- `Kits/matrix.json` — drop the `xcode_version: "16.4"` pin from `braze-12/13/14` so they use the `26.2` default like every other kit. The pin is no longer needed: braze-12 (oldest Braze major, v12.1.0) builds locally on Xcode 26.2 for **iOS and tvOS**.

### Not included
Other workflows (`build-and-lint`, `native-tests`, `build-secondary-platforms`, `size-report`, `cross-platform-tests`) and `Scripts/check_coverage.sh` still hard-code `XCODE_VERSION: "16.4"` / `iPhone 16 Pro`. They currently pass (pinned runners still have 16.4) and are the same latent risk, but fixing them is a coordinated Xcode+device bump that needs its own validation — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
