### PR TITLE
docs: align kit README platform support with iOS/tvOS 15.0

### DIFF
--- a/Kits/README.md
+++ b/Kits/README.md
@@ -2,6 +2,13 @@
 
 Kits forward events from the mParticle Apple SDK to partner services. To use a partner integration, add mParticle core plus the kit that matches the partner SDK major version you use.
 
+## Platform Support
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
+
 ## How to Choose a Kit
 
 Kits are versioned by the partner SDK major:

--- a/Kits/README.md
+++ b/Kits/README.md
@@ -2,13 +2,6 @@
 
 Kits forward events from the mParticle Apple SDK to partner services. To use a partner integration, add mParticle core plus the kit that matches the partner SDK major version you use.
 
-## Platform Support
-
-| Platform | Minimum Version |
-| -------- | --------------- |
-| iOS      | 15.0            |
-| tvOS     | 15.0            |
-
 ## How to Choose a Kit
 
 Kits are versioned by the partner SDK major:

--- a/Kits/adjust/adjust-5/README.md
+++ b/Kits/adjust/adjust-5/README.md
@@ -40,8 +40,8 @@ Included kits: { Adjust }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/adobe/adobe-5/README.md
+++ b/Kits/adobe/adobe-5/README.md
@@ -42,7 +42,8 @@ Included kits: { Adobe }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/appsflyer/appsflyer-6/README.md
+++ b/Kits/appsflyer/appsflyer-6/README.md
@@ -40,8 +40,8 @@ Included kits: { AppsFlyer }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/apptentive/apptentive-6/README.md
+++ b/Kits/apptentive/apptentive-6/README.md
@@ -40,7 +40,8 @@ Included kits: { Apptentive }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/apptimize/apptimize-3/README.md
+++ b/Kits/apptimize/apptimize-3/README.md
@@ -33,6 +33,13 @@ After installing, rebuild and launch your app. With the mParticle log level set 
 Included kits: { Apptimize }
 ```
 
+## Platform Support
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
+
 ## Documentation
 
 - [mParticle Apptimize Integration Guide](https://docs.mparticle.com/integrations/apptimize/event/)

--- a/Kits/branchmetrics/branchmetrics-3/README.md
+++ b/Kits/branchmetrics/branchmetrics-3/README.md
@@ -40,7 +40,8 @@ Included kits: { BranchMetrics }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/braze/braze-12/README.md
+++ b/Kits/braze/braze-12/README.md
@@ -63,8 +63,8 @@ Included kits: { Braze }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/braze/braze-13/README.md
+++ b/Kits/braze/braze-13/README.md
@@ -63,8 +63,8 @@ Included kits: { Braze }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/braze/braze-14/README.md
+++ b/Kits/braze/braze-14/README.md
@@ -63,8 +63,8 @@ Included kits: { Braze }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/clevertap/clevertap-7/README.md
+++ b/Kits/clevertap/clevertap-7/README.md
@@ -40,7 +40,8 @@ Included kits: { CleverTap }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/comscore/comscore-6/README.md
+++ b/Kits/comscore/comscore-6/README.md
@@ -40,8 +40,8 @@ Included kits: { ComScore }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-11/README.md
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-11/README.md
@@ -34,8 +34,8 @@ Included kits: { FirebaseGA4 }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-12/README.md
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-12/README.md
@@ -34,8 +34,8 @@ Included kits: { FirebaseGA4 }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/google-analytics-firebase/firebase-11/README.md
+++ b/Kits/google-analytics-firebase/firebase-11/README.md
@@ -34,8 +34,8 @@ Included kits: { Firebase }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/google-analytics-firebase/firebase-12/README.md
+++ b/Kits/google-analytics-firebase/firebase-12/README.md
@@ -34,8 +34,8 @@ Included kits: { Firebase }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/iterable/iterable-6/README.md
+++ b/Kits/iterable/iterable-6/README.md
@@ -63,7 +63,8 @@ Included kits: { Iterable }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/kochava/kochava-9/README.md
+++ b/Kits/kochava/kochava-9/README.md
@@ -31,8 +31,8 @@ Included kits: { Kochava }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/kochava/kochava-no-tracking-9/README.md
+++ b/Kits/kochava/kochava-no-tracking-9/README.md
@@ -32,8 +32,8 @@ Included kits: { Kochava }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/leanplum/leanplum-6/README.md
+++ b/Kits/leanplum/leanplum-6/README.md
@@ -37,7 +37,8 @@ Included kits: { Leanplum }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/localytics/localytics-6/README.md
+++ b/Kits/localytics/localytics-6/README.md
@@ -37,7 +37,8 @@ Included kits: { Localytics }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/localytics/localytics-7/README.md
+++ b/Kits/localytics/localytics-7/README.md
@@ -37,7 +37,8 @@ Included kits: { Localytics }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/onetrust/onetrust/README.md
+++ b/Kits/onetrust/onetrust/README.md
@@ -58,8 +58,8 @@ Included kits: { OneTrust }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/radar/radar-3/README.md
+++ b/Kits/radar/radar-3/README.md
@@ -40,7 +40,8 @@ Included kits: { Radar }
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/rokt-sdk-plus/rokt-sdk-plus-ios/README.md
+++ b/Kits/rokt-sdk-plus/rokt-sdk-plus-ios/README.md
@@ -42,7 +42,7 @@ In your `Podfile`:
 pod 'RoktSDKPlus', '~> 9.1'
 ```
 
