### PR TITLE
chore(rokt): bump Rokt SDK dependency to 5.3.0 (SPM + CocoaPods)

### DIFF
--- a/Kits/rokt/rokt/Package.swift
+++ b/Kits/rokt/rokt/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         mParticleAppleSDK,
         .package(
             url: "https://github.com/ROKT/rokt-sdk-ios",
-            .upToNextMajor(from: "5.2.1")
+            .upToNextMajor(from: "5.3.0")
         ),
         .package(
             url: "https://github.com/ROKT/rokt-contracts-apple.git",

--- a/Kits/rokt/rokt/mParticle-Rokt.podspec
+++ b/Kits/rokt/rokt/mParticle-Rokt.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
     s.ios.resource_bundles  = { 'mParticle-Rokt-Privacy' => ['Sources/mParticle-Rokt/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK', '~> 9.1'
     s.ios.dependency 'RoktContracts', '~> 2.0'
-    s.ios.dependency 'Rokt-Widget', '~> 5.2'
+    s.ios.dependency 'Rokt-Widget', '~> 5.3'
 end


### PR DESCRIPTION
- Updates the Rokt Widget (Rokt SDK) dependency for the mParticle Rokt kit to 5.3.0.
- SPM (Kits/rokt/rokt/Package.swift): rokt-sdk-ios `.upToNextMajor(from: "5.2.1")` → `.upToNextMajor(from: "5.3.0")`.
- CocoaPods (Kits/rokt/rokt/mParticle-Rokt.podspec): `Rokt-Widget '~> 5.2'` → `'~> 5.3'`.
- Depends on Rokt iOS SDK 5.3.0 being published (SPM tag + CocoaPods trunk) before CI can resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)