### PR TITLE
fix: Mapping should not gate forwardSDKCall

### DIFF
--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -468,7 +468,14 @@ static NSNumber * const kTestRoktKitId = @181;
     [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
     [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
 
-    XCTAssertNoThrow([self.rokt selectPlacements:@"testView" attributes:@{@"f.name": @"Brandon"}]);
+    NSString *identifier = @"testView";
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    [self mp_expectSelectPlacementsForwardWithIdentifier:identifier unmappedAttributes:attributes];
+
+    XCTAssertNoThrow([self.rokt selectPlacements:identifier attributes:attributes]);
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
 }
 
 - (void)testGetRoktPlacementAttributesMapping {

--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -40,6 +40,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
 @interface MPRokt ()
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)getRoktPlacementAttributesMapping;
+- (NSDictionary * _Nullable)getRoktKitConfiguration;
 - (NSNumber *)getRoktHashedEmailUserIdentityType;
 - (void)confirmUser:(NSDictionary<NSString *, NSString *> *)attributes user:(MParticleUser * _Nullable)user completion:(void (^)(MParticleUser *_Nullable))completion;
 - (NSMutableDictionary<NSString *, NSString *> *)mapPlacementAttributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes
@@ -313,34 +314,39 @@ static NSNumber * const kTestRoktKitId = @181;
     OCMVerifyAll(self.mockContainer);
 }
 
-- (void)testSelectPlacementsSimpleWithNilMapping {
-    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
+- (void)mp_stubSharedInstanceWithOriginalConfig:(NSArray *)kitConfig kitsInitialized:(BOOL)kitsInitialized {
     MParticle *instance = [MParticle sharedInstance];
     self.mockInstance = OCMPartialMock(instance);
     self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockContainer stub] andReturn:kitConfig] originalConfig];
+    [[[self.mockContainer stub] andReturnValue:OCMOCK_VALUE(kitsInitialized)] kitsInitialized];
     [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
     [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
-
-    SEL roktSelector = @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:);
-    OCMReject([self.mockContainer forwardSDKCall:roktSelector
-                                      event:[OCMArg any]
-                                 parameters:[OCMArg any]
-                                messageType:MPMessageTypeEvent
-                                   userInfo:[OCMArg any]]);
-    
-    // Set up test parameters
-    NSString *identifier = @"testView";
-    NSDictionary *attributes = @{@"f.name": @"Brandon"};
-    
-    // Execute method
-    [self.rokt selectPlacements:identifier
-                     attributes:attributes];
-
-    // Verify
-    OCMVerifyAll((id)self.mockContainer);
 }
 
