### PR TITLE
fix: Update Binary Framework Generation to Dynamic for Appsflyer Kit

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -151,6 +151,14 @@ jobs:
 
           mkdir -p archives xcframeworks
 
+          # Kits with dynamic_xcframework link partner SDKs at runtime instead of
+          # absorbing static SPM products into the kit binary.
+          if echo '${{ toJson(matrix.kit.dynamic_xcframework) }}' | jq -e . >/dev/null 2>&1; then
+            chmod +x ./Scripts/build_kit_xcframework.sh
+            OUTPUT_DIR="$PWD/xcframeworks" ./Scripts/build_kit_xcframework.sh "${{ matrix.kit.name }}"
+            exit 0
+          fi
+
           SKIP_XCF="${{ matrix.kit.skip_xcframework }}"
           if [ "$SKIP_XCF" = "true" ]; then
             MODULE=$(echo "$SCHEMES_JSON" | jq -r '.[0].module')

--- a/Kits/appsflyer/appsflyer-6/README.md
+++ b/Kits/appsflyer/appsflyer-6/README.md
@@ -28,6 +28,20 @@ Add the kit dependency to your app's Podfile:
 pod 'mParticle-AppsFlyer-6', '~> 9.0'
 ```
 
+### Prebuilt xcframework
+
+Each release attaches `mParticle_AppsFlyer.xcframework.zip`. The kit links its dependencies dynamically, so embed all three frameworks in your app target:
+
+| Framework                         | Source                                                                                                                                 |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `mParticle_AppsFlyer.xcframework` | This repository's releases                                                                                                             |
+| `mParticle_Apple_SDK.xcframework` | [mparticle-apple-sdk releases](https://github.com/mParticle/mparticle-apple-sdk/releases), matching version                            |
+| `AppsFlyerLib.xcframework`        | `AppsFlyerLib-Dynamic.xcframework.zip` from [AppsFlyerFramework releases](https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases) |
+
+Set all three to **Embed & Sign**. Use the dynamic `AppsFlyerLib-Dynamic.xcframework.zip` rather than the static build; the static variant does not provide the dynamic library the kit loads at runtime.
+
+Prefer Swift Package Manager or CocoaPods unless your build requires prebuilt binaries — those integrations resolve these dependencies for you.
+
 ## Verifying the Integration
 
 After installing, rebuild and launch your app. With the mParticle log level set to Debug or higher, you should see the following in your Xcode console:

--- a/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer.xcodeproj/project.pbxproj
+++ b/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		58F939FA48A08B9D29822BDF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3FD23FABD83AEB8A58E427C6 /* PrivacyInfo.xcprivacy */; };
 		32611EB3492425C687D8F69C /* mParticle-Apple-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8625D1443F52E7A698A680A8 /* mParticle-Apple-SDK */; };
 		87C4E16CCDAD49D90C643460 /* AppsFlyerLib-Static in Frameworks */ = {isa = PBXBuildFile; productRef = 6634F5559F44CCAFA10F5747 /* AppsFlyerLib-Static */; };
+		78473C7B513E4351A7578761 /* MPKitAppsFlyer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BDAB6ACE0557CED9BE8FA64 /* MPKitAppsFlyer.m */; };
+		9A8BE0A3C3B7489291AEA10C /* MPKitAppsFlyer.h in Headers */ = {isa = PBXBuildFile; fileRef = D332A9834DC984DB4FD934C6 /* MPKitAppsFlyer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D24E5D7B12C84EA5BFEC06B6 /* mParticle_AppsFlyer.h in Headers */ = {isa = PBXBuildFile; fileRef = 40D0122E117E63949D3A1019 /* mParticle_AppsFlyer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7E139C8F55D4595B9C9CD43 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3FD23FABD83AEB8A58E427C6 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +26,7 @@
 		3FD23FABD83AEB8A58E427C6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		4A731C6E443066D2D5A02B67 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D3BFFD6271B0312661864F2D /* mParticle_AppsFlyer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_AppsFlyer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0FED57E4AC724DAAB618031C /* mParticle_AppsFlyer.framework (Dynamic) */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_AppsFlyer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				D3BFFD6271B0312661864F2D /* mParticle_AppsFlyer.framework */,
+				0FED57E4AC724DAAB618031C /* mParticle_AppsFlyer.framework (Dynamic) */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -90,6 +96,15 @@
 			files = (
 				0A859A3F5E4C5C1D8752AAC2 /* MPKitAppsFlyer.h in Headers */,
 				8CA05B821916C4FFC15062C8 /* mParticle_AppsFlyer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1720ABD9D73A466592CD5DB6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A8BE0A3C3B7489291AEA10C /* MPKitAppsFlyer.h in Headers */,
+				D24E5D7B12C84EA5BFEC06B6 /* mParticle_AppsFlyer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,6 +131,25 @@
 			);
 			productName = "mParticle-AppsFlyer";
 			productReference = D3BFFD6271B0312661864F2D /* mParticle_AppsFlyer.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8A0E4DED3B5F47A1B9AF76DF /* mParticle-AppsFlyer-Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 397B0FFC31F74E739E601A8B /* Build configuration list for PBXNativeTarget "mParticle-AppsFlyer-Dynamic" */;
+			buildPhases = (
+				029A39FC8F6742C0B785D34C /* Sources */,
+				1720ABD9D73A466592CD5DB6 /* Headers */,
+				76AD581017A64FB3B78F293C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "mParticle-AppsFlyer-Dynamic";
+			packageProductDependencies = (
+			);
+			productName = "mParticle-AppsFlyer";
+			productReference = 0FED57E4AC724DAAB618031C /* mParticle_AppsFlyer.framework (Dynamic) */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -150,6 +184,7 @@
 			projectRoot = "";
 			targets = (
 				AECD3EA4B54953C844B5BC75 /* mParticle-AppsFlyer */,
+				8A0E4DED3B5F47A1B9AF76DF /* mParticle-AppsFlyer-Dynamic */,
 			);
 		};
 /* End PBXProject section */
@@ -163,6 +198,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		76AD581017A64FB3B78F293C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7E139C8F55D4595B9C9CD43 /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -171,6 +214,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				890E16DE853441BF79AB1314 /* MPKitAppsFlyer.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		029A39FC8F6742C0B785D34C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78473C7B513E4351A7578761 /* MPKitAppsFlyer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,6 +378,72 @@
 			};
 			name = Release;
 		};
+		76D0AB0E8753423D9038089C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(MPARTICLE_DEPENDENCY_FRAMEWORK_PATHS)",
+				);
+				INFOPLIST_FILE = Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					mParticle_Apple_SDK,
+					"-framework",
+					AppsFlyerLib,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-AppsFlyer";
+				PRODUCT_NAME = mParticle_AppsFlyer;
+				SKIP_INSTALL = NO;
+			};
+			name = Debug;
+		};
+		38C2D6F5CFB24EC3BE67A2B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(MPARTICLE_DEPENDENCY_FRAMEWORK_PATHS)",
+				);
+				INFOPLIST_FILE = Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					mParticle_Apple_SDK,
+					"-framework",
+					AppsFlyerLib,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-AppsFlyer";
+				PRODUCT_NAME = mParticle_AppsFlyer;
+				SKIP_INSTALL = NO;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -344,6 +461,15 @@
 			buildConfigurations = (
 				0B877BB7B096E20BEC4E2C71 /* Debug */,
 				080C267847E0F0E2EBD2B737 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		397B0FFC31F74E739E601A8B /* Build configuration list for PBXNativeTarget "mParticle-AppsFlyer-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				76D0AB0E8753423D9038089C /* Debug */,
+				38C2D6F5CFB24EC3BE67A2B4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer.xcodeproj/xcshareddata/xcschemes/mParticle-AppsFlyer-Dynamic.xcscheme
+++ b/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer.xcodeproj/xcshareddata/xcschemes/mParticle-AppsFlyer-Dynamic.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8A0E4DED3B5F47A1B9AF76DF"
+               BuildableName = "mParticle_AppsFlyer.framework"
+               BlueprintName = "mParticle-AppsFlyer-Dynamic"
+               ReferencedContainer = "container:mParticle-AppsFlyer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Kits/matrix.json
+++ b/Kits/matrix.json
@@ -30,6 +30,17 @@
     "local_path": "Kits/appsflyer/appsflyer-6",
     "podspec": "Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer-6.podspec",
     "dest_repo": "mparticle-apple-integration-appsflyer-6",
+    "dynamic_xcframework": {
+      "scheme": "mParticle-AppsFlyer-Dynamic",
+      "module": "mParticle_AppsFlyer",
+      "dependencies": [
+        {
+          "framework": "AppsFlyerLib",
+          "package_identity": "appsflyerframework",
+          "url": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/{version}/AppsFlyerLib-Dynamic.xcframework.zip"
+        }
+      ]
+    },
     "schemes": [
       {
         "scheme": "mParticle-AppsFlyer",

--- a/Scripts/build_kit_xcframework.sh
+++ b/Scripts/build_kit_xcframework.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+#
+# build_kit_xcframework.sh
+#
+# Builds a distributable kit xcframework that links its dependencies dynamically.
+#
+# Kits that archive the SPM scheme absorb static partner SDKs (and the core SDK)
+# into the kit binary. An app that also links those frameworks then gets two
+# copies of every class and crashes at launch. This script archives a Dynamic
+# scheme that links those frameworks at runtime instead.
+#
+# Kit configuration lives in Kits/matrix.json under `dynamic_xcframework`:
+#
+#   "dynamic_xcframework": {
+#     "scheme": "mParticle-AppsFlyer-Dynamic",
+#     "module": "mParticle_AppsFlyer",
+#     "dependencies": [
+#       {
+#         "framework": "AppsFlyerLib",
+#         "package_identity": "appsflyerframework",
+#         "url": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/{version}/AppsFlyerLib-Dynamic.xcframework.zip"
+#       }
+#     ]
+#   }
+#
+# `{version}` in `url` is replaced with the version pinned in the kit project's
+# Package.resolved (matched by `package_identity`), so the binary links the same
+# partner release SwiftPM resolves. Package.resolved is gitignored, so the script
+# runs `xcodebuild -resolvePackageDependencies` to produce it when missing.
+# Set `version` on a dependency to pin an exact release and skip resolution.
+#
+# Usage:
+#   Scripts/build_kit_xcframework.sh <kit-name>
+#
+# Environment:
+#   OUTPUT_DIR          Where the .xcframework and .zip are written (default: xcframeworks)
+#   CORE_XCFRAMEWORK    Prebuilt mParticle_Apple_SDK.xcframework; built from source when unset
+#   MATRIX_JSON         Path to Kits/matrix.json (default: Kits/matrix.json)
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CORE_MODULE="mParticle_Apple_SDK"
+MATRIX_JSON="${MATRIX_JSON:-${ROOT}/Kits/matrix.json}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT}/xcframeworks}"
+
+BUILD_SETTINGS=(
+	CODE_SIGN_IDENTITY=""
+	CODE_SIGNING_REQUIRED=NO
+	CODE_SIGNING_ALLOWED=NO
+	SKIP_INSTALL=NO
+	BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+)
+
+if [[ $# -lt 1 ]]; then
+	echo "usage: $(basename "$0") <kit-name>" >&2
+	exit 2
+fi
+
+KIT_NAME="$1"
+BUILD_DIR="${ROOT}/build/kit-xcframework/${KIT_NAME}"
+ARCHIVE_DIR="${BUILD_DIR}/archives"
+CONFIG_JSON="${BUILD_DIR}/config.json"
+
+load_kit_config() {
+	mkdir -p "${BUILD_DIR}"
+	python3 - "${MATRIX_JSON}" "${KIT_NAME}" "${CONFIG_JSON}" <<'PY'
+import json, sys
+
+matrix_path, kit_name, out_path = sys.argv[1:]
+matrix = json.load(open(matrix_path))
+kit = next((entry for entry in matrix if entry.get("name") == kit_name), None)
+if kit is None:
+    raise SystemExit(f"::error::Kit '{kit_name}' not found in {matrix_path}")
+
+config = kit.get("dynamic_xcframework")
+if not config:
+    raise SystemExit(
+        f"::error::Kit '{kit_name}' is missing dynamic_xcframework in {matrix_path}"
+    )
+
+for required in ("scheme", "module"):
+    if required not in config:
+        raise SystemExit(
+            f"::error::Kit '{kit_name}' dynamic_xcframework is missing '{required}'"
+        )
+
+payload = {
+    "name": kit_name,
+    "local_path": kit["local_path"],
+    "scheme": config["scheme"],
+    "module": config["module"],
+    "dependencies": config.get("dependencies", []),
+}
+json.dump(payload, open(out_path, "w"), indent=2)
+print(json.dumps(payload))
+PY
+}
+
+kit_field() {
+	python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "${CONFIG_JSON}" "$1"
+}
+
+dependency_count() {
+	python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["dependencies"]))' "${CONFIG_JSON}"
+}
+
+dependency_field() {
+	python3 -c '
+import json, sys
+deps = json.load(open(sys.argv[1]))["dependencies"]
+print(deps[int(sys.argv[2])].get(sys.argv[3], ""))
+' "${CONFIG_JSON}" "$1" "$2"
+}
+
+find_kit_project() {
+	local local_path="$1" project
+	project="$(find "${ROOT}/${local_path}" -maxdepth 1 -name '*.xcodeproj' -type d | head -1)"
+	if [[ -z ${project} ]]; then
+		echo "::error::No .xcodeproj found under ${local_path}" >&2
+		exit 1
+	fi
+	echo "${project}"
+}
+
+# Package.resolved is gitignored, so a fresh checkout has none. Generate it
+# before reading partner versions from it.
+ensure_package_resolution() {
+	local resolved="$1"
+
+	if [[ -f ${resolved} ]]; then
+		return
+	fi
+
+	# Runs inside a command substitution; keep stdout clean for the version.
+	echo "📦 Resolving SPM dependencies for $(basename "${KIT_PROJECT}")" >&2
+	xcodebuild -resolvePackageDependencies \
+		-project "${KIT_PROJECT}" \
+		-clonedSourcePackagesDirPath "${BUILD_DIR}/SourcePackages" >&2
+
+	if [[ ! -f ${resolved} ]]; then
+		echo "::error::xcodebuild did not produce ${resolved}. Set version in matrix.json." >&2
+		exit 1
+	fi
+}
+
+resolve_dependency_version() {
+	local index="$1" package_identity version resolved
+	package_identity="$(dependency_field "${index}" package_identity)"
+	version="$(dependency_field "${index}" version)"
+
+	if [[ -n ${version} ]]; then
+		echo "${version}"
+		return
+	fi
+
+	if [[ -z ${package_identity} ]]; then
+		echo "::error::Dependency is missing package_identity or version" >&2
+		exit 1
+	fi
+
+	resolved="${KIT_PROJECT}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+	ensure_package_resolution "${resolved}"
+
+	version="$(python3 -c '
+import json, sys
+identity = sys.argv[2]
+pins = json.load(open(sys.argv[1]))["pins"]
+for pin in pins:
+    if pin["identity"].startswith(identity):
+        print(pin["state"]["version"])
+        break
+' "${resolved}" "${package_identity}")"
+
+	if [[ -z ${version} ]]; then
+		echo "::error::No Package.resolved pin matching '${package_identity}'. Set version in matrix.json." >&2
+		exit 1
+	fi
+	echo "${version}"
+}
+
+# Downloads a partner xcframework zip and sets DEPENDENCY_XCFRAMEWORK_PATH.
+fetch_dependency_xcframework() {
+	local index="$1"
+	local framework version url_template url destination staging unpacked
+
+	framework="$(dependency_field "${index}" framework)"
+	version="$(resolve_dependency_version "${index}")"
+	url_template="$(dependency_field "${index}" url)"
+
+	if [[ -z ${framework} || -z ${url_template} ]]; then
+		echo "::error::Dependency is missing framework or url" >&2
+		exit 1
+	fi
+
+	url="${url_template//\{version\}/${version}}"
+	destination="${BUILD_DIR}/${framework}.xcframework"
+	DEPENDENCY_XCFRAMEWORK_PATH="${destination}"
+
+	if [[ -d ${destination} ]]; then
+		echo "♻️  Reusing ${destination}"
+		return
+	fi
+
+	staging="${BUILD_DIR}/${framework}-download"
+	echo "⬇️  Fetching ${framework} ${version}"
+	rm -rf "${staging}"
+	mkdir -p "${staging}"
+	if ! curl -fsSL -o "${staging}/${framework}.xcframework.zip" "${url}"; then
+		echo "::error::Failed to download ${url}" >&2
+		exit 1
+	fi
+	unzip -q "${staging}/${framework}.xcframework.zip" -d "${staging}"
+
+	unpacked="$(find "${staging}" -maxdepth 2 -name "${framework}.xcframework" -type d | head -1)"
+	if [[ -z ${unpacked} ]]; then
+		# Some zips nest a differently named xcframework; take the first one found.
+		unpacked="$(find "${staging}" -maxdepth 2 -name '*.xcframework' -type d | head -1)"
+	fi
+	if [[ -z ${unpacked} ]]; then
+		echo "::error::No .xcframework found in ${url}" >&2
+		exit 1
+	fi
+	mv "${unpacked}" "${destination}"
+	rm -rf "${staging}"
+}
+
+# Sets CORE_XCFRAMEWORK_PATH.
+build_core_xcframework() {
+	local destination="${BUILD_DIR}/${CORE_MODULE}.xcframework"
+
+	if [[ -n ${CORE_XCFRAMEWORK-} ]]; then
+		CORE_XCFRAMEWORK_PATH="${CORE_XCFRAMEWORK}"
+		echo "♻️  Using prebuilt core SDK at ${CORE_XCFRAMEWORK_PATH}"
+		return
+	fi
+
+	CORE_XCFRAMEWORK_PATH="${destination}"
+	if [[ -d ${destination} ]]; then
+		echo "♻️  Reusing ${destination}"
+		return
+	fi
+
+	echo "🏗️  Building core SDK xcframework"
+	(
+		cd "${ROOT}"
+		chmod +x ./Scripts/xcframework.sh
+		rm -rf archives "${CORE_MODULE}.xcframework"
+		./Scripts/xcframework.sh mParticle-Apple-SDK
+		mv "${CORE_MODULE}.xcframework" "${destination}"
+		rm -rf archives
+	)
+}
+
+# Absolute path to the directory holding the .framework for a platform variant.
+slice_search_path() {
+	local xcframework="$1" variant="$2" platform="$3" slice platform_key
+	platform_key="$(printf '%s' "${platform}" | tr '[:upper:]' '[:lower:]')"
+
+	case "${variant}" in
+	device)
+		slice="$(find "${xcframework}" -maxdepth 1 -type d -name "${platform_key}-arm64" | head -1)"
+		;;
+	simulator)
+		slice="$(find "${xcframework}" -maxdepth 1 -type d -name "${platform_key}-*-simulator" | head -1)"
+		;;
+	*)
+		echo "::error::Unknown variant ${variant}" >&2
+		exit 1
+		;;
+	esac
+
+	if [[ -z ${slice} ]]; then
+		echo "::error::No ${platform} ${variant} slice in $(basename "${xcframework}")" >&2
+		exit 1
+	fi
+	echo "${slice}"
+}
+
+# Sets ARCHIVE_PATH. Links the Dynamic scheme against core + partner frameworks.
+archive_slice() {
+	local variant="$1" platform_name="$2"
+	local platform archive_path search_paths=() path
+
+	case "${variant}" in
+	device)
+		platform="generic/platform=${platform_name}"
+		archive_path="${ARCHIVE_DIR}/${MODULE}-${platform_name}"
+		;;
+	simulator)
+		platform="generic/platform=${platform_name} Simulator"
+		archive_path="${ARCHIVE_DIR}/${MODULE}-${platform_name}_Simulator"
+		;;
+	*)
+		echo "::error::Unknown variant ${variant}" >&2
+		exit 1
+		;;
+	esac
+
+	path="$(slice_search_path "${CORE_XCFRAMEWORK_PATH}" "${variant}" "${platform_name}")"
+	search_paths+=("${path}")
+
+	for path in "${DEPENDENCY_PATHS[@]}"; do
+		search_paths+=("$(slice_search_path "${path}" "${variant}" "${platform_name}")")
+	done
+
+	echo "🏗️  Archiving ${MODULE} for ${platform}"
+	xcodebuild archive \
+		-project "${KIT_PROJECT}" \
+		-scheme "${KIT_SCHEME}" \
+		-destination "${platform}" \
+		-archivePath "${archive_path}" \
+		"${BUILD_SETTINGS[@]}" \
+		MPARTICLE_DEPENDENCY_FRAMEWORK_PATHS="${search_paths[*]}"
+
+	ARCHIVE_PATH="${archive_path}.xcarchive"
+}
+
+main() {
+	local local_path count index device_archive simulator_archive
+	local verify_args=()
+
+	load_kit_config >/dev/null
+	local_path="$(kit_field local_path)"
+	KIT_SCHEME="$(kit_field scheme)"
+	MODULE="$(kit_field module)"
+	KIT_PROJECT="$(find_kit_project "${local_path}")"
+
+	mkdir -p "${BUILD_DIR}" "${OUTPUT_DIR}"
+	echo "📌 Building ${KIT_NAME} (${MODULE}) via ${KIT_SCHEME}"
+
+	build_core_xcframework
+
+	DEPENDENCY_PATHS=()
+	count="$(dependency_count)"
+	for ((index = 0; index < count; index++)); do
+		fetch_dependency_xcframework "${index}"
+		DEPENDENCY_PATHS+=("${DEPENDENCY_XCFRAMEWORK_PATH}")
+	done
+
+	rm -rf "${ARCHIVE_DIR}" "${OUTPUT_DIR:?}/${MODULE}.xcframework"
+	mkdir -p "${ARCHIVE_DIR}"
+
+	# iOS only for now; kits that also ship tvOS can extend destinations later.
+	archive_slice device iOS
+	device_archive="${ARCHIVE_PATH}"
+	archive_slice simulator iOS
+	simulator_archive="${ARCHIVE_PATH}"
+
+	xcodebuild -create-xcframework \
+		-archive "${device_archive}" -framework "${MODULE}.framework" \
+		-archive "${simulator_archive}" -framework "${MODULE}.framework" \
+		-output "${OUTPUT_DIR}/${MODULE}.xcframework"
+
+	rm -rf "${ARCHIVE_DIR}"
+
+	echo "🔍 Verifying the kit does not redefine its dependencies"
+	chmod +x "${ROOT}/Scripts/verify_kit_xcframework_symbols.sh"
+	verify_args=(
+		"${OUTPUT_DIR}/${MODULE}.xcframework"
+		"${CORE_XCFRAMEWORK_PATH}"
+	)
+	if [[ ${#DEPENDENCY_PATHS[@]} -gt 0 ]]; then
+		verify_args+=("${DEPENDENCY_PATHS[@]}")
+	fi
+	"${ROOT}/Scripts/verify_kit_xcframework_symbols.sh" "${verify_args[@]}"
+
+	(cd "${OUTPUT_DIR}" && rm -f "${MODULE}.xcframework.zip" && zip -qr "${MODULE}.xcframework.zip" "${MODULE}.xcframework")
+	echo "✅ ${OUTPUT_DIR}/${MODULE}.xcframework.zip"
+}
+
+main "$@"

--- a/Scripts/verify_kit_xcframework_import.sh
+++ b/Scripts/verify_kit_xcframework_import.sh
@@ -2,71 +2,46 @@
 #
 # verify_kit_xcframework_import.sh
 #
-# Ensures kit public headers compile against the core SDK xcframework module
-# (mParticle_Apple_SDK), not only the SPM/CocoaPods ObjC module name.
+# Builds the distributable AppsFlyer kit xcframework (representative kit) and
+# checks two things manual xcframework consumers depend on:
+#
+#   1. The kit does not redefine symbols from the core SDK or AppsFlyer, which
+#      would give an app two copies of those classes. Enforced by the build.
+#   2. Kit public headers compile against the core SDK xcframework module
+#      (mParticle_Apple_SDK), not only the SPM/CocoaPods ObjC module name.
 #
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-${ROOT}/build/xcframework-import-smoke}"
-CORE_SCHEME="mParticle-Apple-SDK"
 CORE_MODULE="mParticle_Apple_SDK"
-KIT_PROJECT="${ROOT}/Kits/appsflyer/appsflyer-6/mParticle-AppsFlyer.xcodeproj"
-KIT_SCHEME="mParticle-AppsFlyer"
+KIT_NAME="appsflyer-6"
 KIT_MODULE="mParticle_AppsFlyer"
 SMOKE_SOURCE="${ROOT}/Tests/XCFrameworkImportSmoke/smoke.m"
 
-BUILD_SETTINGS=(
-	CODE_SIGN_IDENTITY=""
-	CODE_SIGNING_REQUIRED=NO
-	CODE_SIGNING_ALLOWED=NO
-	SKIP_INSTALL=NO
-	BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-)
+# build_kit_xcframework.sh builds the core SDK here when it is not given a
+# prebuilt one.
+CORE_XCFRAMEWORK="${ROOT}/build/kit-xcframework/${KIT_NAME}/${CORE_MODULE}.xcframework"
+KIT_XCFRAMEWORK="${BUILD_DIR}/${KIT_MODULE}.xcframework"
 
 framework_search_path() {
 	local xcf="$1"
 	find "${xcf}" -type d -path '*/ios-*simulator/*.framework' -maxdepth 2 | head -1 | xargs dirname
 }
 
-build_core_xcframework() {
-	echo "🏗️  Building core SDK xcframework..."
-	cd "${ROOT}"
-	chmod +x ./Scripts/xcframework.sh
-	rm -rf archives "${CORE_MODULE}.xcframework"
-	./Scripts/xcframework.sh "${CORE_SCHEME}" "${CORE_MODULE}"
-	mv "${CORE_MODULE}.xcframework" "${BUILD_DIR}/"
-	rm -rf archives
-}
-
-build_kit_xcframework() {
-	echo "🏗️  Building AppsFlyer kit xcframework (representative kit)..."
-	local archive_root="${BUILD_DIR}/archives"
-	mkdir -p "${archive_root}"
-	rm -rf "${archive_root}" "${BUILD_DIR}/${KIT_MODULE}.xcframework"
-
-	xcodebuild archive -project "${KIT_PROJECT}" -scheme "${KIT_SCHEME}" \
-		-destination "generic/platform=iOS Simulator" \
-		-archivePath "${archive_root}/${KIT_MODULE}-iOS_Simulator" \
-		"${BUILD_SETTINGS[@]}"
-
-	xcodebuild -create-xcframework \
-		-archive "${archive_root}/${KIT_MODULE}-iOS_Simulator.xcarchive" -framework "${KIT_MODULE}.framework" \
-		-output "${BUILD_DIR}/${KIT_MODULE}.xcframework"
-
-	rm -rf "${archive_root}"
+build_xcframeworks() {
+	echo "🏗️  Building distributable ${KIT_NAME} kit xcframework..."
+	chmod +x "${ROOT}/Scripts/build_kit_xcframework.sh"
+	rm -rf "${KIT_XCFRAMEWORK}"
+	OUTPUT_DIR="${BUILD_DIR}" "${ROOT}/Scripts/build_kit_xcframework.sh" "${KIT_NAME}"
 }
 
 compile_smoke_test() {
 	echo "🧪 Compiling ObjC smoke test against xcframework modules..."
-	local core_xcf="${BUILD_DIR}/${CORE_MODULE}.xcframework"
-	local kit_xcf="${BUILD_DIR}/${KIT_MODULE}.xcframework"
-	local core_fw_path
-	local kit_fw_path
-	local sdk_path
+	local core_fw_path kit_fw_path sdk_path
 
-	core_fw_path="$(framework_search_path "${core_xcf}")"
-	kit_fw_path="$(framework_search_path "${kit_xcf}")"
+	core_fw_path="$(framework_search_path "${CORE_XCFRAMEWORK}")"
+	kit_fw_path="$(framework_search_path "${KIT_XCFRAMEWORK}")"
 	sdk_path="$(xcrun --sdk iphonesimulator --show-sdk-path)"
 
 	if [[ -z ${core_fw_path} || -z ${kit_fw_path} ]]; then
@@ -84,6 +59,5 @@ compile_smoke_test() {
 }
 
 mkdir -p "${BUILD_DIR}"
-build_core_xcframework
-build_kit_xcframework
+build_xcframeworks
 compile_smoke_test

--- a/Scripts/verify_kit_xcframework_symbols.sh
+++ b/Scripts/verify_kit_xcframework_symbols.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# verify_kit_xcframework_symbols.sh
+#
+# Fails if a kit xcframework defines any ObjC class or Swift symbol that one of
+# its dependency xcframeworks also defines.
+#
+# A kit framework must reference its dependencies dynamically. When it absorbs a
+# static copy of them instead, an app that links both the kit and the dependency
+# ends up with two copies of every class, which splits singleton state and
+# crashes at launch.
+#
+# Usage:
+#   verify_kit_xcframework_symbols.sh <kit.xcframework> <dependency.xcframework>...
+#
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+	echo "usage: $(basename "$0") <kit.xcframework> <dependency.xcframework>..." >&2
+	exit 2
+fi
+
+KIT_XCFRAMEWORK="$1"
+shift
+DEPENDENCY_XCFRAMEWORKS=("$@")
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# ObjC classes and metaclasses, plus mangled Swift symbols. Restricting to these
+# avoids false positives from linker-generated and runtime support symbols.
+# shellcheck disable=SC2016 # $ is regex anchoring, not a shell expansion
+INTERESTING_SYMBOLS='^_OBJC_(CLASS|METACLASS)_\$_|^_\$s'
+
+slice_platform() {
+	# ios-arm64_x86_64-simulator -> ios
+	echo "${1%%-*}"
+}
+
+slice_variant() {
+	# ios-arm64_x86_64-simulator -> simulator; ios-arm64 -> device
+	case "$1" in
+	*-simulator) echo "simulator" ;;
+	*-maccatalyst) echo "maccatalyst" ;;
+	*) echo "device" ;;
+	esac
+}
+
+binary_for_slice() {
+	local slice_dir="$1"
+	find "${slice_dir}" -maxdepth 3 -type f -perm -u+x -path '*.framework/*' \
+		! -path '*/Headers/*' ! -path '*/Modules/*' ! -path '*/_CodeSignature/*' \
+		! -path '*/Frameworks/*' 2>/dev/null | head -1
+}
+
+# Writes the defined symbols of every architecture in a Mach-O binary.
+defined_symbols() {
+	local binary="$1"
+	nm -gU -arch all "${binary}" 2>/dev/null |
+		awk '{ print $NF }' |
+		grep -E "${INTERESTING_SYMBOLS}" |
+		sort -u
+}
+
+# Finds the dependency slice matching a kit slice by platform and variant.
+matching_slice() {
+	local xcframework="$1" platform="$2" variant="$3"
+	local candidate name candidate_platform candidate_variant
+	for candidate in "${xcframework}"/*/; do
+		[[ -d ${candidate} ]] || continue
+		name="$(basename "${candidate}")"
+		candidate_platform="$(slice_platform "${name}")"
+		candidate_variant="$(slice_variant "${name}")"
+		[[ ${candidate_platform} == "${platform}" ]] || continue
+		[[ ${candidate_variant} == "${variant}" ]] || continue
+		echo "${candidate}"
+		return 0
+	done
+	return 1
+}
+
+failures=0
+checked_slices=0
+
+for kit_slice in "${KIT_XCFRAMEWORK}"/*/; do
+	[[ -d ${kit_slice} ]] || continue
+	slice_name="$(basename "${kit_slice}")"
+	kit_binary="$(binary_for_slice "${kit_slice}")"
+	if [[ -z ${kit_binary} ]]; then
+		echo "::warning::No framework binary found in slice ${slice_name}; skipping"
+		continue
+	fi
+
+	platform="$(slice_platform "${slice_name}")"
+	variant="$(slice_variant "${slice_name}")"
+	kit_symbols="${WORK_DIR}/kit-${slice_name}.txt"
+	defined_symbols "${kit_binary}" >"${kit_symbols}"
+	checked_slices=$((checked_slices + 1))
+
+	for dependency in "${DEPENDENCY_XCFRAMEWORKS[@]}"; do
+		dependency_name="$(basename "${dependency}" .xcframework)"
+
+		# shellcheck disable=SC2310 # a missing slice is handled, not fatal
+		if ! dependency_slice="$(matching_slice "${dependency}" "${platform}" "${variant}")"; then
+			echo "::warning::${dependency_name} has no ${platform}/${variant} slice; skipping"
+			continue
+		fi
+
+		dependency_binary="$(binary_for_slice "${dependency_slice}")"
+		if [[ -z ${dependency_binary} ]]; then
+			echo "::warning::No framework binary found in ${dependency_name}/$(basename "${dependency_slice}"); skipping"
+			continue
+		fi
+
+		dependency_symbols="${WORK_DIR}/${dependency_name}-${slice_name}.txt"
+		defined_symbols "${dependency_binary}" >"${dependency_symbols}"
+
+		duplicates="${WORK_DIR}/duplicates-${dependency_name}-${slice_name}.txt"
+		comm -12 "${kit_symbols}" "${dependency_symbols}" >"${duplicates}"
+		duplicate_count="$(wc -l <"${duplicates}" | tr -d ' ')"
+
+		if [[ ${duplicate_count} -gt 0 ]]; then
+			failures=$((failures + 1))
+			echo "::error::${slice_name}: kit redefines ${duplicate_count} symbol(s) from ${dependency_name}"
+			echo "  The kit statically absorbed ${dependency_name} instead of linking it dynamically."
+			echo "  First 20 duplicated symbols:"
+			head -20 "${duplicates}" | sed 's/^/    /'
+		else
+			echo "✅ ${slice_name}: no symbols shared with ${dependency_name}"
+		fi
+	done
+done
+
+if [[ ${checked_slices} -eq 0 ]]; then
+	echo "::error::No slices found in ${KIT_XCFRAMEWORK}"
+	exit 1
+fi
+
+if [[ ${failures} -gt 0 ]]; then
+	echo
+	echo "::error::Duplicate symbol check failed for $(basename "${KIT_XCFRAMEWORK}")"
+	exit 1
+fi
+
+echo "✅ $(basename "${KIT_XCFRAMEWORK}") shares no symbols with its dependencies"


### PR DESCRIPTION
## Background
- A customer integrating the mParticle Apple SDK and the AppsFlyer kit via prebuilt xcframeworks (.binaryTarget) crashed at launch after upgrading, with duplicate ObjC class warnings for core SDK types (MParticle, MPIdentityApi, etc.).
- Root cause: the published mParticle_AppsFlyer.xcframework was archived from the SPM scheme, which links mParticle-Apple-SDK and AppsFlyerLib-Static as static libraries. Those were absorbed into the kit binary, so an app that also linked the core SDK xcframework ended up with two copies of every class and split singleton state.
- This has been true of every AppsFlyer kit xcframework since v9.0.0; binary consumers appear to be newly hitting it. The existing header smoke test only ran clang -fsyntax-only and could not catch duplicate symbols. SPM and CocoaPods source integrations were unaffected.

## What Has Changed
- Added a mParticle-AppsFlyer-Dynamic Xcode target/scheme that compiles the same kit sources but links -framework mParticle_Apple_SDK and -framework AppsFlyerLib dynamically, so the distributable binary defines only MPKitAppsFlyer.
- Introduced reusable Scripts/build_kit_xcframework.sh, driven by a dynamic_xcframework block in Kits/matrix.json (scheme, module, partner dependency URL/package_identity). AppsFlyer is the first kit wired through it; other kits can reuse the same script later.
- Release CI now routes kits with dynamic_xcframework through that script instead of the generic SPM archive path.
- Added Scripts/verify_kit_xcframework_symbols.sh to fail the build when a kit xcframework redefines ObjC/Swift symbols from the core SDK or partner frameworks, and updated the import smoke job to build the real distributable and run that check.
- Documented binary-consumer requirements in the AppsFlyer kit README: embed mParticle_AppsFlyer.xcframework, mParticle_Apple_SDK.xcframework, and the dynamic AppsFlyerLib.xcframework together.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
