### PR TITLE
feat: Support Apptentive Region Settings

### DIFF
--- a/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/MPKitApptentive.m
+++ b/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/MPKitApptentive.m
@@ -15,10 +15,12 @@ static NSString * const apptentiveAppKeyKey = @"apptentiveAppKey";
 static NSString * const apptentiveAppSignatureKey = @"apptentiveAppSignature";
 static NSString * const apptentiveInitOnStart = @"apptentiveInitOnStart";
 static NSString * const apptentiveEnableTypeDetectionKey = @"enableTypeDetection";
+static NSString * const apptentiveServiceRegionKey = @"serviceRegion";
 
 // we need to keep the credentials in order to init the SDK later on
 static NSString * _apptentiveKey = nil;
 static NSString * _apptentiveSignature = nil;
+static NSString * _apptentiveServiceRegion = nil;
 
 @interface MPKitApptentive ()
 
@@ -109,6 +111,7 @@ static void MPKitApptentivePerformOnMain(void (^block)(void)) {
     dispatch_once(&kitPredicate, ^{
         _apptentiveKey = self.configuration[apptentiveAppKeyKey];
         _apptentiveSignature = self.configuration[apptentiveAppSignatureKey];
+        _apptentiveServiceRegion = self.configuration[apptentiveServiceRegionKey];
 
         // do we need to init the SDK while the Kit starts
         BOOL initOnStart = self.configuration[apptentiveInitOnStart] == nil ||   // if flag is missing
@@ -157,14 +160,15 @@ static void MPKitApptentivePerformOnMain(void (^block)(void)) {
 
     __block BOOL registered = NO;
     void (^registerBlock)(void) = ^{
-        NSLog(@"mParticle -> Registering Apptentive SDK");
-
         // ApptentiveKit 7 public APIs are MainActor-isolated; set distribution metadata
         // on the shared instance before registering.
         Apptentive.shared.distributionName = @"mParticle";
         Apptentive.shared.distributionVersion = [MParticle sharedInstance].version;
 
         ApptentiveConfiguration *apptentiveConfig = [ApptentiveConfiguration configurationWithApptentiveKey:_apptentiveKey apptentiveSignature:_apptentiveSignature];
+        NSString *normalizedRegion = MPKitApptentiveNormalizeServiceRegion(_apptentiveServiceRegion);
+        apptentiveConfig.region = normalizedRegion;
+        NSLog(@"mParticle -> Registering Apptentive SDK with serviceRegion '%@'", normalizedRegion);
         [Apptentive.shared registerWithConfiguration:apptentiveConfig completion:nil];
         registered = YES;
     };

--- a/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/MPKitApptentiveUtils.m
+++ b/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/MPKitApptentiveUtils.m
@@ -33,3 +33,27 @@ id MPKitApptentiveParseValue(NSString *value) {
     
     return value;
 }
+
+NSString * MPKitApptentiveNormalizeServiceRegion(NSString * _Nullable region) {
+    NSString *trimmed = [region stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length == 0) {
+        return @"us";
+    }
+
+    if ([trimmed caseInsensitiveCompare:@"US"] == NSOrderedSame) {
+        return @"us";
+    }
+    if ([trimmed caseInsensitiveCompare:@"EU"] == NSOrderedSame) {
+        return @"eu";
+    }
+    if ([trimmed caseInsensitiveCompare:@"AU"] == NSOrderedSame) {
+        return @"au";
+    }
+    if ([trimmed caseInsensitiveCompare:@"CA"] == NSOrderedSame) {
+        NSLog(@"mParticle -> Apptentive serviceRegion 'CA' is not supported by the current Apptentive iOS SDK; defaulting to US.");
+        return @"us";
+    }
+
+    NSLog(@"mParticle -> Unrecognized Apptentive serviceRegion '%@'; defaulting to US.", trimmed);
+    return @"us";
+}

--- a/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/include/MPKitApptentiveUtils.h
+++ b/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/include/MPKitApptentiveUtils.h
@@ -12,4 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 id MPKitApptentiveParseValue(NSString *value);
 
+/// Normalizes an mParticle `serviceRegion` config value to an ApptentiveKit region raw value (`us`, `eu`, or `au`).
+/// Defaults to `us` when the value is missing, blank, unsupported (including `CA`), or unrecognized.
+NSString * MPKitApptentiveNormalizeServiceRegion(NSString * _Nullable region);
+
 NS_ASSUME_NONNULL_END

--- a/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/include/mParticle_Apptentive.h
+++ b/Kits/apptentive/apptentive-7/Sources/mParticle-Apptentive/include/mParticle_Apptentive.h
@@ -13,3 +13,9 @@ FOUNDATION_EXPORT const unsigned char mParticle_ApptentiveVersionString[];
 #else
     #import "MPKitApptentive.h"
 #endif
+
+#if defined(__has_include) && __has_include(<mParticle_Apptentive/MPKitApptentiveUtils.h>)
+    #import <mParticle_Apptentive/MPKitApptentiveUtils.h>
+#else
+    #import "MPKitApptentiveUtils.h"
+#endif

--- a/Kits/apptentive/apptentive-7/Tests/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
+++ b/Kits/apptentive/apptentive-7/Tests/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
@@ -71,4 +71,25 @@
     XCTAssertEqualObjects(expected, actual);
 }
 
+- (void)testNormalizeServiceRegionDefaultsToUS {
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(nil));
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@""));
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@"   "));
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@"US"));
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@"us"));
+}
+
+- (void)testNormalizeServiceRegionMapsSupportedRegions {
+    XCTAssertEqualObjects(@"eu", MPKitApptentiveNormalizeServiceRegion(@"EU"));
+    XCTAssertEqualObjects(@"eu", MPKitApptentiveNormalizeServiceRegion(@"eu"));
+    XCTAssertEqualObjects(@"au", MPKitApptentiveNormalizeServiceRegion(@"AU"));
+    XCTAssertEqualObjects(@"au", MPKitApptentiveNormalizeServiceRegion(@"au"));
+}
+
+- (void)testNormalizeServiceRegionFallsBackForUnsupportedValues {
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@"CA"));
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@"ca"));
+    XCTAssertEqualObjects(@"us", MPKitApptentiveNormalizeServiceRegion(@"APAC"));
+}
+
 @end


### PR DESCRIPTION
## Background
- ApptentiveKit 7 supports region-specific API endpoints at registration (us, eu, au) for latency and data residency. mParticle event integrations can now pass a serviceRegion setting (US, EU, AU, CA) with the Apptentive key/signature.
- The apptentive-7 kit previously registered without a region, so everything defaulted to US and customers could not use EU/AU residency from the mParticle configuration.

## What Has Changed
- Reads serviceRegion from kit configuration and persists it with credentials so delayed +registerSDK still applies it.
- Normalizes config values to ApptentiveKit region raw values (us/eu/au), defaults to us when missing, and falls back to us with a warning for unsupported values including CA (not in the current Apptentive iOS SDK).
- Sets ApptentiveConfiguration.region before registerWithConfiguration:completion:.
- Adds unit tests for default, EU/AU mapping, case-insensitivity, and CA/unknown fallback.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