-- (void)testSelectPlacementsWithNilMappingInvokesOnEventWithPlacementFailure {
+- (void)mp_expectSelectPlacementsForwardWithIdentifier:(NSString *)identifier
+                                    unmappedAttributes:(NSDictionary *)attributes {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"forwarded to kit container"];
+    SEL roktSelector = @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:);
+    OCMExpect([self.mockContainer forwardSDKCall:roktSelector
+                                           event:nil
+                                      parameters:[OCMArg checkWithBlock:^BOOL(MPForwardQueueParameters *params) {
+        XCTAssertEqualObjects(params[0], identifier);
+        NSDictionary *forwarded = params[1];
+        for (NSString *key in attributes) {
+            XCTAssertEqualObjects(forwarded[key], attributes[key], @"unmapped key %@ should be preserved", key);
+        }
+        XCTAssertNotNil(forwarded[@"sandbox"]);
+        XCTAssertNotNil(params[5]);
+        return YES;
+    }]
+                                     messageType:MPMessageTypeEvent
+                                        userInfo:nil]).andDo(^(NSInvocation *invocation) {
+        [expectation fulfill];
+    });
+}
+
+- (void)testSelectPlacementsSimpleWithNilMappingForwardsUnmappedAttributes {
     [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
     MParticle *instance = [MParticle sharedInstance];
     self.mockInstance = OCMPartialMock(instance);
@@ -349,21 +355,109 @@ static NSNumber * const kTestRoktKitId = @181;
     [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
 
     NSString *identifier = @"testView";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"onEvent called"];
-    __block RoktEvent *receivedEvent = nil;
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    [self mp_expectSelectPlacementsForwardWithIdentifier:identifier unmappedAttributes:attributes];
+
+    [self.rokt selectPlacements:identifier attributes:attributes];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testGetRoktKitConfigurationReturnsNilWhenOriginalConfigEmpty {
+    [self mp_stubSharedInstanceWithOriginalConfig:@[] kitsInitialized:NO];
+    XCTAssertNil([self.rokt getRoktKitConfiguration]);
+    XCTAssertNil([self.rokt getRoktPlacementAttributesMapping]);
+}
+
+- (void)testGetRoktKitConfigurationReturnsNilWhenOriginalConfigLacksKit181 {
+    NSArray *kitConfig = @[@{@"id": @80, kMPRemoteConfigKitConfigurationKey: @{}}];
+    [self mp_stubSharedInstanceWithOriginalConfig:kitConfig kitsInitialized:YES];
+    XCTAssertNil([self.rokt getRoktKitConfiguration]);
+}
+
+- (void)testSelectPlacementsForwardsWhenOriginalConfigEmptyBeforeKitsInitialized {
+    [self mp_stubSharedInstanceWithOriginalConfig:@[] kitsInitialized:NO];
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    [self mp_expectSelectPlacementsForwardWithIdentifier:@"checkout" unmappedAttributes:attributes];
+
+    [self.rokt selectPlacements:@"checkout" attributes:attributes];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSelectPlacementsForwardsWhenKitsInitializedFromCacheButOriginalConfigEmpty {
+    [self mp_stubSharedInstanceWithOriginalConfig:@[] kitsInitialized:YES];
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    [self mp_expectSelectPlacementsForwardWithIdentifier:@"checkout" unmappedAttributes:attributes];
+
+    [self.rokt selectPlacements:@"checkout" attributes:attributes];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSelectPlacementsForwardsWhenOriginalConfigLacksKit181 {
+    NSArray *kitConfig = @[@{@"id": @80, kMPRemoteConfigKitConfigurationKey: @{}}];
+    [self mp_stubSharedInstanceWithOriginalConfig:kitConfig kitsInitialized:YES];
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    [self mp_expectSelectPlacementsForwardWithIdentifier:@"checkout" unmappedAttributes:attributes];
+
+    [self.rokt selectPlacements:@"checkout" attributes:attributes];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSelectPlacementsForwardsWhenKit181IsInOriginalConfigEvenWithoutAttributeMap {
+    NSArray *kitConfig = @[@{
+        @"id": kTestRoktKitId,
+        kMPRemoteConfigKitConfigurationKey: @{}
+    }];
+    [self mp_stubSharedInstanceWithOriginalConfig:kitConfig kitsInitialized:YES];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"forwarded to kit container"];
+    SEL roktSelector = @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:);
+    OCMExpect([self.mockContainer forwardSDKCall:roktSelector
+                                           event:nil
+                                      parameters:[OCMArg isNotNil]
+                                     messageType:MPMessageTypeEvent
+                                        userInfo:nil]).andDo(^(NSInvocation *invocation) {
+        [expectation fulfill];
+    });
+
+    [self.rokt selectPlacements:@"checkout" attributes:@{@"f.name": @"Brandon"}];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSelectPlacementsWithNilMappingDoesNotInvokeOnEventWithPlacementFailure {
+    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    NSString *identifier = @"testView";
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    [self mp_expectSelectPlacementsForwardWithIdentifier:identifier unmappedAttributes:attributes];
+
+    XCTestExpectation *noFailure = [self expectationWithDescription:@"onEvent must not fire from core"];
+    noFailure.inverted = YES;
 
     [self.rokt selectPlacements:identifier
-                     attributes:@{@"f.name": @"Brandon"}
+                     attributes:attributes
                   embeddedViews:nil
                          config:nil
                         onEvent:^(RoktEvent * _Nonnull event) {
-        receivedEvent = event;
-        [expectation fulfill];
+        [noFailure fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:0.2 handler:nil];
-    XCTAssertTrue([receivedEvent isKindOfClass:[RoktPlacementFailure class]]);
-    XCTAssertEqualObjects(((RoktPlacementFailure *)receivedEvent).identifier, identifier);
+    OCMVerifyAll(self.mockContainer);
 }
 
 - (void)testSelectPlacementsWithNilMappingAndNilOnEventDoesNotCrash {
@@ -1044,27 +1138,7 @@ static NSNumber * const kTestRoktKitId = @181;
     OCMVerifyAll(self.mockContainer);
 }
 
-- (void)testSelectShoppableAdsWithNilMappingDoesNotForward {
-    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
-    MParticle *instance = [MParticle sharedInstance];
-    self.mockInstance = OCMPartialMock(instance);
-    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
-    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
-    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
-
-    SEL roktSelector = @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:);
-    OCMReject([self.mockContainer forwardSDKCall:roktSelector
-                                           event:[OCMArg any]
-                                      parameters:[OCMArg any]
-                                     messageType:MPMessageTypeEvent
-                                        userInfo:[OCMArg any]]);
-
-    [self.rokt selectShoppableAds:@"shoppableView" attributes:@{@"email": @"a@b.com"}];
-
-    OCMVerifyAll((id)self.mockContainer);
-}
-
-- (void)testSelectShoppableAdsWithNilMappingInvokesOnEventWithPlacementFailure {
+- (void)testSelectShoppableAdsWithNilMappingForwardsUnmappedAttributes {
     [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
     MParticle *instance = [MParticle sharedInstance];
     self.mockInstance = OCMPartialMock(instance);
@@ -1073,20 +1147,60 @@ static NSNumber * const kTestRoktKitId = @181;
     [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
 
     NSString *identifier = @"shoppableView";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"onEvent called"];
-    __block RoktEvent *receivedEvent = nil;
+    NSDictionary *attributes = @{@"f.name": @"Brandon"};
+    XCTestExpectation *expectation = [self expectationWithDescription:@"forwarded shoppable ads"];
+    SEL roktSelector = @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:);
+    OCMExpect([self.mockContainer forwardSDKCall:roktSelector
+                                           event:nil
+                                      parameters:[OCMArg checkWithBlock:^BOOL(MPForwardQueueParameters *params) {
+        XCTAssertEqualObjects(params[0], identifier);
+        NSDictionary *forwarded = params[1];
+        XCTAssertEqualObjects(forwarded[@"f.name"], @"Brandon");
+        XCTAssertNotNil(forwarded[@"sandbox"]);
+        return YES;
+    }]
+                                     messageType:MPMessageTypeEvent
+                                        userInfo:nil]).andDo(^(NSInvocation *invocation) {
+        [expectation fulfill];
+    });
+
+    [self.rokt selectShoppableAds:identifier attributes:attributes];
+
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    OCMVerifyAll(self.mockContainer);
+}
+
+- (void)testSelectShoppableAdsWithNilMappingDoesNotInvokeOnEventWithPlacementFailure {
+    [[[self.mockRokt stub] andReturn:nil] getRoktPlacementAttributesMapping];
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
+    [[[self.mockInstance stub] andReturn:self.mockContainer] kitContainer_PRIVATE];
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    NSString *identifier = @"shoppableView";
+    XCTestExpectation *forwarded = [self expectationWithDescription:@"forwarded shoppable ads"];
+    SEL roktSelector = @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:);
+    OCMExpect([self.mockContainer forwardSDKCall:roktSelector
+                                           event:nil
+                                      parameters:[OCMArg isNotNil]
+                                     messageType:MPMessageTypeEvent
+                                        userInfo:nil]).andDo(^(NSInvocation *invocation) {
+        [forwarded fulfill];
+    });
+
+    XCTestExpectation *noFailure = [self expectationWithDescription:@"onEvent must not fire from core"];
+    noFailure.inverted = YES;
 
     [self.rokt selectShoppableAds:identifier
                        attributes:@{@"f.name": @"Brandon"}
                            config:nil
                           onEvent:^(RoktEvent * _Nonnull event) {
-        receivedEvent = event;
-        [expectation fulfill];
+        [noFailure fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:0.2 handler:nil];
-    XCTAssertTrue([receivedEvent isKindOfClass:[RoktPlacementFailure class]]);
-    XCTAssertEqualObjects(((RoktPlacementFailure *)receivedEvent).identifier, identifier);
+    OCMVerifyAll(self.mockContainer);
 }
 
 - (void)testSelectShoppableAdsInvokesConfirmUser {
@@ -1109,6 +1223,52 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self waitForExpectationsWithTimeout:0.2 handler:nil];
     OCMVerifyAll(self.mockContainer);
+}
+
+#pragma mark - confirmUser nil-user path
+
+- (void)testIdentityCurrentUserGetterNeverReturnsNil {
+    MParticleUser *user = [MParticle sharedInstance].identity.currentUser;
+    XCTAssertNotNil(user, @"iOS currentUser synthesizes an MParticleUser from persisted MPID; a nil-user Android-style guard would not fire after identity is accessed");
+}
+
+- (void)testConfirmUserNilUserWithoutEmailCompletesImmediately {
+    __block BOOL completed = NO;
+    [self.rokt confirmUser:@{@"f.name": @"Brandon"} user:nil completion:^(MParticleUser *resolved) {
+        completed = YES;
+        XCTAssertNil(resolved);
+    }];
+    XCTAssertTrue(completed);
+}
+
+- (void)testConfirmUserNilUserWithEmailCallsIdentifyAndBlocksUntilCompletion {
+    MParticle *instance = [MParticle sharedInstance];
+    self.mockInstance = OCMPartialMock(instance);
+    self.identityMock = OCMClassMock([MPIdentityApi class]);
+    OCMStub([(MParticle *)self.mockInstance identity]).andReturn(self.identityMock);
+    [[[self.mockInstance stub] andReturn:self.mockInstance] sharedInstance];
+
+    __block BOOL identifyCalled = NO;
+    __block BOOL identifyCompletionInvokedBySDK = NO;
+    [[[self.identityMock stub] andDo:^(NSInvocation *invocation) {
+        identifyCalled = YES;
+        void (^identityCompletion)(MPIdentityApiResult *_Nullable, NSError *_Nullable);
+        [invocation getArgument:&identityCompletion atIndex:3];
+        identifyCompletionInvokedBySDK = identityCompletion != nil;
+        // Intentionally do not invoke identityCompletion — hang, matching a stuck identify.
+    }] identify:[OCMArg any] completion:[OCMArg any]];
+
+    XCTestExpectation *didNotComplete = [self expectationWithDescription:@"confirmUser must not complete while identify hangs"];
+    didNotComplete.inverted = YES;
+
+    [self.rokt confirmUser:@{@"email": @"a@b.com"} user:nil completion:^(MParticleUser *resolved) {
+        (void)resolved;
+        [didNotComplete fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:0.3 handler:nil];
+    XCTAssertTrue(identifyCalled);
+    XCTAssertTrue(identifyCompletionInvokedBySDK);
 }
 
 #pragma mark - mapPlacementAttributes

--- a/mParticle-Apple-SDK/MPRokt.m
+++ b/mParticle-Apple-SDK/MPRokt.m
@@ -83,40 +83,33 @@ static const NSInteger kMPRoktKitId = 181;
         MPILogDebug(@"MPRokt confirmUser completed - resolvedUser: %@, userId: %@",
                     resolvedUser ? @"present" : @"nil", resolvedUser.userId);
         
-        NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributesMapping];
+        NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributesMapping] ?: @[];
 
         MPILogVerbose(@"MParticle.Rokt selectPlacements called with attributes: %@", attributes);
 
-        // If attributeMap is nil the kit hasn't been initialized
-        if (attributeMap) {
-            NSMutableDictionary *mappedAttributes = [self mapPlacementAttributes:attributes
-                                                                    attributeMap:attributeMap
-                                                                         forUser:resolvedUser];
+        NSMutableDictionary *mappedAttributes = [self mapPlacementAttributes:attributes
+                                                                attributeMap:attributeMap
+                                                                     forUser:resolvedUser];
 
-            dispatch_async([MParticle messageQueue], ^{
-                MPILogDebug(@"MPRokt forwarding to kit - identifier: %@, mappedAttributes count: %lu",
-                            identifier, (unsigned long)mappedAttributes.count);
-                // Forwarding call to kits
-                MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
-                [queueParameters addParameter:identifier];
-                [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
-                [queueParameters addParameter:embeddedViews];
-                [queueParameters addParameter:config];
-                [queueParameters addParameter:onEvent];
-                [queueParameters addParameter:placementOptions];
-                
-                SEL roktSelector = @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:);
-                [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
-                                                                          event:nil
-                                                                     parameters:queueParameters
-                                                                    messageType:MPMessageTypeEvent
-                                                                       userInfo:nil
-                ];
-            });
-        } else {
-            MPILogWarning(@"MPRokt selectPlacements not performed - Rokt Kit not configured. Check with your Rokt representative to ensure the kit is enabled.");
-            [self notifyPlacementFailure:identifier onEvent:onEvent];
-        }
+        dispatch_async([MParticle messageQueue], ^{
+            MPILogDebug(@"MPRokt forwarding to kit - identifier: %@, mappedAttributes count: %lu",
+                        identifier, (unsigned long)mappedAttributes.count);
+            MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
+            [queueParameters addParameter:identifier];
+            [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
+            [queueParameters addParameter:embeddedViews];
+            [queueParameters addParameter:config];
+            [queueParameters addParameter:onEvent];
+            [queueParameters addParameter:placementOptions];
+            
+            SEL roktSelector = @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:);
+            [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
+                                                                      event:nil
+                                                                 parameters:queueParameters
+                                                                messageType:MPMessageTypeEvent
+                                                                   userInfo:nil
+            ];
+        });
     }];
 }
 
@@ -354,38 +347,31 @@ static const NSInteger kMPRoktKitId = 181;
         MPILogDebug(@"MPRokt confirmUser completed - resolvedUser: %@, userId: %@",
                     resolvedUser ? @"present" : @"nil", resolvedUser.userId);
         
-        NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributesMapping];
+        NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = [self getRoktPlacementAttributesMapping] ?: @[];
 
         MPILogVerbose(@"MParticle.Rokt selectShoppableAds called with attributes: %@", attributes);
 
-        // If attributeMap is nil the kit hasn't been initialized
-        if (attributeMap) {
-            NSMutableDictionary *mappedAttributes = [self mapPlacementAttributes:attributes
-                                                                    attributeMap:attributeMap
-                                                                         forUser:resolvedUser];
+        NSMutableDictionary *mappedAttributes = [self mapPlacementAttributes:attributes
+                                                                attributeMap:attributeMap
+                                                                     forUser:resolvedUser];
 
-            dispatch_async([MParticle messageQueue], ^{
-                MPILogDebug(@"MPRokt forwarding selectShoppableAds to kit - identifier: %@, mappedAttributes count: %lu",
-                            identifier, (unsigned long)mappedAttributes.count);
-                // Forwarding call to kits
-                MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
-                [queueParameters addParameter:identifier];
-                [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
-                [queueParameters addParameter:config];
-                [queueParameters addParameter:onEvent];
-                
-                SEL roktSelector = @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:);
-                [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
-                                                                          event:nil
-                                                                     parameters:queueParameters
-                                                                    messageType:MPMessageTypeEvent
-                                                                       userInfo:nil
-                ];
-            });
-        } else {
-            MPILogWarning(@"MPRokt selectShoppableAds not performed - Rokt Kit not configured. Check with your Rokt representative to ensure the kit is enabled.");
-            [self notifyPlacementFailure:identifier onEvent:onEvent];
-        }
+        dispatch_async([MParticle messageQueue], ^{
+            MPILogDebug(@"MPRokt forwarding selectShoppableAds to kit - identifier: %@, mappedAttributes count: %lu",
+                        identifier, (unsigned long)mappedAttributes.count);
+            MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
+            [queueParameters addParameter:identifier];
+            [queueParameters addParameter:[self confirmSandboxAttribute:mappedAttributes]];
+            [queueParameters addParameter:config];
+            [queueParameters addParameter:onEvent];
+            
+            SEL roktSelector = @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:);
+            [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:roktSelector
+                                                                      event:nil
+                                                                 parameters:queueParameters
+                                                                messageType:MPMessageTypeEvent
+                                                                   userInfo:nil
+            ];
+        });
     }];
 }
 
