### PR TITLE
fix: notify callers when a Rokt placement cannot be requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 ## [Unreleased]
 
+### Core
+
+#### Fixed
+
+- `MPRokt.selectPlacements` and `MPRokt.selectShoppableAds` now deliver a `RoktPlacementFailure` event to the caller's `onEvent` handler when the Rokt kit configuration is unavailable. Previously the call was dropped with only a log message, leaving callers waiting on a callback that never arrived. ([#814](https://github.com/mParticle/mparticle-apple-sdk/pull/814))
+
 ### Kits
 
 #### Rokt

--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -340,6 +340,43 @@ static NSNumber * const kTestRoktKitId = @181;
     OCMVerifyAll((id)self.mockContainer);
 }
 
+- (void)testSelectPlacementsWithNilMappingInvokesOnEventWithPlacementFailure {
+    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    NSString *identifier = @"testView";
+    XCTestExpectation *expectation = [self expectationWithDescription:@"onEvent called"];
+    __block RoktEvent *receivedEvent = nil;
+
+    [self.rokt selectPlacements:identifier
+                     attributes:@{@"f.name": @"Brandon"}
+                  embeddedViews:nil
+                         config:nil
+                        onEvent:^(RoktEvent * _Nonnull event) {
+        receivedEvent = event;
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    XCTAssertTrue([receivedEvent isKindOfClass:[RoktPlacementFailure class]]);
+    XCTAssertEqualObjects(((RoktPlacementFailure *)receivedEvent).identifier, identifier);
+}
+
+- (void)testSelectPlacementsWithNilMappingAndNilOnEventDoesNotCrash {
+    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    XCTAssertNoThrow([self.rokt selectPlacements:@"testView" attributes:@{@"f.name": @"Brandon"}]);
+}
+
 - (void)testGetRoktPlacementAttributesMapping {
     MParticle *instance = [MParticle sharedInstance];
     self.mockInstance = OCMPartialMock(instance);
@@ -1025,6 +1062,31 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt selectShoppableAds:@"shoppableView" attributes:@{@"email": @"a@b.com"}];
 
     OCMVerifyAll((id)self.mockContainer);
+}
+
+- (void)testSelectShoppableAdsWithNilMappingInvokesOnEventWithPlacementFailure {
+    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    NSString *identifier = @"shoppableView";
+    XCTestExpectation *expectation = [self expectationWithDescription:@"onEvent called"];
+    __block RoktEvent *receivedEvent = nil;
+
+    [self.rokt selectShoppableAds:identifier
+                       attributes:@{@"f.name": @"Brandon"}
+                           config:nil
+                          onEvent:^(RoktEvent * _Nonnull event) {
+        receivedEvent = event;
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    XCTAssertTrue([receivedEvent isKindOfClass:[RoktPlacementFailure class]]);
+    XCTAssertEqualObjects(((RoktPlacementFailure *)receivedEvent).identifier, identifier);
 }
 
 - (void)testSelectShoppableAdsInvokesConfirmUser {

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -115,6 +115,7 @@ static const NSInteger kMPRoktKitId = 181;
             });
         } else {
             MPILogWarning(@"MPRokt selectPlacements not performed - Rokt Kit not configured. Check with your Rokt representative to ensure the kit is enabled.");
+            [self notifyPlacementFailure:identifier onEvent:onEvent];
         }
     }];
 }
@@ -383,6 +384,7 @@ static const NSInteger kMPRoktKitId = 181;
             });
         } else {
             MPILogWarning(@"MPRokt selectShoppableAds not performed - Rokt Kit not configured. Check with your Rokt representative to ensure the kit is enabled.");
+            [self notifyPlacementFailure:identifier onEvent:onEvent];
         }
     }];
 }
@@ -430,6 +432,22 @@ static const NSInteger kMPRoktKitId = 181;
 }
 
 #pragma mark - Private Helper Methods
+
+/// Delivers a \c RoktPlacementFailure to the caller so a placement request that cannot be served never
+/// completes silently. Dispatched to the main queue because callers drive UI from this handler.
+/// - Parameters:
+///   - identifier: The placement identifier the caller requested
+///   - onEvent: The caller's event handler; nothing is delivered when it is nil
+- (void)notifyPlacementFailure:(NSString * _Nullable)identifier
+                       onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent {
+    if (!onEvent) {
+        return;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        onEvent([[RoktPlacementFailure alloc] initWithIdentifier:identifier]);
+    });
+}
 
 /// Applies dashboard placement attribute key mapping, then sets each non-sandbox key on the user.
 /// @return Mutable dictionary after remapping (empty when \p attributes is nil).


### PR DESCRIPTION
## Background

- `MPRokt.selectPlacements:attributes:embeddedViews:config:onEvent:` resolves the dashboard attribute mapping via `getRoktPlacementAttributesMapping` before forwarding to the Rokt kit. That method returns `nil` whenever the Rokt kit configuration is not present in `MPKitContainer.originalConfig` — most commonly because remote configuration has not been applied yet, and also when the kit is not enabled for the workspace.
- In that case the SDK logged a warning and returned. The caller's `onEvent` handler was never invoked, so partners waiting on a placement lifecycle event (loading indicator, spinner, checkout continuation) were left waiting on a callback that would never arrive, with nothing to distinguish "not configured" from "still loading".
- `MPRokt.selectShoppableAds:attributes:config:onEvent:` had the same behaviour on the same code path.

## What Has Changed

- Both `selectPlacements` and `selectShoppableAds` now deliver `RoktEvent.PlacementFailure` (`RoktPlacementFailure`, carrying the requested placement identifier) to the caller's `onEvent` handler when the Rokt kit configuration is unavailable. The existing warning log is unchanged.
- The event is delivered on the main queue, since callers drive UI from this handler. Nothing is delivered when `onEvent` is `nil` (including the convenience `selectPlacements:attributes:` overload).
- `RoktPlacementFailure` is the event the Rokt SDK already emits when a placement cannot be displayed, so partner event handlers need no new cases.
- No API surface change: this is behaviour on an existing callback.
- Added unit tests covering the placement-failure callback for both entry points, a nil-`onEvent` regression test, and a CHANGELOG entry.

## Scope

- This PR only guarantees that the caller is always notified. It intentionally does not change _when_ the call is dropped. A related gap remains open and is not addressed here: `MPKitContainer.forwardSDKCall` discards a forwarded call when the Rokt kit is registered and configured but has not finished starting, since the kit only sets `started` from the asynchronous `Rokt.init` callback.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Partners who currently treat "no callback" as an implicit failure signal will now receive an explicit `RoktPlacementFailure`. This is additive, but it is the first time this code path emits an event at all, so it is worth calling out in release notes.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes https://go/j/[ticket-number]
