### PR TITLE
fix(rokt): map the alias user identity so placements are not dropped

### DIFF
--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -413,6 +413,10 @@ static __weak MPKitRokt *roktKit = nil;
     NSMutableDictionary<NSString *, NSString *> *identityAttributes = [[NSMutableDictionary alloc] init];
     for (NSNumber *identityNumberKey in filteredUser.userIdentities) {
         NSString *identityStringKey = [MPKitRokt stringForIdentityType:identityNumberKey.unsignedIntegerValue];
+        if (identityStringKey == nil) {
+            [MPKitRokt MPLog:[NSString stringWithFormat:@"Skipping user identity with no Rokt attribute mapping, type: %@", identityNumberKey]];
+            continue;
+        }
         [identityAttributes setObject:filteredUser.userIdentities[identityNumberKey] forKey:identityStringKey];
     }
     
@@ -443,7 +447,8 @@ static __weak MPKitRokt *roktKit = nil;
         return kMPRoktIdentityTypeEmailSha256;
     }
     
-    NSDictionary<NSNumber *, NSString *> *identityStrings = @{@(MPIdentityCustomerId): @"customerid",
+    NSDictionary<NSNumber *, NSString *> *identityStrings = @{@(MPIdentityAlias): @"alias",
+                                                             @(MPIdentityCustomerId): @"customerid",
                                                              @(MPIdentityEmail): @"email",
                                                              @(MPIdentityFacebook): @"facebook",
                                                              @(MPIdentityFacebookCustomAudienceId): @"facebookcustomaudienceid",
@@ -476,7 +481,8 @@ static __weak MPKitRokt *roktKit = nil;
     if (identityString == nil) {
         return nil;
     }
-    NSDictionary<NSString *, NSNumber *> *identityNumbers = @{@"customerid": @(MPIdentityCustomerId),
+    NSDictionary<NSString *, NSNumber *> *identityNumbers = @{@"alias": @(MPIdentityAlias),
+                                                             @"customerid": @(MPIdentityCustomerId),
                                                              @"email": @(MPIdentityEmail),
                                                              @"facebook": @(MPIdentityFacebook),
                                                              @"facebookcustomaudienceid": @(MPIdentityFacebookCustomAudienceId),

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -574,6 +574,105 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertEqualObjects(passedAttributes[@"device_application_stamp"], @"Test DAS");
 }
 
+- (void)testAddIdentityAttributesIncludesAlias {
+    NSMutableDictionary<NSString *, NSString *> *passedAttributes = [[NSMutableDictionary alloc] init];
+    NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
+                                                             @(MPIdentityAlias): @"testCustomerID",
+                                                             @(MPIdentityEmail): @"testEmail@gmail.com"};
+
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] init];
+    id mockfilteredUser = OCMPartialMock(filteredUser);
+    [[[mockfilteredUser stub] andReturn:testIdentities] userIdentities];
+    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
+    [[[mockMPKitRoktClass stub] andReturn:nil] getRoktHashedEmailUserIdentityType];
+
+    XCTAssertNoThrow([MPKitRokt addIdentityAttributes:passedAttributes filteredUser:filteredUser]);
+
+    XCTAssertEqualObjects(passedAttributes[@"alias"], @"testCustomerID");
+    XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
+    XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
+
+    [mockMPKitRoktClass stopMocking];
+    [mockfilteredUser stopMocking];
+}
+
+- (void)testAddIdentityAttributesSkipsUnmappedIdentityTypeWithoutThrowing {
+    NSMutableDictionary<NSString *, NSString *> *passedAttributes = [[NSMutableDictionary alloc] init];
+    NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityEmail): @"testEmail@gmail.com",
+                                                             @(9999): @"unmappedIdentityValue"};
+
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] init];
+    id mockfilteredUser = OCMPartialMock(filteredUser);
+    [[[mockfilteredUser stub] andReturn:testIdentities] userIdentities];
+    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
+    [[[mockMPKitRoktClass stub] andReturn:nil] getRoktHashedEmailUserIdentityType];
+
+    XCTAssertNoThrow([MPKitRokt addIdentityAttributes:passedAttributes filteredUser:filteredUser]);
+
+    XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
+    XCTAssertEqual([passedAttributes.allValues containsObject:@"unmappedIdentityValue"], NO);
+
+    [mockMPKitRoktClass stopMocking];
+    [mockfilteredUser stopMocking];
+}
+
+- (void)testSelectPlacementsWithAliasIdentityStillForwardsToRoktAndLogsEvent {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    id mockMParticleInstance = OCMClassMock([MParticle class]);
+    id mockMParticleClass = OCMClassMock([MParticle class]);
+    OCMStub([mockMParticleClass sharedInstance]).andReturn(mockMParticleInstance);
+    OCMStub([(MParticle *)mockMParticleInstance environment]).andReturn(MPEnvironmentDevelopment);
+
+    NSString *identifier = @"TestView";
+    NSDictionary *attributes = @{@"email": @"test@example.com"};
+
+    FilteredMParticleUser *user = [[FilteredMParticleUser alloc] init];
+    id mockUser = OCMPartialMock(user);
+    OCMStub([mockUser userId]).andReturn(@(123456));
+    NSDictionary<NSNumber *, NSString *> *aliasedIdentities = @{@(MPIdentityCustomerId): @"a-customer-uuid",
+                                                                @(MPIdentityAlias): @"a-customer-uuid",
+                                                                @(MPIdentityEmail): @"test@example.com"};
+    OCMStub([mockUser userIdentities]).andReturn(aliasedIdentities);
+    OCMStub([mockUser userAttributes]).andReturn(@{});
+
+    OCMExpect([(MParticle *)mockMParticleInstance logEvent:[OCMArg checkWithBlock:^BOOL(MPEvent *event) {
+        XCTAssertEqualObjects(event.name, @"selectPlacements");
+        XCTAssertEqualObjects(event.customAttributes[@"alias"], @"a-customer-uuid");
+        XCTAssertEqualObjects(event.customAttributes[@"customerid"], @"a-customer-uuid");
+        return YES;
+    }]]);
+
+    OCMExpect([mockRoktSDK selectPlacementsWithIdentifier:identifier
+                                               attributes:[OCMArg checkWithBlock:^BOOL(NSDictionary *finalAttributes) {
+        XCTAssertEqualObjects(finalAttributes[@"alias"], @"a-customer-uuid");
+        return YES;
+    }]
+                                               placements:OCMOCK_ANY
+                                                   config:OCMOCK_ANY
+                                         placementOptions:OCMOCK_ANY
+                                                  onEvent:OCMOCK_ANY]);
+
+    MPKitExecStatus *status = nil;
+    XCTAssertNoThrow(status = [self.kitInstance selectPlacementsWithIdentifier:identifier
+                                                                   attributes:attributes
+                                                                embeddedViews:nil
+                                                                       config:nil
+                                                                      onEvent:nil
+                                                                 filteredUser:user
+                                                                      options:nil]);
+
+    OCMVerifyAll(mockMParticleInstance);
+    OCMVerifyAll(mockRoktSDK);
+
+    XCTAssertNotNil(status);
+    XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);
+
+    [mockRoktSDK stopMocking];
+    [mockMParticleClass stopMocking];
+    [mockMParticleInstance stopMocking];
+    [mockUser stopMocking];
+}
+
 - (void)runSetWrapperSdkTestWithProvidedMPWrapperType:(MPWrapperSdk)providedMPWrapperType expectedRoktFrameworkType:(RoktFrameworkType)expectedRoktFrameworkType {
     id mockRoktSDK = OCMClassMock([Rokt class]);
 

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -35,6 +35,10 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 + (NSNumber *)getRoktHashedEmailUserIdentityType;
 
++ (NSString *)stringForIdentityType:(MPIdentity)identityType;
+
++ (NSNumber *)identityTypeForString:(NSString *)identityString;
+
 + (NSDictionary<NSString *, NSString *> *)transformValuesToString:(NSDictionary<NSString *, id> * _Nullable)originalDictionary;
 
 + (void)logSelectPlacementEvent:(NSDictionary<NSString *, NSString *> * _Nonnull)attributes;
@@ -320,6 +324,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
                                                              @(MPIdentityEmail): @"testEmail@gmail.com",
                                                              @(MPIdentityFacebook): @"testFacebook",
+                                                             @(MPIdentityAlias): @"testAlias",
                                                              @(MPIdentityFacebookCustomAudienceId): @"testCustomAudienceID",
                                                              @(MPIdentityGoogle): @"testGoogle",
                                                              @(MPIdentityMicrosoft): @"testMicrosoft",
@@ -354,6 +359,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
     XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
     XCTAssertEqualObjects(passedAttributes[@"facebook"], @"testFacebook");
+    XCTAssertEqualObjects(passedAttributes[@"alias"], @"testAlias");
     XCTAssertEqualObjects(passedAttributes[@"facebookcustomaudienceid"], @"testCustomAudienceID");
     XCTAssertEqualObjects(passedAttributes[@"google"], @"testGoogle");
     XCTAssertEqualObjects(passedAttributes[@"microsoft"], @"testMicrosoft");
@@ -384,6 +390,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
                                                              @(MPIdentityEmail): @"testEmail@gmail.com",
                                                              @(MPIdentityFacebook): @"testFacebook",
+                                                             @(MPIdentityAlias): @"testAlias",
                                                              @(MPIdentityFacebookCustomAudienceId): @"testCustomAudienceID",
                                                              @(MPIdentityGoogle): @"testGoogle",
                                                              @(MPIdentityMicrosoft): @"testMicrosoft",
@@ -418,6 +425,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
     XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
     XCTAssertEqualObjects(passedAttributes[@"facebook"], @"testFacebook");
+    XCTAssertEqualObjects(passedAttributes[@"alias"], @"testAlias");
     XCTAssertEqualObjects(passedAttributes[@"facebookcustomaudienceid"], @"testCustomAudienceID");
     XCTAssertEqualObjects(passedAttributes[@"google"], @"testGoogle");
     XCTAssertEqualObjects(passedAttributes[@"microsoft"], @"testMicrosoft");
@@ -448,6 +456,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
                                                              @(MPIdentityEmail): @"testEmail@gmail.com",
                                                              @(MPIdentityFacebook): @"testFacebook",
+                                                             @(MPIdentityAlias): @"testAlias",
                                                              @(MPIdentityFacebookCustomAudienceId): @"testCustomAudienceID",
                                                              @(MPIdentityGoogle): @"testGoogle",
                                                              @(MPIdentityMicrosoft): @"testMicrosoft",
@@ -483,6 +492,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
     XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
     XCTAssertEqualObjects(passedAttributes[@"facebook"], @"testFacebook");
+    XCTAssertEqualObjects(passedAttributes[@"alias"], @"testAlias");
     XCTAssertEqualObjects(passedAttributes[@"facebookcustomaudienceid"], @"testCustomAudienceID");
     XCTAssertEqualObjects(passedAttributes[@"google"], @"testGoogle");
     XCTAssertEqualObjects(passedAttributes[@"microsoft"], @"testMicrosoft");
@@ -514,6 +524,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
                                                              @(MPIdentityEmail): @"testEmail@gmail.com",
                                                              @(MPIdentityFacebook): @"testFacebook",
+                                                             @(MPIdentityAlias): @"testAlias",
                                                              @(MPIdentityFacebookCustomAudienceId): @"testCustomAudienceID",
                                                              @(MPIdentityGoogle): @"testGoogle",
                                                              @(MPIdentityMicrosoft): @"testMicrosoft",
@@ -549,6 +560,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
     XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
     XCTAssertEqualObjects(passedAttributes[@"facebook"], @"testFacebook");
+    XCTAssertEqualObjects(passedAttributes[@"alias"], @"testAlias");
     XCTAssertEqualObjects(passedAttributes[@"facebookcustomaudienceid"], @"testCustomAudienceID");
     XCTAssertEqualObjects(passedAttributes[@"google"], @"testGoogle");
     XCTAssertEqualObjects(passedAttributes[@"microsoft"], @"testMicrosoft");
@@ -610,7 +622,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertNoThrow([MPKitRokt addIdentityAttributes:passedAttributes filteredUser:filteredUser]);
 
     XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
-    XCTAssertEqual([passedAttributes.allValues containsObject:@"unmappedIdentityValue"], NO);
+    XCTAssertFalse([passedAttributes.allValues containsObject:@"unmappedIdentityValue"]);
 
     [mockMPKitRoktClass stopMocking];
     [mockfilteredUser stopMocking];
@@ -671,6 +683,16 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     [mockMParticleClass stopMocking];
     [mockMParticleInstance stopMocking];
     [mockUser stopMocking];
+}
+
+- (void)testAliasIdentityTypeRoundTripsThroughBothMaps {
+    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
+    [[[mockMPKitRoktClass stub] andReturn:nil] getRoktHashedEmailUserIdentityType];
+
+    XCTAssertEqualObjects([MPKitRokt stringForIdentityType:MPIdentityAlias], @"alias");
+    XCTAssertEqualObjects([MPKitRokt identityTypeForString:@"alias"], @(MPIdentityAlias));
+
+    [mockMPKitRoktClass stopMocking];
 }
 
 - (void)runSetWrapperSdkTestWithProvidedMPWrapperType:(MPWrapperSdk)providedMPWrapperType expectedRoktFrameworkType:(RoktFrameworkType)expectedRoktFrameworkType {


### PR DESCRIPTION
## Background

`MPKitRokt.stringForIdentityType:` mapped every `MPIdentity` member except
`MPIdentityAlias`, returning `nil`. `addIdentityAttributes:` passed that `nil` into
`-[NSMutableDictionary setObject:forKey:]`, raising `NSInvalidArgumentException`.
The throw happens in `prepareAttributes:`, before `logSelectPlacementEvent:` and before
the Rokt SDK call, so for a user with an alias identity neither the placement nor its
`selectPlacements` event was emitted.

`prepareAttributes:` is shared by three entry points, with two different outcomes.
`selectPlacements` and `selectShoppableAds` are forwarded through `MPKitContainer`, which
catches and discards the exception — silent drop, no crash, no report. `MPRoktLayout`
calls `prepareAttributes:` directly from Swift, which cannot catch an ObjC `NSException`,
so the SwiftUI embedded path crashed.

Android maps `IdentityType.Alias -> "alias"`, so this was iOS-only.

## What Has Changed

- Added `@(MPIdentityAlias): @"alias"` to `stringForIdentityType:`, and the matching
  reverse entry to `identityTypeForString:`.
- `addIdentityAttributes:` now skips and logs an unmapped identity instead of throwing,
  so a future gap costs one attribute rather than the whole placement.
- Three tests added. Without the source change they fail with `key cannot be nil` and
  OCMock shows neither `logEvent:` nor `selectPlacementsWithIdentifier:` was invoked;
  with it the target passes (55 tests, 0 failures).

Note: these tests are in an SPM target shadowed by the sibling `.xcodeproj`, and
`build-kits.yml` only builds schemes — worth checking whether this suite runs in CI.

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]