@@ -432,22 +418,6 @@ static const NSInteger kMPRoktKitId = 181;
 }
 
 #pragma mark - Private Helper Methods
-
-/// Delivers a \c RoktPlacementFailure to the caller so a placement request that cannot be served never
-/// completes silently. Dispatched to the main queue because callers drive UI from this handler.
-/// - Parameters:
-///   - identifier: The placement identifier the caller requested
-///   - onEvent: The caller's event handler; nothing is delivered when it is nil
-- (void)notifyPlacementFailure:(NSString * _Nullable)identifier
-                       onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent {
-    if (!onEvent) {
-        return;
-    }
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        onEvent([[RoktPlacementFailure alloc] initWithIdentifier:identifier]);
-    });
-}
 
 /// Applies dashboard placement attribute key mapping, then sets each non-sandbox key on the user.
 /// @return Mutable dictionary after remapping (empty when \p attributes is nil).


### PR DESCRIPTION
## Background

- Client production data showed iOS firing selectPlacements far less often than Android (about 7% vs 43% of payment sessions). A missing kit event means MPKitRokt was never invoked.
- Core MPRokt treated a nil placement attribute map as “kit not configured” and skipped forwardSDKCall. That map is loaded from originalConfig, which is only set after server configureKits: — not when kits start from cache. Other kit APIs already queue via forwardSDKCall when kits are not ready; this gate never reached that queue, so early checkout calls were dropped instead of forwarded (unmapped if needed).
- Mapping still belongs in core for the forwarded path for now. Moving it entirely into the kit SDK (and aligning the SwiftUI/MPRoktLayout embedded path, which already maps in the kit) is the longer-term direction, but that contract change is too risky given limited testing time.

## What Has Changed

- MPRokt.selectPlacements and selectShoppableAds always forwardSDKCall after confirmUser. A nil attribute map is treated as empty (@[]): keys are passed through unmapped, sandbox is still applied, and the container queues the call if kits are not initialized.
- Removed the “Rokt Kit not configured” bail and notifyPlacementFailure on this path. If the Rokt kit is genuinely absent, this is now a no-op forward, matching purchaseFinalized / events:.
- Unit tests now expect a forward (unmapped keys + sandbox preserved) when mapping/originalConfig/kit 181 is missing, instead of a drop or RoktPlacementFailure.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
