### PR TITLE
ci: re-enable build-secondary-platforms job in PR workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,10 +28,9 @@ jobs:
     uses: ./.github/workflows/native-tests.yml
     secrets: inherit
 
-  # TODO: Re-enable after 9.0 release
-  # build-secondary-platforms:
-  #   uses: ./.github/workflows/build-secondary-platforms.yml
-  #   secrets: inherit
+  build-secondary-platforms:
+    uses: ./.github/workflows/build-secondary-platforms.yml
+    secrets: inherit
 
   integration-tests:
     uses: ./.github/workflows/integration-tests.yml
@@ -54,7 +53,7 @@ jobs:
     needs:
       - build-and-lint
       - native-tests
-      # - build-secondary-platforms  # TODO: Re-enable after 9.0 release
+      - build-secondary-platforms
       - integration-tests
       - size-report
       - swift-migration-progress


### PR DESCRIPTION
## Summary

Re-enables the `build-secondary-platforms` job in the pull-request workflow. This job was previously disabled pending the 9.0 release.

## Changes

- Uncommented the `build-secondary-platforms` job definition in `.github/workflows/pull-request.yml`
- Added it back to the `pr-notify` job dependencies so it will be included in the notification workflo

🤖 Generated with [Claude Code](https://claude.com/claude-code)