### PR TITLE
feat: Add Workspace Switching Support to Rokt Kit

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -69,7 +69,9 @@ jobs:
           fetch-depth: 0
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Resolve SPM dependencies
         run: |
@@ -154,7 +156,38 @@ jobs:
           fi
           for xc in *.xcodeproj; do [ -d "$xc" ] && mv "$xc" "${xc}.bak"; done
           trap 'for xc in *.xcodeproj.bak; do [ -d "$xc" ] && mv "$xc" "${xc%.bak}"; done' EXIT
-          xcodebuild test -scheme "$SCHEME" \
-            -destination "platform=iOS Simulator,name=iPhone 17" \
-            -derivedDataPath DerivedData-Test \
-            CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+          run_spm_tests() {
+            xcodebuild test -scheme "$SCHEME" \
+              -destination "$1" \
+              -derivedDataPath DerivedData-Test \
+              CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+          }
+
+          DESTINATION="generic/platform=iOS Simulator"
+          set +e
+          run_spm_tests "$DESTINATION"
+          TEST_EXIT=$?
+          set -e
+          if [ "$TEST_EXIT" -eq 0 ]; then
+            exit 0
+          fi
+          if [ "$TEST_EXIT" -ne 70 ]; then
+            echo "::error::SPM tests failed (exit $TEST_EXIT); not retrying with a different simulator"
+            exit "$TEST_EXIT"
+          fi
+
+          echo "generic/platform=iOS Simulator unavailable (exit 70); resolving a concrete iPhone simulator..."
+          AVAILABLE_DEVICES=$(xcrun simctl list devices iPhone available | grep "iPhone" | grep -v "==" || true)
+          DEVICE_NAME=""
+          for device_pattern in "iPhone 17" "iPhone 16" "iPhone 15" "iPhone"; do
+            DEVICE_NAME=$(echo "$AVAILABLE_DEVICES" | grep "$device_pattern" | head -1 | sed 's/^[[:space:]]*//' | sed 's/ (.*//')
+            [ -n "$DEVICE_NAME" ] && break
+          done
+          if [ -z "$DEVICE_NAME" ]; then
+            echo "::error::No suitable iPhone simulator found for SPM tests"
+            exit 1
+          fi
+          echo "Retrying SPM tests on: $DEVICE_NAME"
+          DESTINATION="platform=iOS Simulator,name=${DEVICE_NAME}"
+          run_spm_tests "$DESTINATION"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -374,7 +374,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Wait for core SDK on CocoaPods CDN
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 ##### Added
 
 - Pass through `handleURLCallback:` to `Rokt.handleURLCallback(with:)` on the Rokt SDK.
+- Implement `stop` on `MPKitRokt` so the kit remains active across `switchWorkspaceWithOptions:` without requiring an app restart.
 
 ## [9.2.2] - 2026-06-25
 

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -76,20 +76,23 @@ static __weak MPKitRokt *roktKit = nil;
     
     [MPKitRokt applyMParticleLogLevel];
     
-    // Subscribe to global events to receive RoktInitComplete
-    [Rokt globalEventsOnEvent:^(RoktEvent * _Nonnull event) {
-        if ([event isKindOfClass:[RoktInitComplete class]]) {
-            RoktInitComplete *initComplete = (RoktInitComplete *)event;
-            if (initComplete.success) {
-                [self start];
-                [MPKitRokt MPLog:@"Rokt Init Complete"];
-                NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
-                [[NSNotificationCenter defaultCenter] postNotificationName:@"mParticle.Rokt.Initialized"
-                                                                    object:nil
-                                                                  userInfo:userInfo];
+    static dispatch_once_t globalEventsOnceToken;
+    dispatch_once(&globalEventsOnceToken, ^{
+        [Rokt globalEventsOnEvent:^(RoktEvent * _Nonnull event) {
+            if ([event isKindOfClass:[RoktInitComplete class]]) {
+                RoktInitComplete *initComplete = (RoktInitComplete *)event;
+                MPKitRokt *kit = roktKit;
+                if (initComplete.success && kit) {
+                    [kit start];
+                    [MPKitRokt MPLog:@"Rokt Init Complete"];
+                    NSDictionary *userInfo = @{mParticleKitInstanceKey:[[kit class] kitCode]};
+                    [[NSNotificationCenter defaultCenter] postNotificationName:@"mParticle.Rokt.Initialized"
+                                                                        object:nil
+                                                                      userInfo:userInfo];
+                }
             }
-        }
-    }];
+        }];
+    });
 
     NSURL *customBaseURL = [MParticle sharedInstance].networkOptions.customBaseURL;
     if (customBaseURL) {
@@ -102,19 +105,29 @@ static __weak MPKitRokt *roktKit = nil;
 }
 
 - (void)start {
-    static dispatch_once_t kitPredicate;
+    if (_started) {
+        return;
+    }
 
-    dispatch_once(&kitPredicate, ^{
-        self->_started = YES;
+    _started = YES;
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
 
-            [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeActiveNotification
-                                                                object:nil
-                                                              userInfo:userInfo];
-        });
+        [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeActiveNotification
+                                                            object:nil
+                                                          userInfo:userInfo];
     });
