### PR TITLE
fix(rn-example): update React Native bridge for SDK 9.x

### DIFF
--- a/RNExample/ios/Podfile
+++ b/RNExample/ios/Podfile
@@ -5,7 +5,9 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
-platform :ios, min_ios_version_supported
+# Floor is set by react-native-mparticle 3.x (iOS 15.6), not by this SDK,
+# which still supports iOS 15.0. RN 0.76's own floor is 15.1.
+platform :ios, '15.6'
 prepare_react_native_project!
 
 linkage = ENV['USE_FRAMEWORKS']
@@ -16,7 +18,7 @@ end
 
   # Local Pods for testing Core
   use_frameworks! :linkage => :static
-  pod 'mParticle-Apple-SDK', :path => '../..'
+  pod 'mParticle-Apple-SDK-ObjC', :path => '../..'
 
 target 'RNExample' do
   config = use_native_modules!

--- a/RNExample/ios/Podfile
+++ b/RNExample/ios/Podfile
@@ -16,9 +16,12 @@ if linkage != nil
   use_frameworks! :linkage => linkage.to_sym
 end
 
-  # Local Pods for testing Core
+  # Local Pods for testing Core. Both halves of the SDK must come from this
+  # checkout: the ObjC core references Swift symbols that only exist here until
+  # the next release, so letting the Swift pod resolve from trunk fails to build.
   use_frameworks! :linkage => :static
   pod 'mParticle-Apple-SDK-ObjC', :path => '../..'
+  pod 'mParticle-Apple-SDK-Swift', :path => '../..'
 
 target 'RNExample' do
   config = use_native_modules!

--- a/RNExample/ios/RNExample.xcodeproj/project.pbxproj
+++ b/RNExample/ios/RNExample.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = RNExampleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -446,7 +446,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = RNExampleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -472,7 +472,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = RNExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -499,7 +499,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = RNExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -577,7 +577,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -661,7 +661,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/RNExample/package-lock.json
+++ b/RNExample/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "18.3.1",
         "react-native": "0.76.2",
-        "react-native-mparticle": "^2.7.13"
+        "react-native-mparticle": "^3.3.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -10756,13 +10756,19 @@
       }
     },
     "node_modules/react-native-mparticle": {
-      "version": "2.7.13",
-      "resolved": "https://registry.npmjs.org/react-native-mparticle/-/react-native-mparticle-2.7.13.tgz",
-      "integrity": "sha512-qhCsIHFD94wiZfjsUHm8lfOSYGwBFnfJcLD38HtoPiwGGS7dpEqbkMCSbuka1UAR/b2YJ6NLoZghqL8C/MHkRA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-mparticle/-/react-native-mparticle-3.3.3.tgz",
+      "integrity": "sha512-QSe1+8gOU4ZxBzq8oaQGlNZajFa/Z+8+ClkI/wSwq8y/pU2jsAw0/NeW8V4JIgsMVKLiVphNy+O75gY8QB3G9Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@expo/config-plugins": ">=7.0.0",
         "react": ">= 16.0.0-alpha.12",
-        "react-native": ">= 0.45.0"
+        "react-native": ">= 0.76.0"
+      },
+      "peerDependenciesMeta": {
+        "@expo/config-plugins": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native/node_modules/ansi-styles": {

--- a/RNExample/package.json
+++ b/RNExample/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.3.1",
     "react-native": "0.76.2",
-    "react-native-mparticle": "^2.7.13"
+    "react-native-mparticle": "^3.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Stacked on #847 — base is `claude/job-build-secondary-platforms-1ac262`.

## Problem

Re-enabling `build-secondary-platforms` in #847 surfaced why it was disabled after the 9.0 release. `build-react-native` fails at `pod install`:

```
[!] CocoaPods could not find compatible versions for pod "mParticle-Apple-SDK":
  In Podfile:
    mParticle-Apple-SDK (from `../..`)

    react-native-mparticle (from `../node_modules/react-native-mparticle`) was resolved to 2.9.2, which depends on
      mParticle-Apple-SDK (~> 8.0)
```

`RNExample` pinned `react-native-mparticle` at `^2.7.13`, which resolves to 2.9.2 and requires `mParticle-Apple-SDK (~> 8.0)`. The local podspec is 9.4.0, so resolution fails.

## Fix

- **Bump `react-native-mparticle` to `^3.3.3`.** The 3.x line depends on `mParticle-Apple-SDK-ObjC >= 9.2.2, < 10.0`, which local 9.4.0 satisfies. It also requires `react-native >= 0.76.0`; the example is on 0.76.2.
- **Point the local path pod at `mParticle-Apple-SDK-ObjC`.** After the 9.0 Swift/ObjC split, `mParticle-Apple-SDK-ObjC` is the pod the bridge actually consumes; `mParticle-Apple-SDK` is now the Swift umbrella.
- **Raise the example app deployment target to iOS 15.6.**

## On the iOS 15.6 deployment target

**The SDK's minimum is unchanged at iOS 15.0** — `mParticle-Apple-SDK.podspec`, `mParticle-Apple-SDK-ObjC.podspec`, `mParticle-Apple-SDK-Swift.podspec`, and `Package.swift` are all untouched. This change is scoped to `RNExample`.

The 15.6 floor is imposed by the third party, not chosen here. Every `react-native-mparticle` 3.x release declares `ios_platform = '15.6'`:

| bridge version | iOS platform | SDK dependency |
| --- | --- | --- |
| 3.0.0 | 15.6 | `mParticle-Apple-SDK-ObjC ~> 9.0` |
| 3.1.0 – 3.3.0 | 15.6 | `mParticle-Apple-SDK-ObjC ~> 9.2` |
| 3.3.1 – 3.3.3 | 15.6 | `mParticle-Apple-SDK-ObjC >= 9.2.2, < 10.0` |

There is no 3.x release that supports a lower target, and 2.x cannot work with 9.x at all.

Worth noting the example app was never at 15.0 to begin with: `min_ios_version_supported` resolves to **15.1** on RN 0.76.2, and the Xcode project already had `IPHONEOS_DEPLOYMENT_TARGET = 15.1`. This moves the example from 15.1 to 15.6.

## Validation

Resolved the full graph against the local podspecs:

- `mParticle-Apple-SDK-ObjC` local 9.4.0 satisfies bridge requirement `>= 9.2.2, < 10.0` ✅
- `mParticle-Apple-SDK-Swift = 9.4.0` published on trunk ✅
- `RoktContracts ~> 2.0` → 2.0.2 available ✅
- Platform: Podfile 15.6 ≥ bridge 15.6 ≥ local SDK 15.0 ✅
- `trunk check` — no new issues ✅

A full local `pod install` could not finish because `repo1.maven.org` rate-limited this machine (HTTP 429) on the Hermes artifact, which is unrelated to these changes — the CI runner downloaded that tarball without trouble in the failing run. The `build-react-native` job on this PR is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)