### PR TITLE
feat(rokt): forward MPRokt.clearSession to the Rokt SDK

### DIFF
--- a/Kits/rokt/rokt/Package.swift
+++ b/Kits/rokt/rokt/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         mParticleAppleSDK,
         .package(
             url: "https://github.com/ROKT/rokt-sdk-ios",
-            .upToNextMajor(from: "5.3.2")
+            .upToNextMajor(from: "5.4.0")
         ),
         .package(
             url: "https://github.com/ROKT/rokt-contracts-apple.git",

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -117,6 +117,12 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
 
     _started = YES;
 
+    // mParticle forwards identity callbacks only to kits that are already started
+    // (MPKitContainer isActiveAndNotDisabled), so any identify/login/logout that completed while
+    // Rokt was still initialising never reached us. Reconcile against the current user here, or
+    // the first callback we *do* receive looks like a first observation and skips the reset.
+    [self clearRoktSessionIfMpidChanged:[MParticle sharedInstance].identity.currentUser.userId];
+
     dispatch_async(dispatch_get_main_queue(), ^{
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
 
@@ -617,36 +623,32 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
     cannot change the MPID and would never pass the check below.
 */
 - (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfMpidChanged:user];
+    [self clearRoktSessionIfMpidChanged:user.userId];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfMpidChanged:user];
+    [self clearRoktSessionIfMpidChanged:user.userId];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfMpidChanged:user];
+    [self clearRoktSessionIfMpidChanged:user.userId];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
 
-/// Resets the Rokt session when this identity call produced a different MPID than the last one
-/// seen. The first MPID ever observed is recorded without resetting: there is no previous customer
-/// to separate from, and resetting there would discard a session the host app may have only just
-/// established.
-- (void)clearRoktSessionIfMpidChanged:(FilteredMParticleUser *)user {
-    NSNumber *mpid = user.userId;
+/// Resets the Rokt session when [mpid] differs from the last one this kit acted on. The first MPID
+/// ever observed is recorded without resetting: there is no previous customer to separate from.
+///
+/// Persisted rather than held in memory so a terminal relaunched mid-queue still recognises the
+/// next customer as a different person.
+- (void)clearRoktSessionIfMpidChanged:(NSNumber *)mpid {
     if (mpid == nil || [mpid isKindOfClass:[NSNull class]]) {
         return;
     }
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSNumber *lastSeenMpid = [defaults objectForKey:kMPRoktLastSeenMpidKey];
-    // Recorded unconditionally, and deliberately before any readiness check. Identity callbacks
-    // routinely land before Rokt finishes initialising; skipping the write there would leave the
-    // *next* customer looking like the first observation, so their arrival would not reset and
-    // they would inherit the previous customer's session.
     [defaults setObject:mpid forKey:kMPRoktLastSeenMpidKey];
 
     if (lastSeenMpid == nil) {
@@ -659,9 +661,6 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
     }
 
     [MPKitRokt MPLog:@"Rokt Kit detected an MPID change; resetting the Rokt session"];
-    // No `started` check: clearing only touches stored session state, so it is safe before Rokt
-    // finishes initialising, and it is exactly what a terminal relaunched mid-queue needs — a
-    // session persisted for the previous customer is dropped rather than restored.
     [MPKitRokt clearRoktSession];
 }
 

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -38,18 +38,6 @@ static __weak MPKitRokt *roktKit = nil;
 
 @end
 
-// Last MPID this kit acted on. Persisted rather than held in memory so an app relaunched
-// mid-queue on a shared terminal still recognises the next customer as a different person; an
-// in-memory value would reset to nil on launch, read as a first observation, and let that
-// customer inherit the previous one's Rokt session.
-static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid";
-
-// Whether the last-seen user was identified (held any user identity, or was logged in).
-// This types the MPID transition: an anonymous user acquiring an identity is the SAME person
-// being named (payment page → confirmation page), so the Rokt session must survive it; only a
-// KNOWN user leaving — replaced by another user or logged out — ends the session.
-static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSeenMpidWasIdentified";
-
 @implementation MPKitRokt
 
 /*
@@ -122,16 +110,6 @@ static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSe
     }
 
     _started = YES;
-
-    // mParticle forwards identity callbacks only to kits that are already started
-    // (MPKitContainer isActiveAndNotDisabled), so any identify/login/logout that completed while
-    // Rokt was still initialising never reached us. Reconcile against the current user here, or
-    // the first callback we *do* receive looks like a first observation and skips the reset.
-    MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
-    if (currentUser != nil) {
-        [self clearRoktSessionIfKnownUserChanged:currentUser.userId
-                                    isIdentified:[MPKitRokt isIdentifiedUser:currentUser]];
-    }
 
     dispatch_async(dispatch_get_main_queue(), ^{
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
@@ -601,190 +579,19 @@ static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSe
     return [Rokt getSessionId];
 }
 
-/// End the current Rokt session so the next placement starts a new one.
+/// End the current Rokt session so the next selectPlacements call starts a new one.
 ///
-/// Reached either from MPRokt.clearSession (host-driven) or from the identity and session
-/// triggers below.
+/// Reached only from MPRokt.clearSession — the host names the transaction boundary itself. The
+/// kit deliberately does not infer boundaries from identity or session callbacks: those fire for
+/// every partner on this kit, and a login or logout is not reliably a change of person.
+///
+/// Fire-and-forget, mirroring close: the Rokt SDK performs the reset (flush buffered events,
+/// then drop the session) synchronously on its side, so there is nothing to return here.
 - (MPKitExecStatus *)clearSession {
-    [MPKitRokt clearRoktSession];
-    return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
-}
-
-/// Single funnel for every reset trigger, so the ordering guarantees inside the Rokt SDK
-/// (flush buffered events, then drop the session) are exercised identically by all of them.
-+ (void)clearRoktSession {
     [MPKitRokt MPLog:@"Rokt Kit clearing the Rokt session"];
     [Rokt clearSession];
-}
-
-#pragma mark - Identity
-
-/*
-    The MPID transition is TYPED — not every change of MPID means a different person:
-
-      anonymous → known   same person acquiring an identity (unknown on the payment page,
-                          known on the confirmation page) — the session MUST survive, or a
-                          single shopper's journey is split and attribution breaks.
-      known → known′      a different person (the kiosk case) — reset.
-      known → anonymous   a logout — the known user departed — reset.
-      anonymous → anon′   placeholder churn — nobody was known — no-op.
-
-    So the reset condition is "a KNOWN user left", not "the MPID moved". "Known" means the user
-    held any user identity or was logged in; identity-set emptiness is used rather than
-    isLoggedIn alone because kiosk customers identify() without ever logging in.
-
-    The kit is never told "the MPID changed" directly: MPIdentityApi fires that branch internally
-    and then forwards the identity completion unconditionally. So the comparison is made here,
-    against the last MPID this kit acted on.
-
-    onModifyComplete is implemented for the identified flag alone. modify() resolves through
-    onModifyRequestComplete with a response carrying no mpid, so it can never change the MPID and
-    never reaches the reset below — but it IS how a host attaches an email or customer id to the
-    current user. Without it, an anonymous MPID that later acquires an identity stays recorded as
-    anonymous, and the next customer's arrival reads as anonymous churn and skips the reset.
-*/
-- (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
-
-- (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
-    return [self execStatus:MPKitReturnCodeSuccess];
-}
-
-- (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
-    return [self execStatus:MPKitReturnCodeSuccess];
-}
-
-- (MPKitExecStatus *)onModifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
-    return [self execStatus:MPKitReturnCodeSuccess];
-}
-
-/// A user is "identified" when they hold any USER identity (email, customer id, …) or are logged
-/// in. Both identity dictionaries include device identities (IDFV, push token, device application
-/// stamp — every key from MPIdentityIOSAdvertiserId up), which exist for anonymous users too, so
-/// counting the raw dictionary would make everyone read as known. Only user-identity keys count.
-+ (BOOL)isIdentifiedFromIdentities:(NSDictionary<NSNumber *, NSString *> *)identities
-                        isLoggedIn:(BOOL)isLoggedIn {
-    if (isLoggedIn) {
-        return YES;
-    }
-    for (NSNumber *identityType in identities) {
-        if (identityType.unsignedIntegerValue < MPIdentityIOSAdvertiserId) {
-            return YES;
-        }
-    }
-    return NO;
-}
-
-+ (BOOL)isIdentifiedFilteredUser:(FilteredMParticleUser *)user {
-    if ([MPKitRokt isIdentifiedFromIdentities:user.userIdentities isLoggedIn:user.isLoggedIn]) {
-        return YES;
-    }
-
-    // FilteredMParticleUser.userIdentities drops kit-filtered and data-plan-blocked identities, so
-    // it can only ever under-report: a NO here may just mean the partner filtered email/customer id
-    // off this kit, which would make every known user read as anonymous and stop the reset from
-    // ever firing. Re-check against the unfiltered current user — the same source `start` uses, so
-    // the two paths agree — but only when it is demonstrably the same user this callback is about,
-    // since kit forwarding is dispatched async and currentUser may already have moved on.
-    MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
-    if (currentUser != nil && currentUser.userId != nil && [currentUser.userId isEqualToNumber:user.userId]) {
-        return [MPKitRokt isIdentifiedUser:currentUser];
-    }
-
-    return NO;
-}
-
-+ (BOOL)isIdentifiedUser:(MParticleUser *)user {
-    return [MPKitRokt isIdentifiedFromIdentities:user.identities isLoggedIn:user.isLoggedIn];
-}
-
-/// Resets the Rokt session when a KNOWN user is replaced or departs. The first MPID ever observed
-/// is recorded without resetting: there is no previous customer to separate from. An anonymous
-/// user acquiring an identity is the same person and never resets.
-///
-/// Persisted rather than held in memory so a terminal relaunched mid-queue still recognises the
-/// next customer as a different person.
-- (void)clearRoktSessionIfKnownUserChanged:(NSNumber *)mpid isIdentified:(BOOL)isIdentified {
-    // 0 is mParticle's "no MPID assigned yet" sentinel, not a customer. Recording it would make
-    // the first real identify look like a change and drop a session the host had already opened.
-    if (mpid == nil || [mpid isKindOfClass:[NSNull class]] || mpid.longLongValue == 0) {
-        return;
-    }
-
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSNumber *lastSeenMpid = [defaults objectForKey:kMPRoktLastSeenMpidKey];
-    BOOL lastSeenIdentified = [defaults boolForKey:kMPRoktLastSeenIdentifiedKey];
-    BOOL sameMpid = (lastSeenMpid != nil && [lastSeenMpid isEqualToNumber:mpid]);
-
-    // The flag answers "did a known person occupy this device", so within one MPID it only ever
-    // ratchets up. A user who identified and later had an identity removed still needs their
-    // departure to reset, and no single under-reporting read can downgrade an established YES.
-    [defaults setObject:mpid forKey:kMPRoktLastSeenMpidKey];
-    [defaults setBool:(sameMpid ? (lastSeenIdentified || isIdentified) : isIdentified)
-               forKey:kMPRoktLastSeenIdentifiedKey];
-
-    if (lastSeenMpid == nil) {
-        [MPKitRokt MPLog:@"Rokt Kit recording first observed MPID; no session reset"];
-        return;
-    }
-
-    if (sameMpid) {
-        return;
-    }
-
-    if (!lastSeenIdentified) {
-        [MPKitRokt MPLog:@"Rokt Kit: anonymous user was identified; keeping the Rokt session"];
-        return;
-    }
-
-    [MPKitRokt MPLog:@"Rokt Kit: known user changed; resetting the Rokt session"];
-    [MPKitRokt clearRoktSession];
-}
-
-#pragma mark - Session
-
-/*
-    Session boundaries are honoured only when the host app drives sessions itself
-    (automaticSessionTracking == NO). Under automatic tracking a session ends after the app has
-    been in the *background* past a 60s timeout — a statement about app lifecycle, not about who is
-    using the device — and a terminal pinned in the foreground never triggers it at all. Acting on
-    automatic sessions would fragment sessions for every existing partner while doing nothing for
-    the case this exists to solve.
-
-    Both begin and end are wired. A host rotating sessions per transaction must call endSession
-    then beginSession (beginSession is a no-op while a session exists), and honouring begin as well
-    guarantees a clean slate when a previous transaction ended abnormally. The redundant reset that
-    follows an end/begin pair is harmless: Rokt.clearSession is idempotent.
-*/
-- (MPKitExecStatus *)beginSession {
-    [self clearRoktSessionOnManualSessionBoundary];
-    return [self execStatus:MPKitReturnCodeSuccess];
-}
-
-- (MPKitExecStatus *)endSession {
-    [self clearRoktSessionOnManualSessionBoundary];
-    return [self execStatus:MPKitReturnCodeSuccess];
-}
-
-- (void)clearRoktSessionOnManualSessionBoundary {
-    if (!self.started) {
-        return;
-    }
-
-    if ([MParticle sharedInstance].automaticSessionTracking) {
-        return;
-    }
-
-    [MPKitRokt MPLog:@"Rokt Kit reached a manual session boundary; resetting the Rokt session"];
-    [MPKitRokt clearRoktSession];
-}
-
-#pragma mark - Diagnostics
 
 /// Forwards a bounded public-API-usage diagnostic code from mParticle core into the Rokt SDK.
 - (void)logMParticleApiDiagnostic:(NSString *)code {

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -44,6 +44,12 @@ static __weak MPKitRokt *roktKit = nil;
 // customer inherit the previous one's Rokt session.
 static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid";
 
+// Whether the last-seen user was identified (held any user identity, or was logged in).
+// This types the MPID transition: an anonymous user acquiring an identity is the SAME person
+// being named (payment page → confirmation page), so the Rokt session must survive it; only a
+// KNOWN user leaving — replaced by another user or logged out — ends the session.
+static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSeenMpidWasIdentified";
+
 @implementation MPKitRokt
 
 /*
@@ -121,7 +127,11 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
     // (MPKitContainer isActiveAndNotDisabled), so any identify/login/logout that completed while
     // Rokt was still initialising never reached us. Reconcile against the current user here, or
     // the first callback we *do* receive looks like a first observation and skips the reset.
-    [self clearRoktSessionIfMpidChanged:[MParticle sharedInstance].identity.currentUser.userId];
+    MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
+    if (currentUser != nil) {
+        [self clearRoktSessionIfKnownUserChanged:currentUser.userId
+                                    isIdentified:[MPKitRokt isIdentifiedUser:currentUser]];
+    }
 
     dispatch_async(dispatch_get_main_queue(), ^{
         NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
@@ -610,9 +620,18 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
 #pragma mark - Identity
 
 /*
-    A change of MPID means a different person is using the device. On a self-service terminal —
-    a kiosk, counter tablet or shared point-of-sale device — that is the transaction boundary, so
-    the Rokt session must end or the next customer is folded into the previous customer's session.
+    The MPID transition is TYPED — not every change of MPID means a different person:
+
+      anonymous → known   same person acquiring an identity (unknown on the payment page,
+                          known on the confirmation page) — the session MUST survive, or a
+                          single shopper's journey is split and attribution breaks.
+      known → known′      a different person (the kiosk case) — reset.
+      known → anonymous   a logout — the known user departed — reset.
+      anonymous → anon′   placeholder churn — nobody was known — no-op.
+
+    So the reset condition is "a KNOWN user left", not "the MPID moved". "Known" means the user
+    held any user identity or was logged in; identity-set emptiness is used rather than
+    isLoggedIn alone because kiosk customers identify() without ever logging in.
 
     The kit is never told "the MPID changed" directly: MPIdentityApi fires that branch internally
     and then forwards the identity completion unconditionally. So the comparison is made here,
@@ -623,26 +642,52 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
     cannot change the MPID and would never pass the check below.
 */
 - (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfMpidChanged:user.userId];
+    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfMpidChanged:user.userId];
+    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-    [self clearRoktSessionIfMpidChanged:user.userId];
+    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
 
-/// Resets the Rokt session when [mpid] differs from the last one this kit acted on. The first MPID
-/// ever observed is recorded without resetting: there is no previous customer to separate from.
+/// A user is "identified" when they hold any USER identity (email, customer id, …) or are logged
+/// in. Both identity dictionaries include device identities (IDFV, push token, device application
+/// stamp — every key from MPIdentityIOSAdvertiserId up), which exist for anonymous users too, so
+/// counting the raw dictionary would make everyone read as known. Only user-identity keys count.
++ (BOOL)isIdentifiedFromIdentities:(NSDictionary<NSNumber *, NSString *> *)identities
+                        isLoggedIn:(BOOL)isLoggedIn {
+    if (isLoggedIn) {
+        return YES;
+    }
+    for (NSNumber *identityType in identities) {
+        if (identityType.unsignedIntegerValue < MPIdentityIOSAdvertiserId) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
++ (BOOL)isIdentifiedFilteredUser:(FilteredMParticleUser *)user {
+    return [MPKitRokt isIdentifiedFromIdentities:user.userIdentities isLoggedIn:user.isLoggedIn];
+}
+
++ (BOOL)isIdentifiedUser:(MParticleUser *)user {
+    return [MPKitRokt isIdentifiedFromIdentities:user.identities isLoggedIn:user.isLoggedIn];
+}
+
+/// Resets the Rokt session when a KNOWN user is replaced or departs. The first MPID ever observed
+/// is recorded without resetting: there is no previous customer to separate from. An anonymous
+/// user acquiring an identity is the same person and never resets.
 ///
 /// Persisted rather than held in memory so a terminal relaunched mid-queue still recognises the
 /// next customer as a different person.
-- (void)clearRoktSessionIfMpidChanged:(NSNumber *)mpid {
+- (void)clearRoktSessionIfKnownUserChanged:(NSNumber *)mpid isIdentified:(BOOL)isIdentified {
     // 0 is mParticle's "no MPID assigned yet" sentinel, not a customer. Recording it would make
     // the first real identify look like a change and drop a session the host had already opened.
     if (mpid == nil || [mpid isKindOfClass:[NSNull class]] || mpid.longLongValue == 0) {
@@ -651,7 +696,9 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSNumber *lastSeenMpid = [defaults objectForKey:kMPRoktLastSeenMpidKey];
+    BOOL lastSeenIdentified = [defaults boolForKey:kMPRoktLastSeenIdentifiedKey];
     [defaults setObject:mpid forKey:kMPRoktLastSeenMpidKey];
+    [defaults setBool:isIdentified forKey:kMPRoktLastSeenIdentifiedKey];
 
     if (lastSeenMpid == nil) {
         [MPKitRokt MPLog:@"Rokt Kit recording first observed MPID; no session reset"];
@@ -662,7 +709,12 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
         return;
     }
 
-    [MPKitRokt MPLog:@"Rokt Kit detected an MPID change; resetting the Rokt session"];
+    if (!lastSeenIdentified) {
+        [MPKitRokt MPLog:@"Rokt Kit: anonymous user was identified; keeping the Rokt session"];
+        return;
+    }
+
+    [MPKitRokt MPLog:@"Rokt Kit: known user changed; resetting the Rokt session"];
     [MPKitRokt clearRoktSession];
 }
 

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -643,7 +643,9 @@ static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid
 /// Persisted rather than held in memory so a terminal relaunched mid-queue still recognises the
 /// next customer as a different person.
 - (void)clearRoktSessionIfMpidChanged:(NSNumber *)mpid {
-    if (mpid == nil || [mpid isKindOfClass:[NSNull class]]) {
+    // 0 is mParticle's "no MPID assigned yet" sentinel, not a customer. Recording it would make
+    // the first real identify look like a change and drop a session the host had already opened.
+    if (mpid == nil || [mpid isKindOfClass:[NSNull class]] || mpid.longLongValue == 0) {
         return;
     }
 

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -38,6 +38,12 @@ static __weak MPKitRokt *roktKit = nil;
 
 @end
 
+// Last MPID this kit acted on. Persisted rather than held in memory so an app relaunched
+// mid-queue on a shared terminal still recognises the next customer as a different person; an
+// in-memory value would reset to nil on launch, read as a first observation, and let that
+// customer inherit the previous one's Rokt session.
+static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid";
+
 @implementation MPKitRokt
 
 /*
@@ -578,6 +584,126 @@ static __weak MPKitRokt *roktKit = nil;
 - (NSString *)getSessionId {
     return [Rokt getSessionId];
 }
+
+/// End the current Rokt session so the next placement starts a new one.
+///
+/// Reached either from MPRokt.clearSession (host-driven) or from the identity and session
+/// triggers below.
+- (MPKitExecStatus *)clearSession {
+    [MPKitRokt clearRoktSession];
+    return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
+}
+
+/// Single funnel for every reset trigger, so the ordering guarantees inside the Rokt SDK
+/// (flush buffered events, then drop the session) are exercised identically by all of them.
++ (void)clearRoktSession {
+    [MPKitRokt MPLog:@"Rokt Kit clearing the Rokt session"];
+    [Rokt clearSession];
+}
+
+#pragma mark - Identity
+
+/*
+    A change of MPID means a different person is using the device. On a self-service terminal —
+    a kiosk, counter tablet or shared point-of-sale device — that is the transaction boundary, so
+    the Rokt session must end or the next customer is folded into the previous customer's session.
+
+    The kit is never told "the MPID changed" directly: MPIdentityApi fires that branch internally
+    and then forwards the identity completion unconditionally. So the comparison is made here,
+    against the last MPID this kit acted on.
+
+    onModifyComplete is deliberately not implemented: modify() resolves through
+    onModifyRequestComplete with a response carrying no mpid and forwards the current user, so it
+    cannot change the MPID and would never pass the check below.
+*/
+- (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
+    [self clearRoktSessionIfMpidChanged:user];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
+    [self clearRoktSessionIfMpidChanged:user];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
+    [self clearRoktSessionIfMpidChanged:user];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+/// Resets the Rokt session when this identity call produced a different MPID than the last one
+/// seen. The first MPID ever observed is recorded without resetting: there is no previous customer
+/// to separate from, and resetting there would discard a session the host app may have only just
+/// established.
+- (void)clearRoktSessionIfMpidChanged:(FilteredMParticleUser *)user {
+    NSNumber *mpid = user.userId;
+    if (mpid == nil || [mpid isKindOfClass:[NSNull class]]) {
+        return;
+    }
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSNumber *lastSeenMpid = [defaults objectForKey:kMPRoktLastSeenMpidKey];
+    // Recorded unconditionally, and deliberately before any readiness check. Identity callbacks
+    // routinely land before Rokt finishes initialising; skipping the write there would leave the
+    // *next* customer looking like the first observation, so their arrival would not reset and
+    // they would inherit the previous customer's session.
+    [defaults setObject:mpid forKey:kMPRoktLastSeenMpidKey];
+
+    if (lastSeenMpid == nil) {
+        [MPKitRokt MPLog:@"Rokt Kit recording first observed MPID; no session reset"];
+        return;
+    }
+
+    if ([lastSeenMpid isEqualToNumber:mpid]) {
+        return;
+    }
+
+    [MPKitRokt MPLog:@"Rokt Kit detected an MPID change; resetting the Rokt session"];
+    // No `started` check: clearing only touches stored session state, so it is safe before Rokt
+    // finishes initialising, and it is exactly what a terminal relaunched mid-queue needs — a
+    // session persisted for the previous customer is dropped rather than restored.
+    [MPKitRokt clearRoktSession];
+}
+
+#pragma mark - Session
+
+/*
+    Session boundaries are honoured only when the host app drives sessions itself
+    (automaticSessionTracking == NO). Under automatic tracking a session ends after the app has
+    been in the *background* past a 60s timeout — a statement about app lifecycle, not about who is
+    using the device — and a terminal pinned in the foreground never triggers it at all. Acting on
+    automatic sessions would fragment sessions for every existing partner while doing nothing for
+    the case this exists to solve.
+
+    Both begin and end are wired. A host rotating sessions per transaction must call endSession
+    then beginSession (beginSession is a no-op while a session exists), and honouring begin as well
+    guarantees a clean slate when a previous transaction ended abnormally. The redundant reset that
+    follows an end/begin pair is harmless: Rokt.clearSession is idempotent.
+*/
+- (MPKitExecStatus *)beginSession {
+    [self clearRoktSessionOnManualSessionBoundary];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (MPKitExecStatus *)endSession {
+    [self clearRoktSessionOnManualSessionBoundary];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (void)clearRoktSessionOnManualSessionBoundary {
+    if (!self.started) {
+        return;
+    }
+
+    if ([MParticle sharedInstance].automaticSessionTracking) {
+        return;
+    }
+
+    [MPKitRokt MPLog:@"Rokt Kit reached a manual session boundary; resetting the Rokt session"];
+    [MPKitRokt clearRoktSession];
+}
+
+#pragma mark - Diagnostics
 
 /// Forwards a bounded public-API-usage diagnostic code from mParticle core into the Rokt SDK.
 - (void)logMParticleApiDiagnostic:(NSString *)code {

--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -637,9 +637,11 @@ static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSe
     and then forwards the identity completion unconditionally. So the comparison is made here,
     against the last MPID this kit acted on.
 
-    onModifyComplete is deliberately not implemented: modify() resolves through
-    onModifyRequestComplete with a response carrying no mpid and forwards the current user, so it
-    cannot change the MPID and would never pass the check below.
+    onModifyComplete is implemented for the identified flag alone. modify() resolves through
+    onModifyRequestComplete with a response carrying no mpid, so it can never change the MPID and
+    never reaches the reset below — but it IS how a host attaches an email or customer id to the
+    current user. Without it, an anonymous MPID that later acquires an identity stays recorded as
+    anonymous, and the next customer's arrival reads as anonymous churn and skips the reset.
 */
 - (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
     [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
@@ -652,6 +654,11 @@ static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSe
 }
 
 - (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
+    [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (MPKitExecStatus *)onModifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
     [self clearRoktSessionIfKnownUserChanged:user.userId isIdentified:[MPKitRokt isIdentifiedFilteredUser:user]];
     return [self execStatus:MPKitReturnCodeSuccess];
 }
@@ -674,7 +681,22 @@ static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSe
 }
 
 + (BOOL)isIdentifiedFilteredUser:(FilteredMParticleUser *)user {
-    return [MPKitRokt isIdentifiedFromIdentities:user.userIdentities isLoggedIn:user.isLoggedIn];
+    if ([MPKitRokt isIdentifiedFromIdentities:user.userIdentities isLoggedIn:user.isLoggedIn]) {
+        return YES;
+    }
+
+    // FilteredMParticleUser.userIdentities drops kit-filtered and data-plan-blocked identities, so
+    // it can only ever under-report: a NO here may just mean the partner filtered email/customer id
+    // off this kit, which would make every known user read as anonymous and stop the reset from
+    // ever firing. Re-check against the unfiltered current user — the same source `start` uses, so
+    // the two paths agree — but only when it is demonstrably the same user this callback is about,
+    // since kit forwarding is dispatched async and currentUser may already have moved on.
+    MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
+    if (currentUser != nil && currentUser.userId != nil && [currentUser.userId isEqualToNumber:user.userId]) {
+        return [MPKitRokt isIdentifiedUser:currentUser];
+    }
+
+    return NO;
 }
 
 + (BOOL)isIdentifiedUser:(MParticleUser *)user {
@@ -697,15 +719,21 @@ static NSString * const kMPRoktLastSeenIdentifiedKey = @"mParticle::rokt::lastSe
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSNumber *lastSeenMpid = [defaults objectForKey:kMPRoktLastSeenMpidKey];
     BOOL lastSeenIdentified = [defaults boolForKey:kMPRoktLastSeenIdentifiedKey];
+    BOOL sameMpid = (lastSeenMpid != nil && [lastSeenMpid isEqualToNumber:mpid]);
+
+    // The flag answers "did a known person occupy this device", so within one MPID it only ever
+    // ratchets up. A user who identified and later had an identity removed still needs their
+    // departure to reset, and no single under-reporting read can downgrade an established YES.
     [defaults setObject:mpid forKey:kMPRoktLastSeenMpidKey];
-    [defaults setBool:isIdentified forKey:kMPRoktLastSeenIdentifiedKey];
+    [defaults setBool:(sameMpid ? (lastSeenIdentified || isIdentified) : isIdentified)
+               forKey:kMPRoktLastSeenIdentifiedKey];
 
     if (lastSeenMpid == nil) {
         [MPKitRokt MPLog:@"Rokt Kit recording first observed MPID; no session reset"];
         return;
     }
 
-    if ([lastSeenMpid isEqualToNumber:mpid]) {
+    if (sameMpid) {
         return;
     }
 

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -24,7 +24,6 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 - (MPKitExecStatus *)setSessionId:(NSString *)sessionId;
 - (NSString *)getSessionId;
-- (MPKitExecStatus *)clearSession;
 
 - (NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable)confirmEmbeddedViews:(NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable)embeddedViews;
 
@@ -929,7 +928,12 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
     OCMExpect([mockRoktSDK clearSession]);
 
-    MPKitExecStatus *status = [self.kitInstance clearSession];
+    // Invoked dynamically on purpose. Declaring -clearSession on MPKitRokt here would put a
+    // second `clearSession` with a different return type in this translation unit, alongside
+    // Rokt's +clearSession, and sending it to OCMock's id receiver above then fails to compile
+    // with "multiple methods named 'clearSession' ... mismatched result". A selector carries no
+    // return type, so this stays unambiguous.
+    MPKitExecStatus *status = [self.kitInstance performSelector:@selector(clearSession)];
 
     XCTAssertNotNil(status);
     XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -7,6 +7,11 @@
 static NSInteger const kMPRoktKitCode = 181;
 static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserIdentityType";
 
+// Mirrored from MPKitRokt.m — the session-boundary state is persisted, so every test in this file
+// must start from a clean slate or the transition assertions become order-dependent.
+static NSString * const kTestLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid";
+static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeenMpidWasIdentified";
+
 @interface MPKitRokt ()
 
 - (MPKitExecStatus *)selectPlacementsWithIdentifier:(NSString * _Nullable)identifier
@@ -61,6 +66,14 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 - (void)stop;
 
+- (void)start;
+- (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
+- (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
+- (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
+- (MPKitExecStatus *)onModifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
+- (MPKitExecStatus *)beginSession;
+- (MPKitExecStatus *)endSession;
+
 @end
 
 @interface mParticle_RoktTests : XCTestCase
@@ -76,12 +89,20 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     [super setUp];
     self.kitInstance = [[MPKitRokt alloc] init];
     self.configuration = @{@"accountId": @"test_account_id"};
+    [self clearPersistedSessionBoundaryState];
 }
 
 - (void)tearDown {
+    [self clearPersistedSessionBoundaryState];
     self.kitInstance = nil;
     self.configuration = nil;
     [super tearDown];
+}
+
+- (void)clearPersistedSessionBoundaryState {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults removeObjectForKey:kTestLastSeenMpidKey];
+    [defaults removeObjectForKey:kTestLastSeenIdentifiedKey];
 }
 
 - (void)testKitCode {
@@ -1247,6 +1268,275 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     [mockRoktSDK stopMocking];
     [mockMParticleClass stopMocking];
     [mockMParticleInstance stopMocking];
+}
+
+#pragma mark - Session boundary helpers
+
+/// A stubbed FilteredMParticleUser. `identities` is what the kit sees AFTER kit-config and
+/// data-plan filtering, which is the distinction several of the tests below turn on.
+- (id)filteredUserWithMpid:(long long)mpid
+                identities:(NSDictionary<NSNumber *, NSString *> *)identities
+                isLoggedIn:(BOOL)isLoggedIn {
+    FilteredMParticleUser *user = [[FilteredMParticleUser alloc] init];
+    id mockUser = OCMPartialMock(user);
+    [[[mockUser stub] andReturn:@(mpid)] userId];
+    [[[mockUser stub] andReturn:identities] userIdentities];
+    [[[mockUser stub] andReturnValue:@(isLoggedIn)] isLoggedIn];
+    return mockUser;
+}
+
+- (id)knownUserWithMpid:(long long)mpid {
+    return [self filteredUserWithMpid:mpid
+                           identities:@{@(MPIdentityEmail): @"customer@example.com"}
+                           isLoggedIn:NO];
+}
+
+/// Anonymous users still carry device identities, which is why the kit counts only user-identity
+/// keys rather than the raw dictionary being non-empty.
+- (id)anonymousUserWithMpid:(long long)mpid {
+    return [self filteredUserWithMpid:mpid
+                           identities:@{@(MPIdentityIOSVendorId): @"test-idfv",
+                                        @(MPIdentityDeviceApplicationStamp): @"test-das"}
+                           isLoggedIn:NO];
+}
+
+#pragma mark - Identity transition tests
+
+- (void)testIdentity_FirstObservedMpid_RecordsWithoutReset {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    OCMReject([mockRoktSDK clearSession]);
+
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
+
+    XCTAssertEqualObjects([[NSUserDefaults standardUserDefaults] objectForKey:kTestLastSeenMpidKey], @100);
+    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testIdentity_AnonymousToKnown_KeepsSession {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
+
+    // The same shopper acquiring an identity mid-journey — unknown on the payment page, known on
+    // the confirmation page. Severing here would split one person's attribution.
+    OCMReject([mockRoktSDK clearSession]);
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testIdentity_KnownToDifferentKnown_ResetsSession {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
+
+    // The kiosk case: one customer finishes, the next steps up to the same terminal.
+    OCMExpect([mockRoktSDK clearSession]);
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testIdentity_KnownToAnonymousLogout_ResetsSession {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
+
+    OCMExpect([mockRoktSDK clearSession]);
+    [self.kitInstance onLogoutComplete:[self anonymousUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testIdentity_AnonymousToAnonymous_KeepsSession {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
+
+    // Placeholder churn — nobody was ever known, so there is no customer boundary here.
+    OCMReject([mockRoktSDK clearSession]);
+    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testIdentity_SentinelMpidZero_IsNotRecorded {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    OCMReject([mockRoktSDK clearSession]);
+
+    // 0 is mParticle's "no MPID assigned yet" sentinel. Recording it would make the first real
+    // identify look like a customer change and drop a session the host had already opened.
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:0] request:nil];
+
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kTestLastSeenMpidKey]);
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testOnLoginComplete_KnownToDifferentKnown_ResetsSession {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    // login() forwards onLoginComplete and ONLY that — onIdentifyComplete does not fire for a
+    // login, so a partner who uses login() for the returning customer needs this override or the
+    // transition is never observed.
+    [self.kitInstance onLoginComplete:[self knownUserWithMpid:100] request:nil];
+
+    OCMExpect([mockRoktSDK clearSession]);
+    [self.kitInstance onLoginComplete:[self knownUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+#pragma mark - onModifyComplete
+
+- (void)testOnModifyComplete_MarksIdentifiedWithoutResetting {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    OCMReject([mockRoktSDK clearSession]);
+
+    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
+    XCTAssertFalse([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
+
+    // modify() cannot change the MPID, so it must never reset — but it IS how a host attaches an
+    // email to the current user, so it must upgrade the identified flag.
+    [self.kitInstance onModifyComplete:[self knownUserWithMpid:100] request:nil];
+
+    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testOnModifyComplete_IdentityAttachedByModify_StillResetsForNextCustomer {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    // The regression this guards: without onModifyComplete the kit still believes MPID 100 was
+    // anonymous, so customer 2 below reads as anonymous churn and inherits customer 1's session.
+    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
+    [self.kitInstance onModifyComplete:[self knownUserWithMpid:100] request:nil];
+
+    OCMExpect([mockRoktSDK clearSession]);
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+#pragma mark - Filtered identities
+
+- (void)testIdentity_FilteredIdentitiesFallBackToUnfilteredCurrentUser {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    // A partner who filters email off this kit sees an EMPTY filtered identity set for a user who
+    // is genuinely known. Taken at face value that records them as anonymous and no later
+    // transition ever resets.
+    MParticleUser *currentUser = [[MParticleUser alloc] init];
+    id mockCurrentUser = OCMPartialMock(currentUser);
+    [[[mockCurrentUser stub] andReturn:@100] userId];
+    [[[mockCurrentUser stub] andReturn:@{@(MPIdentityEmail): @"customer@example.com"}] identities];
+    [[[mockCurrentUser stub] andReturnValue:@NO] isLoggedIn];
+
+    id mockIdentityApi = OCMClassMock([MPIdentityApi class]);
+    OCMStub([mockIdentityApi currentUser]).andReturn(mockCurrentUser);
+    id mockMParticleInstance = OCMClassMock([MParticle class]);
+    OCMStub([(MParticle *)mockMParticleInstance identity]).andReturn(mockIdentityApi);
+    id mockMParticleClass = OCMClassMock([MParticle class]);
+    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
+
+    id filteredButKnown = [self filteredUserWithMpid:100 identities:@{} isLoggedIn:NO];
+    [self.kitInstance onIdentifyComplete:filteredButKnown request:nil];
+
+    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey],
+                  @"A user filtered down to no identities must still resolve as known via the unfiltered current user");
+
+    [mockMParticleClass stopMocking];
+    [mockMParticleInstance stopMocking];
+    [mockIdentityApi stopMocking];
+    [mockCurrentUser stopMocking];
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testIdentity_IdentifiedFlagIsNotDowngradedWithinOneMpid {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
+    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
+
+    // A second, under-reporting read of the SAME user must not erase the fact that a known person
+    // occupied this device — otherwise their departure would stop resetting.
+    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
+    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
+
+    OCMExpect([mockRoktSDK clearSession]);
+    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+#pragma mark - Manual session boundaries
+
+- (void)testSessionBoundary_IgnoredUnderAutomaticSessionTracking {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    id mockMParticleInstance = OCMClassMock([MParticle class]);
+    OCMStub([(MParticle *)mockMParticleInstance automaticSessionTracking]).andReturn(YES);
+    OCMStub([(MParticle *)mockMParticleInstance identity]).andReturn(nil);
+    id mockMParticleClass = OCMClassMock([MParticle class]);
+    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
+
+    [self.kitInstance start];
+
+    // Under automatic tracking a session ends after a BACKGROUND timeout — a statement about app
+    // lifecycle, not about who is using the device. Acting on it would fragment sessions for every
+    // existing partner.
+    OCMReject([mockRoktSDK clearSession]);
+    [self.kitInstance endSession];
+    [self.kitInstance beginSession];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockMParticleClass stopMocking];
+    [mockMParticleInstance stopMocking];
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testSessionBoundary_ResetsWhenHostDrivesSessions {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    id mockMParticleInstance = OCMClassMock([MParticle class]);
+    OCMStub([(MParticle *)mockMParticleInstance automaticSessionTracking]).andReturn(NO);
+    OCMStub([(MParticle *)mockMParticleInstance identity]).andReturn(nil);
+    id mockMParticleClass = OCMClassMock([MParticle class]);
+    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
+
+    [self.kitInstance start];
+
+    OCMExpect([mockRoktSDK clearSession]);
+    [self.kitInstance endSession];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockMParticleClass stopMocking];
+    [mockMParticleInstance stopMocking];
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testSessionBoundary_IgnoredBeforeKitStarts {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    id mockMParticleInstance = OCMClassMock([MParticle class]);
+    OCMStub([(MParticle *)mockMParticleInstance automaticSessionTracking]).andReturn(NO);
+    id mockMParticleClass = OCMClassMock([MParticle class]);
+    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
+
+    OCMReject([mockRoktSDK clearSession]);
+    [self.kitInstance endSession];
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockMParticleClass stopMocking];
+    [mockMParticleInstance stopMocking];
+    [mockRoktSDK stopMocking];
 }
 
 @end

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -7,11 +7,6 @@
 static NSInteger const kMPRoktKitCode = 181;
 static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserIdentityType";
 
-// Mirrored from MPKitRokt.m — the session-boundary state is persisted, so every test in this file
-// must start from a clean slate or the transition assertions become order-dependent.
-static NSString * const kTestLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid";
-static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeenMpidWasIdentified";
-
 @interface MPKitRokt ()
 
 - (MPKitExecStatus *)selectPlacementsWithIdentifier:(NSString * _Nullable)identifier
@@ -29,6 +24,7 @@ static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeen
 
 - (MPKitExecStatus *)setSessionId:(NSString *)sessionId;
 - (NSString *)getSessionId;
+- (MPKitExecStatus *)clearSession;
 
 - (NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable)confirmEmbeddedViews:(NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable)embeddedViews;
 
@@ -66,14 +62,6 @@ static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeen
 
 - (void)stop;
 
-- (void)start;
-- (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
-- (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
-- (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
-- (MPKitExecStatus *)onModifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request;
-- (MPKitExecStatus *)beginSession;
-- (MPKitExecStatus *)endSession;
-
 @end
 
 @interface mParticle_RoktTests : XCTestCase
@@ -89,20 +77,12 @@ static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeen
     [super setUp];
     self.kitInstance = [[MPKitRokt alloc] init];
     self.configuration = @{@"accountId": @"test_account_id"};
-    [self clearPersistedSessionBoundaryState];
 }
 
 - (void)tearDown {
-    [self clearPersistedSessionBoundaryState];
     self.kitInstance = nil;
     self.configuration = nil;
     [super tearDown];
-}
-
-- (void)clearPersistedSessionBoundaryState {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults removeObjectForKey:kTestLastSeenMpidKey];
-    [defaults removeObjectForKey:kTestLastSeenIdentifiedKey];
 }
 
 - (void)testKitCode {
@@ -944,6 +924,38 @@ static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeen
     [mockRoktSDK stopMocking];
 }
 
+- (void)testClearSessionForwardsToRoktSDK {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    OCMExpect([mockRoktSDK clearSession]);
+
+    MPKitExecStatus *status = [self.kitInstance clearSession];
+
+    XCTAssertNotNil(status);
+    XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);
+    XCTAssertEqualObjects(status.integrationId, @181);
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
+- (void)testClearSessionIsNotTriggeredByIdentityOrSessionCallbacks {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
+    // The kit resets ONLY when the host names the boundary via MPRokt.clearSession. Inferring it
+    // from identity or session callbacks would change session behaviour for every partner on this
+    // kit, so those selectors are deliberately not implemented — mParticle skips what a kit does
+    // not respond to.
+    XCTAssertFalse([self.kitInstance respondsToSelector:@selector(onIdentifyComplete:request:)]);
+    XCTAssertFalse([self.kitInstance respondsToSelector:@selector(onLoginComplete:request:)]);
+    XCTAssertFalse([self.kitInstance respondsToSelector:@selector(onLogoutComplete:request:)]);
+    XCTAssertFalse([self.kitInstance respondsToSelector:@selector(onModifyComplete:request:)]);
+    XCTAssertFalse([self.kitInstance respondsToSelector:@selector(beginSession)]);
+    XCTAssertFalse([self.kitInstance respondsToSelector:@selector(endSession)]);
+
+    OCMVerifyAll(mockRoktSDK);
+    [mockRoktSDK stopMocking];
+}
+
 - (void)testSetSessionIdWithEmptyString {
     id mockRoktSDK = OCMClassMock([Rokt class]);
 
@@ -1268,275 +1280,6 @@ static NSString * const kTestLastSeenIdentifiedKey = @"mParticle::rokt::lastSeen
     [mockRoktSDK stopMocking];
     [mockMParticleClass stopMocking];
     [mockMParticleInstance stopMocking];
-}
-
-#pragma mark - Session boundary helpers
-
-/// A stubbed FilteredMParticleUser. `identities` is what the kit sees AFTER kit-config and
-/// data-plan filtering, which is the distinction several of the tests below turn on.
-- (id)filteredUserWithMpid:(long long)mpid
-                identities:(NSDictionary<NSNumber *, NSString *> *)identities
-                isLoggedIn:(BOOL)isLoggedIn {
-    FilteredMParticleUser *user = [[FilteredMParticleUser alloc] init];
-    id mockUser = OCMPartialMock(user);
-    [[[mockUser stub] andReturn:@(mpid)] userId];
-    [[[mockUser stub] andReturn:identities] userIdentities];
-    [[[mockUser stub] andReturnValue:@(isLoggedIn)] isLoggedIn];
-    return mockUser;
-}
-
-- (id)knownUserWithMpid:(long long)mpid {
-    return [self filteredUserWithMpid:mpid
-                           identities:@{@(MPIdentityEmail): @"customer@example.com"}
-                           isLoggedIn:NO];
-}
-
-/// Anonymous users still carry device identities, which is why the kit counts only user-identity
-/// keys rather than the raw dictionary being non-empty.
-- (id)anonymousUserWithMpid:(long long)mpid {
-    return [self filteredUserWithMpid:mpid
-                           identities:@{@(MPIdentityIOSVendorId): @"test-idfv",
-                                        @(MPIdentityDeviceApplicationStamp): @"test-das"}
-                           isLoggedIn:NO];
-}
-
-#pragma mark - Identity transition tests
-
-- (void)testIdentity_FirstObservedMpid_RecordsWithoutReset {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-    OCMReject([mockRoktSDK clearSession]);
-
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
-
-    XCTAssertEqualObjects([[NSUserDefaults standardUserDefaults] objectForKey:kTestLastSeenMpidKey], @100);
-    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testIdentity_AnonymousToKnown_KeepsSession {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
-
-    // The same shopper acquiring an identity mid-journey — unknown on the payment page, known on
-    // the confirmation page. Severing here would split one person's attribution.
-    OCMReject([mockRoktSDK clearSession]);
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testIdentity_KnownToDifferentKnown_ResetsSession {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
-
-    // The kiosk case: one customer finishes, the next steps up to the same terminal.
-    OCMExpect([mockRoktSDK clearSession]);
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testIdentity_KnownToAnonymousLogout_ResetsSession {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
-
-    OCMExpect([mockRoktSDK clearSession]);
-    [self.kitInstance onLogoutComplete:[self anonymousUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testIdentity_AnonymousToAnonymous_KeepsSession {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
-
-    // Placeholder churn — nobody was ever known, so there is no customer boundary here.
-    OCMReject([mockRoktSDK clearSession]);
-    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testIdentity_SentinelMpidZero_IsNotRecorded {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-    OCMReject([mockRoktSDK clearSession]);
-
-    // 0 is mParticle's "no MPID assigned yet" sentinel. Recording it would make the first real
-    // identify look like a customer change and drop a session the host had already opened.
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:0] request:nil];
-
-    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kTestLastSeenMpidKey]);
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testOnLoginComplete_KnownToDifferentKnown_ResetsSession {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    // login() forwards onLoginComplete and ONLY that — onIdentifyComplete does not fire for a
-    // login, so a partner who uses login() for the returning customer needs this override or the
-    // transition is never observed.
-    [self.kitInstance onLoginComplete:[self knownUserWithMpid:100] request:nil];
-
-    OCMExpect([mockRoktSDK clearSession]);
-    [self.kitInstance onLoginComplete:[self knownUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-#pragma mark - onModifyComplete
-
-- (void)testOnModifyComplete_MarksIdentifiedWithoutResetting {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-    OCMReject([mockRoktSDK clearSession]);
-
-    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
-    XCTAssertFalse([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
-
-    // modify() cannot change the MPID, so it must never reset — but it IS how a host attaches an
-    // email to the current user, so it must upgrade the identified flag.
-    [self.kitInstance onModifyComplete:[self knownUserWithMpid:100] request:nil];
-
-    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testOnModifyComplete_IdentityAttachedByModify_StillResetsForNextCustomer {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    // The regression this guards: without onModifyComplete the kit still believes MPID 100 was
-    // anonymous, so customer 2 below reads as anonymous churn and inherits customer 1's session.
-    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
-    [self.kitInstance onModifyComplete:[self knownUserWithMpid:100] request:nil];
-
-    OCMExpect([mockRoktSDK clearSession]);
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-#pragma mark - Filtered identities
-
-- (void)testIdentity_FilteredIdentitiesFallBackToUnfilteredCurrentUser {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    // A partner who filters email off this kit sees an EMPTY filtered identity set for a user who
-    // is genuinely known. Taken at face value that records them as anonymous and no later
-    // transition ever resets.
-    MParticleUser *currentUser = [[MParticleUser alloc] init];
-    id mockCurrentUser = OCMPartialMock(currentUser);
-    [[[mockCurrentUser stub] andReturn:@100] userId];
-    [[[mockCurrentUser stub] andReturn:@{@(MPIdentityEmail): @"customer@example.com"}] identities];
-    [[[mockCurrentUser stub] andReturnValue:@NO] isLoggedIn];
-
-    id mockIdentityApi = OCMClassMock([MPIdentityApi class]);
-    OCMStub([mockIdentityApi currentUser]).andReturn(mockCurrentUser);
-    id mockMParticleInstance = OCMClassMock([MParticle class]);
-    OCMStub([(MParticle *)mockMParticleInstance identity]).andReturn(mockIdentityApi);
-    id mockMParticleClass = OCMClassMock([MParticle class]);
-    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
-
-    id filteredButKnown = [self filteredUserWithMpid:100 identities:@{} isLoggedIn:NO];
-    [self.kitInstance onIdentifyComplete:filteredButKnown request:nil];
-
-    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey],
-                  @"A user filtered down to no identities must still resolve as known via the unfiltered current user");
-
-    [mockMParticleClass stopMocking];
-    [mockMParticleInstance stopMocking];
-    [mockIdentityApi stopMocking];
-    [mockCurrentUser stopMocking];
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testIdentity_IdentifiedFlagIsNotDowngradedWithinOneMpid {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:100] request:nil];
-    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
-
-    // A second, under-reporting read of the SAME user must not erase the fact that a known person
-    // occupied this device — otherwise their departure would stop resetting.
-    [self.kitInstance onIdentifyComplete:[self anonymousUserWithMpid:100] request:nil];
-    XCTAssertTrue([[NSUserDefaults standardUserDefaults] boolForKey:kTestLastSeenIdentifiedKey]);
-
-    OCMExpect([mockRoktSDK clearSession]);
-    [self.kitInstance onIdentifyComplete:[self knownUserWithMpid:200] request:nil];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockRoktSDK stopMocking];
-}
-
-#pragma mark - Manual session boundaries
-
-- (void)testSessionBoundary_IgnoredUnderAutomaticSessionTracking {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-    id mockMParticleInstance = OCMClassMock([MParticle class]);
-    OCMStub([(MParticle *)mockMParticleInstance automaticSessionTracking]).andReturn(YES);
-    OCMStub([(MParticle *)mockMParticleInstance identity]).andReturn(nil);
-    id mockMParticleClass = OCMClassMock([MParticle class]);
-    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
-
-    [self.kitInstance start];
-
-    // Under automatic tracking a session ends after a BACKGROUND timeout — a statement about app
-    // lifecycle, not about who is using the device. Acting on it would fragment sessions for every
-    // existing partner.
-    OCMReject([mockRoktSDK clearSession]);
-    [self.kitInstance endSession];
-    [self.kitInstance beginSession];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockMParticleClass stopMocking];
-    [mockMParticleInstance stopMocking];
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testSessionBoundary_ResetsWhenHostDrivesSessions {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-    id mockMParticleInstance = OCMClassMock([MParticle class]);
-    OCMStub([(MParticle *)mockMParticleInstance automaticSessionTracking]).andReturn(NO);
-    OCMStub([(MParticle *)mockMParticleInstance identity]).andReturn(nil);
-    id mockMParticleClass = OCMClassMock([MParticle class]);
-    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
-
-    [self.kitInstance start];
-
-    OCMExpect([mockRoktSDK clearSession]);
-    [self.kitInstance endSession];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockMParticleClass stopMocking];
-    [mockMParticleInstance stopMocking];
-    [mockRoktSDK stopMocking];
-}
-
-- (void)testSessionBoundary_IgnoredBeforeKitStarts {
-    id mockRoktSDK = OCMClassMock([Rokt class]);
-    id mockMParticleInstance = OCMClassMock([MParticle class]);
-    OCMStub([(MParticle *)mockMParticleInstance automaticSessionTracking]).andReturn(NO);
-    id mockMParticleClass = OCMClassMock([MParticle class]);
-    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
-
-    OCMReject([mockRoktSDK clearSession]);
-    [self.kitInstance endSession];
-
-    OCMVerifyAll(mockRoktSDK);
-    [mockMParticleClass stopMocking];
-    [mockMParticleInstance stopMocking];
-    [mockRoktSDK stopMocking];
 }
 
 @end

--- a/Kits/rokt/rokt/mParticle-Rokt.podspec
+++ b/Kits/rokt/rokt/mParticle-Rokt.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
     s.ios.resource_bundles  = { 'mParticle-Rokt-Privacy' => ['Sources/mParticle-Rokt/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK', '~> 9.1'
     s.ios.dependency 'RoktContracts', '~> 2.0'
-    s.ios.dependency 'Rokt-Widget', '~> 5.3.2'
+    s.ios.dependency 'Rokt-Widget', '~> 5.4'
 end

--- a/Kits/rokt/rokt/mParticle-Rokt.xcodeproj/project.pbxproj
+++ b/Kits/rokt/rokt/mParticle-Rokt.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 			repositoryURL = "https://github.com/ROKT/rokt-sdk-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.3.2;
+				minimumVersion = 5.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
> **Stacked on #818** — base is `rokt/add-clear-session`, so this diff shows only the kit change. Merge #818 first.

## Problem

On a **self-service terminal** — a kiosk, counter tablet, or shared point-of-sale device — a queue of unrelated customers uses a single device. Device id, IP and every other device-level signal stay constant, and transactions can be seconds apart.

The Rokt SDK carries session identity in a token it persists and replays on every request. Its gateway continues the existing session for as long as a live token is presented, and each response pushes that token's expiry forward — so on a busy terminal it never lapses, and consecutive customers were all recorded against one session. Frequency capping, dedupe, attribution and reporting then treat strangers as one person.

## Change

Implements the kit half of the explicit path. `MPRokt.clearSession` (#818) forwards `@selector(clearSession)` to active kits, and mParticle skips a kit that does not respond to that selector — so without this passthrough the host-driven call reaches nothing.

```objc
- (MPKitExecStatus *)clearSession {
    [MPKitRokt MPLog:@"Rokt Kit clearing the Rokt session"];
    [Rokt clearSession];
    return [self execStatus:MPKitReturnCodeSuccess];
}
```

Fire-and-forget, mirroring `close`: the Rokt SDK performs the reset — flush buffered events, then drop the session — synchronously on its side.

## Why there is no automatic trigger

An earlier revision of this PR had the kit infer the boundary itself, resetting on identity completions (`onIdentifyComplete` / `onLoginComplete` / `onLogoutComplete` / `onModifyComplete`) and on manual session boundaries. That has been removed, for two reasons:

1. **It changed behaviour for every partner on this kit, not only shared-device ones.** A login or logout would have started a new Rokt session for everyone, splitting sessions for partners running placements either side of a login.
2. **An MPID moving is not reliably a change of person.** A single shopper can be anonymous on the payment page and known on the confirmation page. The typed transition rule built to handle that (anonymous→known keeps the session, known→known′ resets) worked, but it depended on correctly tracking whether the departing user was known — and review surfaced two separate ways that state could go stale, each silently restoring the original bug.

The explicit API gets kiosk partners what they need with no behaviour change for anyone else. Hosts that run shared terminals know their own transaction boundaries better than the kit can infer them.

`testClearSessionIsNotTriggeredByIdentityOrSessionCallbacks` asserts the kit does not respond to any of those selectors, so the automatic path cannot return by accident.

## Testing

- 54 Rokt kit ObjC tests pass, including the new passthrough test
- `trunk check --ci` clean

Local verification required temporarily pinning `rokt-sdk-ios` to `main`, since `Rokt.clearSession()` is merged there but not yet in a release. That pin was reverted before committing — see below.

## CI status

`Rokt-Widget` is pinned to **5.4.0** (`Package.swift`, the podspec, and the xcodeproj), the release that introduced `Rokt.clearSession()`. 54 kit ObjC tests pass against the 5.4.0 tag.

Two categories of red are expected and not build breaks:

- **`Check PR for semantic branch name`** — this branch is `rokt/…` and the check wants `feat/…`. Not a required check; left as-is rather than renaming the branch mid-review.
- **`native-unit-tests` (iOS / tvOS)** — also red on `main` (`171231d4`). Pre-existing crash in `MPTestConnectorFactory`, which builds an OCMock on `com.mparticle.messageQueue` from the backend upload timer; OCMock's class-mock setup is not thread-safe. Presents as partial test totals with zero assertion failures after `Restarting after unexpected exit`. No Rokt frames in the stack — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
