### PR TITLE
fix(cocoapods): prevent mixed SDK component versions

### DIFF
--- a/mParticle-Apple-SDK-ObjC.podspec
+++ b/mParticle-Apple-SDK-ObjC.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
         mp.preserve_paths       = 'mParticle-Apple-SDK', 'mParticle-Apple-SDK/**', 'mParticle-Apple-SDK/**/*'
         mp.source_files         = 'mParticle-Apple-SDK/**/*.{h,m}'
         mp.resource_bundles = {'mParticle-Privacy' => ['PrivacyInfo.xcprivacy']}
-        mp.dependency 'mParticle-Apple-SDK-Swift'
+        mp.dependency 'mParticle-Apple-SDK-Swift', s.version.to_s
         mp.dependency 'RoktContracts', '~> 2.0'
     end
 end


### PR DESCRIPTION
## Background

A pinned mParticle Apple SDK version could still resolve a newer
`mParticle-Apple-SDK-Swift` pod because the ObjC podspec did not specify
a version constraint. This could install incompatible core SDK components.

## What Has Changed

- Pin `mParticle-Apple-SDK-Swift` to the same version as
  `mParticle-Apple-SDK-ObjC`.
- Keep SwiftPM unchanged because its internal Swift and Objective-C targets
  already come from the same pinned package tag.
- Keep the release workflow unchanged because it already updates all core
  podspec versions together and publishes them in dependency order.

## Screenshots/Video

N/A — no visual changes.

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [x] Tested locally