### PR TITLE
feat: Update Rokt Session Handoff

### DIFF
--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -2,6 +2,15 @@
 @import Rokt_Widget;
 @import RoktContracts;
 
+@class RoktSession;
+
+// TODO: Remove this category once Rokt-Widget ships `+[Rokt setSession:]` / `+[Rokt getSession]`
+// (rokt-sdk-ios#280) and the kit pin is bumped to that release.
+@interface Rokt (MPRoktSessionHandoff)
++ (void)setSession:(RoktSession *)session;
++ (nullable RoktSession *)getSession;
+@end
+
 // Kit version
 static NSString * const kMPRoktKitVersion = @"9.3.5";
 
@@ -560,6 +569,21 @@ static __weak MPKitRokt *roktKit = nil;
 - (MPKitExecStatus *)close {
     [Rokt close];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
+}
+
+/// Set the session (id + token) to use for the next execute call.
+///
+/// @param session The session id and JWT session token to apply (optional expiry).
+- (MPKitExecStatus *)setSession:(RoktSession *)session {
+    [Rokt setSession:session];
+    return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
+}
+
+/// Get the current session (id + token) for use within a non-native integration e.g. WebView.
+///
+/// @return The session, or nil if no session is present or the persisted token has expired.
+- (RoktSession *)getSession {
+    return [Rokt getSession];
 }
 
 /// Set the session id to use for the next execute call.

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -7,6 +7,27 @@
 static NSInteger const kMPRoktKitCode = 181;
 static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserIdentityType";
 
+// TODO: Remove this category and MPRoktSessionHandoffMock once Rokt-Widget ships
+// `+[Rokt setSession:]` / `+[Rokt getSession]` (rokt-sdk-ios#280) and the kit pin is bumped.
+// Until then, OCMock cannot stub those selectors on the real Rokt class.
+@interface Rokt (MPRoktSessionHandoff)
++ (void)setSession:(id)session;
++ (nullable id)getSession;
+@end
+
+@implementation Rokt (MPRoktSessionHandoff)
++ (void)setSession:(id)session {
+}
++ (nullable id)getSession {
+    return nil;
+}
+@end
+
+@protocol MPRoktSessionHandoffMock <NSObject>
+- (void)setSession:(id)session;
+- (nullable id)getSession;
+@end
+
 @interface MPKitRokt ()
 
 - (MPKitExecStatus *)selectPlacementsWithIdentifier:(NSString * _Nullable)identifier
@@ -22,6 +43,8 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
                          catalogItemId:(NSString *)catalogItemId
                                success:(NSNumber *)success;
 
+- (MPKitExecStatus *)setSession:(RoktSession *)session;
+- (RoktSession *)getSession;
 - (MPKitExecStatus *)setSessionId:(NSString *)sessionId;
 - (NSString *)getSessionId;
 
@@ -899,6 +922,53 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     [mockRoktSDK stopMocking];
     [mockMParticleClass stopMocking];
     [mockMParticleInstance stopMocking];
