### PR TITLE
feat: Add tvOS Support to Adobe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 #### Added
 
+- **Adobe 5** — Add tvOS 15.0+ support for CocoaPods and Swift Package Manager.
 - **Braze 16** — Add `braze-16` kit track for [Braze Swift SDK 16.x](https://github.com/braze-inc/braze-swift-sdk/releases).
 - **Braze 16** — When `useEcommerceRecommendedEvents` is enabled in kit configuration, forward supported mParticle commerce events to Braze recommended eCommerce events (`ecommerce.cart_updated`, `ecommerce.checkout_started`, `ecommerce.product_viewed`, `ecommerce.order_placed`, `ecommerce.order_refunded`).
 - **Rokt SDK+ (`RoktSDKPlus`)** — Umbrella Swift package and CocoaPods pod at `Kits/rokt-sdk-plus/rokt-sdk-plus-ios`, versioned with the core SDK and mirrored to [ROKT/rokt-sdk-plus-ios](https://github.com/ROKT/rokt-sdk-plus-ios).

--- a/Kits/adobe/adobe-5/Package.swift
+++ b/Kits/adobe/adobe-5/Package.swift
@@ -20,7 +20,7 @@ let mParticleAppleSDK: Package.Dependency = {
 
 let package = Package(
     name: "mParticle-Adobe",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v15), .tvOS(.v15)],
     products: [
         .library(
             name: "mParticle-Adobe",

--- a/Kits/adobe/adobe-5/mParticle-Adobe.xcodeproj/project.pbxproj
+++ b/Kits/adobe/adobe-5/mParticle-Adobe.xcodeproj/project.pbxproj
@@ -14,6 +14,13 @@
 		A40010005F50000000000005 /* mParticle_Adobe.h in Headers */ = {isa = PBXBuildFile; fileRef = A40020005F50000000000005 /* mParticle_Adobe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A40010006F50000000000006 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A40020006F50000000000006 /* PrivacyInfo.xcprivacy */; };
 		A40010007F50000000000007 /* mParticle-Apple-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = A40030001F50000000000001 /* mParticle-Apple-SDK */; };
+		A40010008F50000000000008 /* MPKitAdobe.m in Sources */ = {isa = PBXBuildFile; fileRef = A40020001F50000000000001 /* MPKitAdobe.m */; };
+		A40010009F50000000000009 /* MPIAdobe.m in Sources */ = {isa = PBXBuildFile; fileRef = A40020002F50000000000002 /* MPIAdobe.m */; };
+		A40010010F50000000000010 /* MPKitAdobe.h in Headers */ = {isa = PBXBuildFile; fileRef = A40020003F50000000000003 /* MPKitAdobe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A40010011F50000000000011 /* MPIAdobe.h in Headers */ = {isa = PBXBuildFile; fileRef = A40020004F50000000000004 /* MPIAdobe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A40010012F50000000000012 /* mParticle_Adobe.h in Headers */ = {isa = PBXBuildFile; fileRef = A40020005F50000000000005 /* mParticle_Adobe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A40010013F50000000000013 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A40020006F50000000000006 /* PrivacyInfo.xcprivacy */; };
+		A40010014F50000000000014 /* mParticle-Apple-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = A40030001F50000000000001 /* mParticle-Apple-SDK */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +32,7 @@
 		A40020006F50000000000006 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A40020007F50000000000007 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A40020008F50000000000008 /* mParticle_Adobe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Adobe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A40020009F50000000000009 /* mParticle_Adobe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Adobe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -33,6 +41,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				A40010007F50000000000007 /* mParticle-Apple-SDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A40040005F50000000000005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A40010014F50000000000014 /* mParticle-Apple-SDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -81,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				A40020008F50000000000008 /* mParticle_Adobe.framework */,
+				A40020009F50000000000009 /* mParticle_Adobe.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -95,6 +112,16 @@
 				A40010003F50000000000003 /* MPKitAdobe.h in Headers */,
 				A40010004F50000000000004 /* MPIAdobe.h in Headers */,
 				A40010005F50000000000005 /* mParticle_Adobe.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A40040006F50000000000006 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A40010010F50000000000010 /* MPKitAdobe.h in Headers */,
+				A40010011F50000000000011 /* MPIAdobe.h in Headers */,
+				A40010012F50000000000012 /* mParticle_Adobe.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,6 +149,27 @@
 			productReference = A40020008F50000000000008 /* mParticle_Adobe.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		A40060002F50000000000002 /* mParticle-Adobe-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A40070003F50000000000003 /* Build configuration list for PBXNativeTarget "mParticle-Adobe-tvOS" */;
+			buildPhases = (
+				A40040007F50000000000007 /* Sources */,
+				A40040005F50000000000005 /* Frameworks */,
+				A40040006F50000000000006 /* Headers */,
+				A40040008F50000000000008 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "mParticle-Adobe-tvOS";
+			packageProductDependencies = (
+				A40030001F50000000000001 /* mParticle-Apple-SDK */,
+			);
+			productName = "mParticle-Adobe-tvOS";
+			productReference = A40020009F50000000000009 /* mParticle_Adobe.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -130,6 +178,14 @@
 			attributes = {
 				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = mParticle;
+				TargetAttributes = {
+					A40060001F50000000000001 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					A40060002F50000000000002 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
 			};
 			buildConfigurationList = A40090001F50000000000002 /* Build configuration list for PBXProject "mParticle-Adobe" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -146,7 +202,10 @@
 			productRefGroup = A40050005F50000000000005 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-			targets = (A40060001F50000000000001 /* mParticle-Adobe */);
+			targets = (
+				A40060001F50000000000001 /* mParticle-Adobe */,
+				A40060002F50000000000002 /* mParticle-Adobe-tvOS */,
+			);
 		};
 /* End PBXProject section */
 
@@ -155,6 +214,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (A40010006F50000000000006 /* PrivacyInfo.xcprivacy in Resources */);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A40040008F50000000000008 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (A40010013F50000000000013 /* PrivacyInfo.xcprivacy in Resources */);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
@@ -166,6 +231,15 @@
 			files = (
 				A40010001F50000000000001 /* MPKitAdobe.m in Sources */,
 				A40010002F50000000000002 /* MPIAdobe.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A40040007F50000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A40010008F50000000000008 /* MPKitAdobe.m in Sources */,
+				A40010009F50000000000009 /* MPIAdobe.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -204,6 +278,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/mParticle-Adobe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Adobe";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
@@ -216,9 +291,41 @@
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/mParticle-Adobe/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Adobe";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
+			};
+			name = Release;
+		};
+		A400B005F50000000000005 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/mParticle-Adobe/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Adobe-tvOS";
+				PRODUCT_NAME = mParticle_Adobe;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = NO;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
+		A400B006F50000000000006 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources/mParticle-Adobe/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Adobe-tvOS";
+				PRODUCT_NAME = mParticle_Adobe;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = NO;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -234,6 +341,12 @@
 		A40070002F50000000000002 /* Build configuration list for PBXNativeTarget "mParticle-Adobe" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (A400B003F50000000000003 /* Debug */, A400B004F50000000000004 /* Release */);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A40070003F50000000000003 /* Build configuration list for PBXNativeTarget "mParticle-Adobe-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (A400B005F50000000000005 /* Debug */, A400B006F50000000000006 /* Release */);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};

--- a/Kits/adobe/adobe-5/mParticle-Adobe.xcodeproj/xcshareddata/xcschemes/mParticle-Adobe-tvOS.xcscheme
+++ b/Kits/adobe/adobe-5/mParticle-Adobe.xcodeproj/xcshareddata/xcschemes/mParticle-Adobe-tvOS.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A40060002F50000000000002"
+               BuildableName = "mParticle_Adobe.framework"
+               BlueprintName = "mParticle-Adobe-tvOS"
+               ReferencedContainer = "container:mParticle-Adobe.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Background
- The Adobe 5 kit (Kits/adobe/adobe-5/) documents tvOS 15.0+ support and the CocoaPods podspec already declares a tvOS deployment target, but Swift Package Manager clients could not actually use the kit on tvOS. Package.swift only declared iOS, which caused SPM resolution/build failures when paired with mParticle-Apple-SDK (tvOS 15.0+). The Xcode project was also iOS-only—no tvOS target or scheme—so tvOS builds could not be validated locally the way other kits (e.g. ComScore, Braze) do.

## What Has Changed
- Added .tvOS(.v15) to Package.swift so SPM clients can resolve and build mParticle-Adobe on tvOS alongside the core SDK.
- Added a mParticle-Adobe-tvOS native target to mParticle-Adobe.xcodeproj, reusing the existing kit sources with tvOS build settings (SDKROOT = appletvos, TVOS_DEPLOYMENT_TARGET = 15.0).
- Added a shared mParticle-Adobe-tvOS Xcode scheme for local tvOS development and CI-style validation.
- Added a changelog entry under [Unreleased] noting tvOS 15.0+ support for CocoaPods and Swift Package Manager.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