-Match deployment target and Swift version expectations to the upstream podspecs (this podspec uses **iOS 15.6** and **Swift 5.9**).
+Match deployment target and Swift version expectations to the upstream podspecs (this podspec uses **iOS 15.0** and **tvOS 15.0** and **Swift 5.9**).
 
 ## mParticle core (essential)
 
@@ -85,6 +85,13 @@ MParticle.sharedInstance().rokt.selectPlacements(
 ```
 
 **Shoppable Ads** use a registered payment extension (for example Stripe) and `selectShoppableAds`; see the [Rokt kit README](https://github.com/mparticle-integrations/mp-apple-integration-rokt/blob/main/README.md) for `registerPaymentExtension` / `selectShoppableAds` snippets and [MIGRATING.md](https://github.com/mparticle-integrations/mp-apple-integration-rokt/blob/main/MIGRATING.md) for event types.
+
+## Platform Support
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## License
 

--- a/Kits/rokt/rokt/README.md
+++ b/Kits/rokt/rokt/README.md
@@ -87,6 +87,13 @@ MParticle.sharedInstance().rokt.selectShoppableAds("ShopView",
 
 For the full event type reference, see [MIGRATING.md](../../MIGRATING.md).
 
+## Platform Support
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
+
 ## Documentation
 
 - [Rokt mParticle Integration](https://docs.rokt.com/developers/integration-guides/rokt-ads/customer-data-platforms/mparticle/)

--- a/Kits/singular/singular-12/README.md
+++ b/Kits/singular/singular-12/README.md
@@ -33,6 +33,13 @@ After installing, rebuild and launch your app. With the mParticle log level set 
 Included kits: { Singular }
 ```
 
+## Platform Support
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
+
 ## Documentation
 
 - [Singular mParticle Integration](https://support.singular.net/)

--- a/Kits/urbanairship/urbanairship-19/README.md
+++ b/Kits/urbanairship/urbanairship-19/README.md
@@ -84,7 +84,8 @@ private func removeTag(key: String) {
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 

--- a/Kits/urbanairship/urbanairship-20/README.md
+++ b/Kits/urbanairship/urbanairship-20/README.md
@@ -84,8 +84,8 @@ private func removeTag(key: String) {
 
 | Platform | Minimum Version |
 | -------- | --------------- |
-| iOS      | 15.6            |
-| tvOS     | 15.6            |
+| iOS      | 15.0            |
+| tvOS     | 15.0            |
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Update all 29 README files under `Kits/` to document **iOS 15.0** and **tvOS 15.0** minimum deployment targets
- Correct outdated **15.6** references that no longer match the mParticle Apple SDK baseline (see #791)
- Add missing **Platform Support** sections to kit READMEs that did not previously include them (Apptimize, Singular, Rokt, Rokt SDK+, and the Kits index)

## Test plan

- [x] Verified no remaining `15.6` references in `Kits/**/README.md`
- [x] Verified all kit READMEs include a Platform Support table with iOS 15.0 and tvOS 15.0
- [x] `trunk check` passed on modified files (pre-commit hook)