### PR TITLE
fix(example): resolve the local SDK from this checkout

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,8 +4,12 @@ target 'mParticleExample' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
   use_frameworks!
 
-  # Local monorepo SDK (same checkout as this Example/ directory)
-  pod 'mParticle-Apple-SDK-Swift', :path => '../mParticle-Apple-SDK-Swift'
+  # Local monorepo SDK (same checkout as this Example/ directory). All three
+  # podspecs live at the repo root, and :path does not cascade to transitive
+  # dependencies, so each half must be declared to keep the umbrella from
+  # resolving the released core out of the CocoaPods registry.
+  pod 'mParticle-Apple-SDK-ObjC', :path => '..'
+  pod 'mParticle-Apple-SDK-Swift', :path => '..'
   pod 'mParticle-Apple-SDK', :path => '..'
 
   pod 'mParticle-Apple-Media-SDK/mParticleMediaNoLocation', '~> 1.7.0'


### PR DESCRIPTION
Stacked on #852 — base is `fix/rn-example-mparticle-9x-compat`.

Same class of bug as #852, in the native `Example/` app.

## Problems

**1. The Swift pod pointed at a directory with no podspec.**

```ruby
pod 'mParticle-Apple-SDK-Swift', :path => '../mParticle-Apple-SDK-Swift'
```

From `Example/`, that resolves to the Swift *sources* directory, which contains only `Sources/` and `Test/`. All three podspecs live at the repo root.

**2. Only the umbrella was declared locally.**

`mParticle-Apple-SDK.podspec` pins `mParticle-Apple-SDK-ObjC = <version>`, and CocoaPods `:path` applies to the named pod only — it does not cascade to transitive dependencies. So the ObjC core resolved from the **CocoaPods registry** (the published release) rather than this checkout, meaning local changes to `mParticle-Apple-SDK/` were never exercised by the Example app. That is exactly the failure #852 hit in CI:

```
SettingsProvider.m:6:31: error: unknown type name 'MPSettingsProviderPRIVATE'
```

## Fix

Declare all three pods against the repo root so both halves build from this checkout:

```ruby
pod 'mParticle-Apple-SDK-ObjC', :path => '..'
pod 'mParticle-Apple-SDK-Swift', :path => '..'
pod 'mParticle-Apple-SDK', :path => '..'
```

## Pre-existing breakage NOT fixed here

`Example/Podfile` cannot complete `pod install` today for reasons unrelated to this change. Both predate it and are left alone deliberately — each is a version-policy decision that deserves its own review:

**Media SDK pinned to an 8.x subspec**

```
mParticle-Apple-Media-SDK/mParticleMediaNoLocation (~> 1.7.0) depends on
  mParticle-Apple-SDK/mParticleNoLocation (~> 8.37)
None of your spec sources contain a spec satisfying the dependency
```

The `mParticleNoLocation` subspec no longer exists in 9.x. `mParticle-Apple-Media-SDK 2.0.2` is published and depends on `mParticle-Apple-SDK ~> 9.0` with no subspecs, so the likely fix is `pod 'mParticle-Apple-Media-SDK', '~> 2.0'`.

**Rokt-Widget pinned below what the kit requires**

```
Rokt-Widget (from git, tag `5.1.0`)
mParticle-Rokt was resolved to 9.4.0, which depends on
  Rokt-Widget (~> 5.4)
```

Tag `5.4.0` exists on `ROKT/rokt-sdk-ios`. The 5.x line is git-only (not on the CocoaPods registry), so the `:git`/`:tag` approach stays. The `RoktUXHelper` 0.10.4 pin on the line above likely needs to move too — per upstream's own sample Podfile, Rokt-Widget 5.3+ resolves RoktUXHelper 1.0.0.

## Validation

The two fixes here are verified directly: the podspec locations are confirmed at the repo root, and `Example/..` resolves there. A full `pod install` still fails on the two pre-existing conflicts above, so this change is a prerequisite for a working Example rather than a complete restoration of it.

`trunk check` — no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)