### PR TITLE
chore: exclude braze-16 kit from mirror/release matrix

### DIFF
--- a/Kits/matrix.json
+++ b/Kits/matrix.json
@@ -132,24 +132,6 @@
     ]
   },
   {
-    "name": "braze-16",
-    "local_path": "Kits/braze/braze-16",
-    "podspec": "Kits/braze/braze-16/mParticle-Braze-16.podspec",
-    "dest_repo": "mparticle-apple-integration-braze-16",
-    "schemes": [
-      {
-        "scheme": "mParticle-Braze",
-        "module": "mParticle_Braze",
-        "destination": "iOS"
-      },
-      {
-        "scheme": "mParticle-Braze-tvOS",
-        "module": "mParticle_Braze",
-        "destination": "tvOS"
-      }
-    ]
-  },
-  {
     "name": "clevertap-7",
     "local_path": "Kits/clevertap/clevertap-7",
     "podspec": "Kits/clevertap/clevertap-7/mParticle-CleverTap-7.podspec",


### PR DESCRIPTION
## Background
[#793](https://github.com/mParticle/mparticle-apple-sdk/pull/793) added the `braze-16` kit and registered it in `Kits/matrix.json`. We do **not** want those changes released to the mirror yet — i.e. braze-16 should not be pushed to `mparticle-integrations/mparticle-apple-integration-braze-16` or published to CocoaPods / SPM.

## What Has Changed
- Removed the `braze-16` entry from `Kits/matrix.json`.

`release-publish.yml`'s `mirror-and-release-kits` job (and `build-kits.yml` / `release-draft.yml`) build the release matrix directly from `Kits/matrix.json` via `jq`, with no per-kit enable/skip filter. Dropping the entry excludes braze-16 from the subtree split + mirror push + tag/release, so it will not appear on CocoaPods or SPM.

> Note: `matrix.json` is parsed as strict JSON (`jq -c . Kits/matrix.json`), so it cannot hold inline comments — adding `//` would break parsing for every kit. Removing the entry is the safe, revertable equivalent of "commenting it out".

## Not changed
- The braze-16 kit **source** (`Kits/braze/braze-16/`) is retained in the repo. Re-enabling release is a one-line revert (re-add the matrix entry).
- No other kits affected (29 remaining entries unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)