### PR TITLE
ci: raise native-unit-tests job timeout to 30 minutes

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -9,7 +9,10 @@ env:
 
 jobs:
   native-unit-tests:
-    timeout-minutes: 15
+    # A healthy run is ~5 minutes. The headroom is for the intermittent hang between
+    # "test bundle built" and "Testing started", where xcodebuild sits silently waiting
+    # on the simulator and never begins the run.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
## What is happening

`native-unit-tests (iOS, mParticle-Apple-SDK-Swift)` has been cancelled at **exactly 15m** on two branches: `refactor/custom-modules-config-parsing` (#836) and `refactor/identity-request-filter-user-to-swift` (#844).

A job that exceeds `timeout-minutes` is reported by GitHub as **cancelled**, not failed — which is why this reads like an ordinary concurrency cancellation and has been easy to miss. The other cancelled `native-unit-tests` jobs in the same window (7m, 8m) really are concurrency cancellations from `cancel-in-progress`; these two are not.

## It is not slow tests

Both cancelled runs execute **zero** test cases. The build completes, then `xcodebuild` goes silent and is killed:

| | build finishes | cancelled | silent gap |
|---|---|---|---|
| #836 (job 97860914598) | 15:33:53 | 15:44:33 | **10m40s** |
| #844 (job 97899515415) | 17:32:26 | 17:39:44 | **7m18s** |

Neither log contains `Testing started`, `IDETestOperationsObserverDebug`, or `TEST SUCCEEDED`. A healthy run of the same job emits all three and finishes in about **5 minutes** total, with a 67-second test phase.

So the hang sits between "test bundle built" and "test run begins" — simulator boot or test-runner launch — and it is intermittent, since the same job passes on other runs.

## Not caused by the recent test changes

- **#837** (`MPRoktTests` timeouts and teardown drain) touches `UnitTests/ObjCTests/MPRoktTests.m`, which belongs to the `mParticle-Apple-SDK` scheme. The hanging job is the `mParticle-Apple-SDK-Swift` scheme — a different target that does not compile that file.
- **#836** adds Swift tests, but no test ever starts, so test content cannot be the cause.

## Caveat on this fix

This treats the symptom. More headroom will not rescue a run that hangs indefinitely; it just spends more of a contended macOS runner pool before giving up. A retry on the test step matches the failure mode better, but that changes the gate's behaviour, so it should be a deliberate separate decision rather than something folded in here.

30 minutes matches `cross-platform-tests.yml` and `integration-tests.yml`.