+}
+
+#pragma mark - setSession tests
+
+- (void)testSetSessionCallsRoktSDK {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    id session = [[NSObject alloc] init];
+
+    OCMExpect([(id<MPRoktSessionHandoffMock>)mockRoktSDK setSession:session]);
+
+    MPKitExecStatus *status = [self.kitInstance setSession:session];
+
+    XCTAssertNotNil(status);
+    XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);
+    XCTAssertEqualObjects(status.integrationId, @181);
+    OCMVerifyAll(mockRoktSDK);
+
+    [mockRoktSDK stopMocking];
+}
+
+#pragma mark - getSession tests
+
+- (void)testGetSessionReturnsSessionFromRoktSDK {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    id expectedSession = [[NSObject alloc] init];
+
+    OCMStub([(id<MPRoktSessionHandoffMock>)mockRoktSDK getSession]).andReturn(expectedSession);
+
+    id result = [self.kitInstance getSession];
+
+    XCTAssertEqual(result, expectedSession, @"Should return the session from the Rokt SDK");
+
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testGetSessionReturnsNilWhenRoktSDKReturnsNil {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    OCMStub([(id<MPRoktSessionHandoffMock>)mockRoktSDK getSession]).andReturn(nil);
+
+    id result = [self.kitInstance getSession];
+
+    XCTAssertNil(result, @"Should return nil when Rokt SDK returns nil");
+
+    [mockRoktSDK stopMocking];
 }
 
 #pragma mark - setSessionId tests

--- a/MParticle/Sources/mParticle_Apple_SDK/MPRokt+Swift.swift
+++ b/MParticle/Sources/mParticle_Apple_SDK/MPRokt+Swift.swift
@@ -62,6 +62,22 @@ extension MPRokt {
         unsafeBitCast(imp, to: Fn.self)(self, sel, onEvent as Block)
     }
 
+    public func setSession(_ session: AnyObject) {
+        let sel = NSSelectorFromString("setSession:")
+        guard let method = class_getInstanceMethod(MPRokt.self, sel) else { return }
+        let imp = method_getImplementation(method)
+        typealias Fn = @convention(c) (AnyObject, Selector, AnyObject) -> Void
+        unsafeBitCast(imp, to: Fn.self)(self, sel, session)
+    }
+
+    public func getSession() -> AnyObject? {
+        let sel = NSSelectorFromString("getSession")
+        guard let method = class_getInstanceMethod(MPRokt.self, sel) else { return nil }
+        let imp = method_getImplementation(method)
+        typealias Fn = @convention(c) (AnyObject, Selector) -> AnyObject?
+        return unsafeBitCast(imp, to: Fn.self)(self, sel)
+    }
+
     public func registerPaymentExtension(_ paymentExtension: PaymentExtension) {
         let sel = NSSelectorFromString("registerPaymentExtension:")
         guard let method = class_getInstanceMethod(MPRokt.self, sel) else { return }

--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -14,13 +14,15 @@
 // Rokt kit identifier for testing
 static NSNumber * const kTestRoktKitId = @181;
 
-// Test helper class that simulates a kit with getSessionId and handleURLCallback methods
+// Test helper class that simulates a kit with getSessionId, getSession, and handleURLCallback methods
 @interface MPRoktTestKitInstance : NSObject
 @property (nonatomic, copy) NSString *sessionIdToReturn;
+@property (nonatomic, strong) id sessionToReturn;
 @property (nonatomic, copy) NSString *lastDiagnosticCode;
 @property (nonatomic, assign) BOOL handleURLCallbackReturn;
 @property (nonatomic, strong) NSURL *lastHandleURLCallbackURL;
 - (NSString *)getSessionId;
+- (id)getSession;
 - (void)logMParticleApiDiagnostic:(NSString *)code;
 - (BOOL)handleURLCallback:(NSURL *)url;
 @end
@@ -28,6 +30,9 @@ static NSNumber * const kTestRoktKitId = @181;
 @implementation MPRoktTestKitInstance
 - (NSString *)getSessionId {
     return self.sessionIdToReturn;
+}
+- (id)getSession {
+    return self.sessionToReturn;
 }
 - (void)logMParticleApiDiagnostic:(NSString *)code {
     self.lastDiagnosticCode = code;
@@ -1154,6 +1159,37 @@ static NSNumber * const kTestRoktKitId = @181;
     XCTAssertFalse([keysSet containsObject:@"sandbox"]);
 }
 
+#pragma mark - setSession Tests
+
+- (void)testSetSessionForwardsToKitContainer {
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    id session = [[NSObject alloc] init];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for async operation"];
+    SEL roktSelector = @selector(setSession:);
+    OCMExpect([self.mockContainer forwardSDKCall:roktSelector
+                                           event:nil
+                                      parameters:[OCMArg checkWithBlock:^BOOL(MPForwardQueueParameters *params) {
+        XCTAssertEqual(params[0], session);
+        return true;
+    }]
+                                     messageType:MPMessageTypeEvent
+                                        userInfo:nil]).andDo(^(NSInvocation *invocation) {
+        [expectation fulfill];
+    });
+
+    [self.rokt setSession:session];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+
+    OCMVerifyAll(self.mockContainer);
+}
+
 #pragma mark - setSessionId Tests
 
 - (void)testSetSessionIdForwardsToKitContainer {
@@ -1181,7 +1217,10 @@ static NSNumber * const kTestRoktKitId = @181;
     });
 
     // Execute method
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.rokt setSessionId:sessionId];
+#pragma clang diagnostic pop
 
     // Wait for async operation
     [self waitForExpectationsWithTimeout:0.2 handler:nil];
@@ -1223,6 +1262,48 @@ static NSNumber * const kTestRoktKitId = @181;
     OCMVerify([self.mockContainer activeKitsRegistry]);
 }
 