+}
+
+- (void)stop {
+    [MPKitRokt MPLog:@"Stopping Rokt Kit for workspace switch"];
+    [Rokt close];
+    if (roktKit == self) {
+        roktKit = nil;
+    }
+    _started = NO;
+    _configuration = nil;
 }
 
 /// Displays a Rokt ad placement with full configuration options.

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -59,6 +59,8 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 + (void)applyMParticleLogLevel;
 
+- (void)stop;
+
 @end
 
 @interface mParticle_RoktTests : XCTestCase
@@ -108,6 +110,45 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     
     XCTAssertNotNil(status);
     XCTAssertEqual(status.returnCode, MPKitReturnCodeRequirementsNotMet);
+}
+
+- (void)testStopResetsKitState {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    OCMExpect([mockRoktSDK close]);
+
+    [self.kitInstance didFinishLaunchingWithConfiguration:self.configuration];
+    [self.kitInstance start];
+
+    XCTAssertTrue(self.kitInstance.started);
+    XCTAssertNotNil(self.kitInstance.configuration);
+
+    [self.kitInstance stop];
+
+    XCTAssertFalse(self.kitInstance.started);
+    XCTAssertNil(self.kitInstance.configuration);
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testStartCanBeCalledAgainAfterStop {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    OCMStub([mockRoktSDK close]);
+
+    [self.kitInstance didFinishLaunchingWithConfiguration:self.configuration];
+    [self.kitInstance start];
+    XCTAssertTrue(self.kitInstance.started);
+
+    [self.kitInstance stop];
+    XCTAssertFalse(self.kitInstance.started);
+
+    [self.kitInstance start];
+    XCTAssertTrue(self.kitInstance.started);
+
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testKitImplementsStopForWorkspaceSwitching {
+    XCTAssertTrue([self.kitInstance respondsToSelector:@selector(stop)]);
 }
 
 - (void)testConfirmEmbeddedViews_ValidEmbeddedViews {


### PR DESCRIPTION
## Background
- mParticle supports runtime workspace switching via switchWorkspaceWithOptions:, which resets SDK state and re-initializes with a new API key/secret.
- Kits that were active in the previous workspace must implement the optional stop lifecycle method; otherwise the SDK removes them from the kit registry and they stop receiving events until the app is restarted.
- MPKitRokt did not implement stop, so the Rokt kit was deactivated after a workspace switch when it had been configured in the prior workspace. That broke MPRokt APIs such as selectPlacements, selectShoppableAds, and handleURLCallback until a full app restart.
- The kit also used dispatch_once in start, which prevented _started from being set again on a new kit instance after a switch, and registered a new globalEvents handler on every launch, which could route init callbacks to a stale instance.

## What Has Changed
- Added stop to MPKitRokt to support workspace switching: closes active Rokt placements via [Rokt close], clears the weak roktKit reference, and resets _started and _configuration.
- Refactored start to remove dispatch_once so the kit can be marked active again after a workspace switch.
- Consolidated RoktInitComplete handling into a single globalEvents subscription that forwards to the current roktKit instance.
- Added unit tests covering stop behavior, re-start after stop, and respondsToSelector:@selector(stop).
- Updated CHANGELOG.md under the Rokt kit section to document workspace switching support.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
