### PR TITLE
fix: do not raise on an unsupported attribute value

### DIFF
--- a/UnitTests/ObjCTests/NSDictionaryMPCaseInsensitiveTests.m
+++ b/UnitTests/ObjCTests/NSDictionaryMPCaseInsensitiveTests.m
@@ -147,28 +147,21 @@
 }
 
 // Zero-length NSData fails the `length > 0` guard and falls through to the
-// unsupported-type branch, so it is dropped in Release and trips NSAssert in
-// any build with assertions enabled.
+// unsupported-value branch, so the key is dropped.
 - (void)testTransformOfEmptyDataIsUnsupported {
     NSDictionary *original = @{@"empty": [NSData data], @"keep": @"value"};
-#ifdef NS_BLOCK_ASSERTIONS
-    NSDictionary *result = [original transformValuesToString];
+    NSDictionary *result = nil;
+    XCTAssertNoThrow(result = [original transformValuesToString]);
     XCTAssertNil(result[@"empty"]);
     XCTAssertEqualObjects(result[@"keep"], @"value");
-#else
-    XCTAssertThrows([original transformValuesToString]);
-#endif
 }
 
 - (void)testTransformOfUnsupportedValueType {
     NSDictionary *original = @{@"unsupported": [[NSObject alloc] init], @"keep": @"value"};
-#ifdef NS_BLOCK_ASSERTIONS
-    NSDictionary *result = [original transformValuesToString];
+    NSDictionary *result = nil;
+    XCTAssertNoThrow(result = [original transformValuesToString]);
     XCTAssertNil(result[@"unsupported"]);
     XCTAssertEqualObjects(result[@"keep"], @"value");
-#else
-    XCTAssertThrows([original transformValuesToString]);
-#endif
 }
 
 @end

--- a/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
+++ b/mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
@@ -34,7 +34,6 @@
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         if (![MPAttributeValueTransformer isSupportedAttributeValue:obj]) {
             MPILogError(@"Data type is not supported as an attribute value: %@ - %@", obj, [[obj class] description]);
-            NSAssert([obj isKindOfClass:[NSString class]], @"Data type is not supported as an attribute value");
             return;
         }
 


### PR DESCRIPTION
## The bug

`transformValuesToString` calls `NSAssert` for any value it cannot encode, and no caller wraps it in `@try`:

```objc
MPILogError(@"Data type is not supported as an attribute value: %@ - %@", obj, [[obj class] description]);
NSAssert([obj isKindOfClass:[NSString class]], @"Data type is not supported as an attribute value");
return;
```

`ENABLE_NS_ASSERTIONS = NO` is set only on the Release configuration, so the same customer input behaves two different ways: quietly dropped in a release build, `NSInternalInconsistencyException` thrown out of the SDK in a debug one.

This is reachable from ordinary input. Anything set as an event or user attribute that is not a string, number, date, non-empty data, collection or `NSNull` hits it. **Zero-length `NSData` hits it too**, because it fails the `length > 0` guard and falls through to the same branch, so a customer setting an empty data attribute is enough to trigger it.

`AGENTS.md` is explicit that the SDK should never crash on bad input, and this is bad input from the host app rather than a programming error inside the SDK, so an assertion is the wrong tool.

Pre-existing, not introduced by this stack. Found while writing the characterisation tests in #829.

## The fix

Remove the assert. Keep the error log. The key is skipped, which is exactly what release builds already did.

## Scope: deliberately not fixing the payload

**Nothing about what gets serialized changes.** Unsupported values are still omitted from the payload.

Empty `NSData` arguably ought to encode as `""` rather than vanish, and it would be easy to add. I have not, because that changes the event payload rather than fixing a crash: keys that never appeared would start appearing, which can affect data plan validation and kit projection matching. That is a product decision and belongs in its own change with its own review. Happy to follow up if you want it.

## Tests

The two characterisation tests from #829 covered this behaviour with `#ifdef NS_BLOCK_ASSERTIONS`, asserting a throw under assertions and a silent drop otherwise. Both now assert a single unconditional behaviour and use `XCTAssertNoThrow` explicitly, since not throwing is the point of the change. The conditional compilation is gone.

The rest of that file is untouched, so the encoding is still pinned by the other 17 tests.

- `NSDictionaryMPCaseInsensitiveTests`, `MPMessageBuilderTests`, `MPCommerceEventTests`, `MPBase_Attribute_Event_ProjectionTests`: 59 passed, 0 failed.
- `trunk check` clean via the pre-commit hook.