+#pragma mark - getSession Tests
+
+- (void)testGetSessionReturnsSessionFromKit {
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    id mockKitRegister = OCMProtocolMock(@protocol(MPExtensionKitProtocol));
+    OCMStub([(id<MPExtensionKitProtocol>)mockKitRegister code]).andReturn(kTestRoktKitId);
+
+    id expectedSession = [[NSObject alloc] init];
+    MPRoktTestKitInstance *kitInstance = [[MPRoktTestKitInstance alloc] init];
+    kitInstance.sessionToReturn = expectedSession;
+    OCMStub([mockKitRegister wrapperInstance]).andReturn(kitInstance);
+
+    OCMStub([self.mockContainer activeKitsRegistry]).andReturn(@[mockKitRegister]);
+
+    id result = [self.rokt getSession];
+
+    XCTAssertEqual(result, expectedSession, @"Should return the session from the kit");
+}
+
+- (void)testGetSessionReturnsNilWhenKitInstanceIsNil {
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    id mockKitRegister = OCMProtocolMock(@protocol(MPExtensionKitProtocol));
+    OCMStub([(id<MPExtensionKitProtocol>)mockKitRegister code]).andReturn(kTestRoktKitId);
+    OCMStub([mockKitRegister wrapperInstance]).andReturn(nil);
+
+    OCMStub([self.mockContainer activeKitsRegistry]).andReturn(@[mockKitRegister]);
+
+    id result = [self.rokt getSession];
+
+    XCTAssertNil(result, @"Should return nil when kit wrapper instance is nil");
+}
+
 #pragma mark - getSessionId Tests
 
 - (void)testGetSessionIdReturnsSessionIdFromKit {
@@ -1247,7 +1328,10 @@ static NSNumber * const kTestRoktKitId = @181;
     OCMStub([self.mockContainer activeKitsRegistry]).andReturn(activeKits);
 
     // Execute method
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSString *result = [self.rokt getSessionId];
+#pragma clang diagnostic pop
 
     // Verify
     XCTAssertEqualObjects(result, expectedSessionId, @"Should return the session id from the kit");
@@ -1270,7 +1354,10 @@ static NSNumber * const kTestRoktKitId = @181;
     OCMStub([self.mockContainer activeKitsRegistry]).andReturn(activeKits);
 
     // Execute method
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSString *result = [self.rokt getSessionId];
+#pragma clang diagnostic pop
 
     // Verify
     XCTAssertNil(result, @"Should return nil when kit wrapper instance is nil");

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -11,6 +11,7 @@
 @class RoktConfig;
 @class RoktEvent;
 @class RoktPlacementOptions;
+@class RoktSession;
 @protocol RoktPaymentExtension;
 
 @class MPCommerceEvent;
@@ -148,6 +149,10 @@
 - (nonnull MPKitExecStatus *)events:(NSString * _Nonnull)identifier onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent;
 - (nonnull MPKitExecStatus *)globalEvents:(void (^ _Nonnull)(RoktEvent * _Nonnull))onEvent;
 - (nonnull MPKitExecStatus *)registerPaymentExtension:(id<RoktPaymentExtension> _Nonnull)paymentExtension;
+- (nonnull MPKitExecStatus *)setSession:(RoktSession * _Nonnull)session;
+- (nullable RoktSession *)getSession;
+- (nonnull MPKitExecStatus *)setSessionId:(NSString * _Nonnull)sessionId;
+- (nullable NSString *)getSessionId;
 - (nonnull MPKitExecStatus *)selectShoppableAdsWithIdentifier:(nonnull NSString *)identifier
                                                    attributes:(NSDictionary<NSString *, NSString *> * _Nonnull)attributes
                                                        config:(RoktConfig * _Nullable)config

--- a/mParticle-Apple-SDK/Include/MPRokt.h
+++ b/mParticle-Apple-SDK/Include/MPRokt.h
@@ -11,6 +11,7 @@
 @class RoktEmbeddedView;
 @class RoktConfig;
 @class RoktEvent;
+@class RoktSession;
 @protocol RoktPaymentExtension;
 
 /**
@@ -77,22 +78,41 @@
 - (void)close;
 
 /**
+ * Set the session (id + token) to use for the next execute call.
+ * Use this when you have a session from a non-native integration (e.g. WebView)
+ * and want the session — including Bearer authorization for offers and events —
+ * to stay consistent across integrations.
+ *
+ * @param session The session id and JWT session token to apply (optional expiry).
+ */
+- (void)setSession:(RoktSession * _Nonnull)session;
+
+/**
+ * Get the current session (id + token) for use within a non-native integration e.g. WebView.
+ *
+ * @return The session, or nil if the Rokt kit is not active, no session is present, or the persisted token has expired.
+ */
+- (RoktSession * _Nullable)getSession;
+
+/**
  * Set the session id to use for the next execute call.
  * This is useful for cases where you have a session id from a non-native integration,
  * e.g. WebView, and you want the session to be consistent across integrations.
  *
  * @note Empty strings are ignored and will not update the session.
+ * @note Prefer setSession: so the session token is also applied for offers and events.
  *
  * @param sessionId The session id to be set. Must be a non-empty string.
  */
-- (void)setSessionId:(NSString * _Nonnull)sessionId;
+- (void)setSessionId:(NSString * _Nonnull)sessionId DEPRECATED_MSG_ATTRIBUTE("Use setSession: to set session id and session token.");
 
 /**
  * Get the session id to use within a non-native integration e.g. WebView.
  *
  * @return The session id or nil if no session is present.
+ * @note Prefer getSession to also read the session token.
  */
-- (NSString * _Nullable)getSessionId;
+- (NSString * _Nullable)getSessionId DEPRECATED_MSG_ATTRIBUTE("Use getSession to read session id and session token.");
 
 /**
  * Registers a payment extension for Shoppable Ads.

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -208,6 +208,64 @@ static const NSInteger kMPRoktKitId = 181;
     });
 }
 
+/// Set the session (id + token) to use for the next execute call.
+/// Use this when you have a session from a non-native integration (e.g. WebView)
+/// and want the session — including Bearer authorization for offers and events —
+/// to stay consistent across integrations.
+/// - Parameter session: The session id and JWT session token to apply (optional expiry).
+- (void)setSession:(RoktSession * _Nonnull)session {
+    [self logRoktApiDiagnostic:@"ROKT_SET_SESSION"];
+    MPILogDebug(@"MPRokt setSession called - session: %@", session ? @"present" : @"nil");
+    dispatch_async(dispatch_get_main_queue(), ^{
+        MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
+        [queueParameters addParameter:session];
+
+        [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:@selector(setSession:)
+                                                                  event:nil
+                                                             parameters:queueParameters
+                                                            messageType:MPMessageTypeEvent
+                                                               userInfo:nil
+        ];
+    });
+}
+
+/// Get the current session (id + token) for use within a non-native integration e.g. WebView.
+/// - Returns: The session, or nil if the Rokt kit is not active, no session is present, or the persisted token has expired.
+- (RoktSession * _Nullable)getSession {
+    [self logRoktApiDiagnostic:@"ROKT_GET_SESSION"];
+    MPILogDebug(@"MPRokt getSession called");
+    __block RoktSession *result = nil;
+
+    NSArray<id<MPExtensionKitProtocol>> *activeKits = [[MParticle sharedInstance].kitContainer_PRIVATE activeKitsRegistry];
+
+    if (!activeKits || activeKits.count == 0) {
+        MPILogDebug(@"MPRokt getSession - no active kits found");
+        return nil;
+    }
+
+    for (id<MPExtensionKitProtocol> kitRegister in activeKits) {
+        if ([kitRegister.code integerValue] == kMPRoktKitId) {
+            id kitInstance = kitRegister.wrapperInstance;
+            if (kitInstance && [kitInstance respondsToSelector:@selector(getSession)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                result = [kitInstance performSelector:@selector(getSession)];
+#pragma clang diagnostic pop
+                MPILogDebug(@"MPRokt getSession returning: %@", result ? @"session present" : @"nil");
+                break;
+            } else {
+                MPILogDebug(@"MPRokt getSession - kit found but doesn't respond to getSession");
+            }
+        }
+    }
+
+    if (!result) {
+        MPILogDebug(@"MPRokt getSession - Rokt Kit not found in active kits");
+    }
+
+    return result;
+}
+
 /// Set the session id to use for the next execute call.
 /// This is useful for cases where you have a session id from a non-native integration,
 /// e.g. WebView, and you want the session to be consistent across integrations.


### PR DESCRIPTION
## Background
- Hybrid native + WebView integrations need to share more than a Rokt session id. Offers and events authorize with a short-lived session token (Bearer JWT), but MPRokt only exposed setSessionId: / getSessionId, which map to the legacy diagnostics session id and do not seed the token used on the next offers/events call.
- This aligns the mParticle layer with 
[rokt-sdk-ios#280](https://github.com/ROKT/rokt-sdk-ios/pull/280) (RoktSession, setSession, getSession) so partners can hand off session id + token the same way as Web (sessionId / sessionToken).

## What Has Changed
- Added MPRokt.setSession: / getSession (forward-declared RoktSession) and Swift overlays that take/return AnyObject so core does not depend on Rokt-Widget.
- Deprecated setSessionId: / getSessionId; behavior is unchanged.
- Forwarded the new APIs through MPKitRokt and MPKitProtocol. Until a Rokt-Widget release includes #280, a temporary ObjC category (marked to remove after the pin bump) lets the kit compile against the current SDK.
- Added core and kit unit tests for forwarding, kit lookup, and nil-kit paths.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
