### PR TITLE
ci: Stop force-pushing when mirroring the braze-17 kit

### DIFF
--- a/Kits/matrix.json
+++ b/Kits/matrix.json
@@ -136,7 +136,6 @@
     "local_path": "Kits/braze/braze-17",
     "podspec": "Kits/braze/braze-17/mParticle-Braze-17.podspec",
     "dest_repo": "mparticle-apple-integration-braze-17",
-    "mirror_force_push_main": true,
     "schemes": [
       {
         "scheme": "mParticle-Braze",


### PR DESCRIPTION
## Background
- The braze-17 kit was initially mirrored with mirror_force_push_main enabled so early subtree splits could overwrite main on mparticle-apple-integration-braze-17. That force-push behavior is no longer needed and risks rewriting history on the mirror repo.

## What Has Changed
- Removed mirror_force_push_main: true from the braze-17 entry in Kits/matrix.json, so Release – Publish mirrors braze-17 with a normal git push to main, consistent with other kits.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
