### PR TITLE
feat: Migrate Identity to Swift Implementation

### DIFF
--- a/UnitTests/ObjCTests/MPIdentityTests.m
+++ b/UnitTests/ObjCTests/MPIdentityTests.m
@@ -1107,4 +1107,22 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     XCTAssertEqualObjects([MParticle sharedInstance].identity.deviceApplicationStamp, expected);
 }
 
+- (void)testIdentityChangePlainInitProducesNullValues {
+    MPIdentityHTTPIdentityChange *change = [[MPIdentityHTTPIdentityChange alloc] init];
+    NSMutableDictionary *dictionary = [change dictionaryRepresentation];
+    XCTAssertEqualObjects(dictionary[@"old_value"], [NSNull null]);
+    XCTAssertEqualObjects(dictionary[@"new_value"], [NSNull null]);
+    XCTAssertNil(dictionary[@"identity_type"]);
+}
+
+- (void)testHTTPIdentitiesPreservesNonStringValues {
+    MPIdentityHTTPIdentities *identities = [[MPIdentityHTTPIdentities alloc] initWithIdentities:@{
+        @(MPIdentityGoogle): @12345,
+        @(MPIdentityOther): [NSNull null]
+    }];
+    NSDictionary *dictionary = [identities dictionaryRepresentation];
+    XCTAssertEqualObjects(dictionary[@"google"], @12345);
+    XCTAssertEqualObjects(dictionary[@"other"], [NSNull null]);
+}
+
 @end

--- a/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityApiLogic.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityApiLogic.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+@objc public final class MPIdentityAliasPlanPRIVATE: NSObject {
+    @objc public let isValid: Bool
+    @objc public let startTime: Date?
+    @objc public let endTime: Date?
+    @objc public let shouldWarnDateOrder: Bool
+
+    @objc public init(isValid: Bool, startTime: Date?, endTime: Date?, shouldWarnDateOrder: Bool) {
+        self.isValid = isValid
+        self.startTime = startTime
+        self.endTime = endTime
+        self.shouldWarnDateOrder = shouldWarnDateOrder
+        super.init()
+    }
+
+    @objc(planWithSourceMPID:destinationMPID:startTime:endTime:usedFirstLastSeen:aliasMaxWindow:)
+    public static func plan(
+        sourceMPID: NSNumber?,
+        destinationMPID: NSNumber?,
+        startTime: Date?,
+        endTime: Date?,
+        usedFirstLastSeen: Bool,
+        aliasMaxWindow: NSNumber?
+    ) -> MPIdentityAliasPlanPRIVATE {
+        let source = sourceMPID?.int64Value ?? 0
+        let destination = destinationMPID?.int64Value ?? 0
+        if sourceMPID == nil || destinationMPID == nil || source == 0 || destination == 0 || sourceMPID == destinationMPID {
+            return MPIdentityAliasPlanPRIVATE(isValid: false, startTime: startTime, endTime: endTime, shouldWarnDateOrder: false)
+        }
+
+        let maxDaysAgo = aliasMaxWindow?.doubleValue ?? 90
+        let oldestAllowableDate = Date(timeIntervalSinceNow: -60 * 60 * 24 * maxDaysAgo)
+        var adjustedStart = startTime
+        var adjustedEnd = endTime
+
+        if usedFirstLastSeen, let startTime, startTime.compare(oldestAllowableDate) == .orderedAscending {
+            adjustedStart = oldestAllowableDate
+        }
+
+        if adjustedStart == nil || adjustedEnd == nil {
+            adjustedStart = oldestAllowableDate
+            adjustedEnd = Date()
+        }
+
+        let shouldWarn: Bool
+        if let adjustedStart, let adjustedEnd {
+            shouldWarn = adjustedStart.compare(adjustedEnd) != .orderedAscending
+        } else {
+            shouldWarn = false
+        }
+
+        return MPIdentityAliasPlanPRIVATE(
+            isValid: true,
+            startTime: adjustedStart,
+            endTime: adjustedEnd,
+            shouldWarnDateOrder: shouldWarn
+        )
+    }
+}
+
+@objc public final class MPIdentityApiLogicPRIVATE: NSObject {
+    @objc public static func sortedIndexes(byLastSeen dates: NSArray) -> [NSNumber] {
+        dates.enumerated()
+            .compactMap { index, element -> (offset: Int, element: Date)? in
+                guard let date = element as? Date else { return nil }
+                return (index, date)
+            }
+            .sorted { lhs, rhs in
+                let comparison = lhs.element.compare(rhs.element)
+                if comparison == .orderedSame {
+                    return lhs.offset < rhs.offset
+                }
+                return comparison == .orderedDescending
+            }
+            .map { NSNumber(value: $0.offset) }
+    }
+
+    @objc public static func parsedModifyChanges(_ changeResults: NSArray?) -> NSArray {
+        let changes = NSMutableArray()
+        changeResults?.enumerateObjects { object, _, _ in
+            guard let userChange = object as? NSDictionary,
+                  userChange[IdentityHTTPKeys.modifiedMPID] != nil,
+                  let identityString = userChange[IdentityHTTPKeys.identityType] as? String
+            else { return }
+            let identityNumber = MPIdentityHTTPIdentitiesPRIVATE.identityType(for: identityString)
+            let record = NSMutableDictionary()
+            record[IdentityHTTPKeys.modifiedMPID] = userChange[IdentityHTTPKeys.modifiedMPID]
+            record[IdentityHTTPKeys.identityType] = identityString
+            if let identityNumber {
+                record["identity_type_number"] = identityNumber
+            }
+            changes.add(record)
+        }
+        return changes
+    }
+
+    @objc public static func errorFields(from dictionary: NSDictionary?, httpCode: Int) -> NSDictionary {
+        let result = NSMutableDictionary()
+        result["httpCode"] = NSNumber(value: httpCode)
+        if let dictionary {
+            result["code"] = dictionary[IdentityHTTPKeys.code]
+            result["message"] = dictionary[IdentityHTTPKeys.message]
+        } else {
+            result["code"] = NSNumber(value: httpCode)
+        }
+        return result
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityDTO.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityDTO.swift
@@ -33,7 +33,7 @@ enum IdentityHTTPKeys {
 }
 
 @objc public final class MPIdentityHTTPIdentitiesPRIVATE: NSObject {
-    private var nullIdentityKeys = Set<String>()
+    private let passthroughValues = NSMutableDictionary()
 
     @objc public var advertiserId: String?
     @objc public var vendorId: String?
@@ -152,20 +152,20 @@ enum IdentityHTTPKeys {
     }
 
     private func apply(_ value: Any, to property: inout String?, key: String) {
-        if value is NSNull {
-            nullIdentityKeys.insert(key)
-            property = nil
-        } else if let stringValue = value as? String {
-            nullIdentityKeys.remove(key)
+        if let stringValue = value as? String {
+            passthroughValues.removeObject(forKey: key)
             property = stringValue
+            return
         }
+        property = nil
+        passthroughValues[key] = value
     }
 
     private func assign(_ value: String?, to dictionary: NSMutableDictionary, key: String) {
         if let value {
             dictionary[key] = value
-        } else if nullIdentityKeys.contains(key) {
-            dictionary[key] = NSNull()
+        } else if let passthrough = passthroughValues[key] {
+            dictionary[key] = passthrough
         }
     }
 }
@@ -293,6 +293,10 @@ enum IdentityHTTPKeys {
     @objc public var oldValue: String?
     @objc public var value: String?
     @objc public var identityType: String?
+
+    override public init() {
+        super.init()
+    }
 
     @objc public init(oldValue: String?, value: String?, identityType: String?) {
         self.oldValue = oldValue

--- a/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityDTO.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityDTO.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+enum IdentityHTTPKeys {
+    static let clientSDK = "client_sdk"
+    static let platform = "platform"
+    static let sdkVendor = "sdk_vendor"
+    static let sdkVersion = "sdk_version"
+    static let environment = "environment"
+    static let requestId = "request_id"
+    static let requestTimestamp = "request_timestamp_ms"
+    static let previousMPID = "previous_mpid"
+    static let knownIdentities = "known_identities"
+    static let identityChanges = "identity_changes"
+    static let requestType = "request_type"
+    static let apiKey = "api_key"
+    static let data = "data"
+    static let sourceMPID = "source_mpid"
+    static let destinationMPID = "destination_mpid"
+    static let startUnixTime = "start_unixtime_ms"
+    static let endUnixTime = "end_unixtime_ms"
+    static let deviceApplicationStamp = "device_application_stamp"
+    static let oldValue = "old_value"
+    static let newValue = "new_value"
+    static let identityType = "identity_type"
+    static let mpid = "mpid"
+    static let context = "context"
+    static let isEphemeral = "is_ephemeral"
+    static let isLoggedIn = "is_logged_in"
+    static let code = "code"
+    static let message = "message"
+    static let changeResults = "change_results"
+    static let modifiedMPID = "modified_mpid"
+}
+
+@objc public final class MPIdentityHTTPIdentitiesPRIVATE: NSObject {
+    private var nullIdentityKeys = Set<String>()
+
+    @objc public var advertiserId: String?
+    @objc public var vendorId: String?
+    @objc public var deviceApplicationStamp: String?
+    @objc public var pushToken: String?
+    @objc public var customerId: String?
+    @objc public var email: String?
+    @objc public var facebook: String?
+    @objc public var facebookCustomAudienceId: String?
+    @objc public var google: String?
+    @objc public var microsoft: String?
+    @objc public var other: String?
+    @objc public var twitter: String?
+    @objc public var yahoo: String?
+    @objc public var other2: String?
+    @objc public var other3: String?
+    @objc public var other4: String?
+    @objc public var other5: String?
+    @objc public var other6: String?
+    @objc public var other7: String?
+    @objc public var other8: String?
+    @objc public var other9: String?
+    @objc public var other10: String?
+    @objc public var mobileNumber: String?
+    @objc public var phoneNumber2: String?
+    @objc public var phoneNumber3: String?
+
+    override public init() {
+        super.init()
+    }
+
+    @objc(initWithIdentities:attAuthorizationStatus:)
+    public init(identities: NSDictionary?, attAuthorizationStatus: NSNumber?) {
+        super.init()
+        apply(identities: identities, attAuthorizationStatus: attAuthorizationStatus)
+    }
+
+    @objc(stringForIdentityType:)
+    public static func string(forIdentityType identityType: Int) -> String? {
+        IdentityHTTPKeys.string(forIdentityType: identityType)
+    }
+
+    @objc(identityTypeForString:)
+    public static func identityType(for string: String?) -> NSNumber? {
+        IdentityHTTPKeys.identityType(for: string)
+    }
+
+    @objc public func dictionaryRepresentation() -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+        assign(advertiserId, to: dictionary, key: "ios_idfa")
+        assign(vendorId, to: dictionary, key: "ios_idfv")
+        assign(deviceApplicationStamp, to: dictionary, key: "device_application_stamp")
+        #if os(iOS)
+        assign(pushToken, to: dictionary, key: "push_token")
+        #endif
+        assign(customerId, to: dictionary, key: "customerid")
+        assign(email, to: dictionary, key: "email")
+        assign(facebook, to: dictionary, key: "facebook")
+        assign(facebookCustomAudienceId, to: dictionary, key: "facebookcustomaudienceid")
+        assign(google, to: dictionary, key: "google")
+        assign(microsoft, to: dictionary, key: "microsoft")
+        assign(other, to: dictionary, key: "other")
+        assign(twitter, to: dictionary, key: "twitter")
+        assign(yahoo, to: dictionary, key: "yahoo")
+        assign(other2, to: dictionary, key: "other2")
+        assign(other3, to: dictionary, key: "other3")
+        assign(other4, to: dictionary, key: "other4")
+        assign(other5, to: dictionary, key: "other5")
+        assign(other6, to: dictionary, key: "other6")
+        assign(other7, to: dictionary, key: "other7")
+        assign(other8, to: dictionary, key: "other8")
+        assign(other9, to: dictionary, key: "other9")
+        assign(other10, to: dictionary, key: "other10")
+        assign(mobileNumber, to: dictionary, key: "mobile_number")
+        assign(phoneNumber2, to: dictionary, key: "phone_number_2")
+        assign(phoneNumber3, to: dictionary, key: "phone_number_3")
+        return dictionary
+    }
+
+    private func apply(identities: NSDictionary?, attAuthorizationStatus: NSNumber?) {
+        identities?.enumerateKeysAndObjects { key, value, _ in
+            guard let typeNumber = key as? NSNumber else { return }
+            switch MPIdentitySwift(rawValue: typeNumber.intValue) {
+            case .customerId: apply(value, to: &customerId, key: "customerid")
+            case .email: apply(value, to: &email, key: "email")
+            case .facebook: apply(value, to: &facebook, key: "facebook")
+            case .facebookCustomAudienceId: apply(value, to: &facebookCustomAudienceId, key: "facebookcustomaudienceid")
+            case .google: apply(value, to: &google, key: "google")
+            case .microsoft: apply(value, to: &microsoft, key: "microsoft")
+            case .other: apply(value, to: &other, key: "other")
+            case .twitter: apply(value, to: &twitter, key: "twitter")
+            case .yahoo: apply(value, to: &yahoo, key: "yahoo")
+            case .other2: apply(value, to: &other2, key: "other2")
+            case .other3: apply(value, to: &other3, key: "other3")
+            case .other4: apply(value, to: &other4, key: "other4")
+            case .other5: apply(value, to: &other5, key: "other5")
+            case .other6: apply(value, to: &other6, key: "other6")
+            case .other7: apply(value, to: &other7, key: "other7")
+            case .other8: apply(value, to: &other8, key: "other8")
+            case .other9: apply(value, to: &other9, key: "other9")
+            case .other10: apply(value, to: &other10, key: "other10")
+            case .mobileNumber: apply(value, to: &mobileNumber, key: "mobile_number")
+            case .phoneNumber2: apply(value, to: &phoneNumber2, key: "phone_number_2")
+            case .phoneNumber3: apply(value, to: &phoneNumber3, key: "phone_number_3")
+            case .iosAdvertiserId:
+                if attAuthorizationStatus == nil
+                    || attAuthorizationStatus?.intValue == MPATTAuthorizationStatusSwift.authorized.rawValue {
+                    apply(value, to: &advertiserId, key: "ios_idfa")
+                }
+            case .iosVendorId: apply(value, to: &vendorId, key: "ios_idfv")
+            case .pushToken: apply(value, to: &pushToken, key: "push_token")
+            case .deviceApplicationStamp: apply(value, to: &deviceApplicationStamp, key: "device_application_stamp")
+            default: break
+            }
+        }
+    }
+
+    private func apply(_ value: Any, to property: inout String?, key: String) {
+        if value is NSNull {
+            nullIdentityKeys.insert(key)
+            property = nil
+        } else if let stringValue = value as? String {
+            nullIdentityKeys.remove(key)
+            property = stringValue
+        }
+    }
+
+    private func assign(_ value: String?, to dictionary: NSMutableDictionary, key: String) {
+        if let value {
+            dictionary[key] = value
+        } else if nullIdentityKeys.contains(key) {
+            dictionary[key] = NSNull()
+        }
+    }
+}
+
+@objc public final class MPIdentityHTTPRequestBuilderPRIVATE: NSObject {
+    @objc public static func clientSDKDictionary(withVersion sdkVersion: String?) -> NSDictionary {
+        let dictionary = NSMutableDictionary()
+        #if os(tvOS)
+        dictionary[IdentityHTTPKeys.platform] = "tvos"
+        #else
+        dictionary[IdentityHTTPKeys.platform] = "ios"
+        #endif
+        dictionary[IdentityHTTPKeys.sdkVendor] = "mparticle"
+        if let sdkVersion {
+            dictionary[IdentityHTTPKeys.sdkVersion] = sdkVersion
+        }
+        return dictionary
+    }
+
+    @objc public static func baseDictionary(sdkVersion: String?, environment: String?) -> NSMutableDictionary {
+        let dictionary = NSMutableDictionary()
+        dictionary[IdentityHTTPKeys.clientSDK] = clientSDKDictionary(withVersion: sdkVersion)
+        if let environment {
+            dictionary[IdentityHTTPKeys.environment] = environment
+        }
+        dictionary[IdentityHTTPKeys.requestId] = UUID().uuidString
+        let timestamp = floor(Date().timeIntervalSince1970 * 1000)
+        dictionary[IdentityHTTPKeys.requestTimestamp] = NSNumber(value: Int64(timestamp))
+        return dictionary
+    }
+
+    @objc public static func identifyDictionary(
+        sdkVersion: String?,
+        environment: String?,
+        previousMPID: String?,
+        identities: NSDictionary?
+    ) -> NSDictionary {
+        let dictionary = baseDictionary(sdkVersion: sdkVersion, environment: environment)
+        if let previousMPID {
+            dictionary[IdentityHTTPKeys.previousMPID] = previousMPID
+        }
+        if let identities {
+            dictionary[IdentityHTTPKeys.knownIdentities] = identities
+        }
+        return dictionary
+    }
+
+    @objc public static func modifyDictionary(
+        sdkVersion: String?,
+        environment: String?,
+        identityChanges: NSArray?
+    ) -> NSDictionary {
+        let dictionary = baseDictionary(sdkVersion: sdkVersion, environment: environment)
+        let changes = NSMutableArray()
+        identityChanges?.enumerateObjects { object, _, _ in
+            if let changeDictionary = object as? NSDictionary {
+                changes.add(changeDictionary)
+            }
+        }
+        dictionary[IdentityHTTPKeys.identityChanges] = changes
+        return dictionary
+    }
+
+    @objc public static func aliasDictionary(
+        sdkVersion: String?,
+        environment: String?,
+        apiKey: String?,
+        sourceMPID: NSNumber?,
+        destinationMPID: NSNumber?,
+        startTime: Date?,
+        endTime: Date?,
+        deviceApplicationStamp: String?
+    ) -> NSDictionary {
+        let dictionary = baseDictionary(sdkVersion: sdkVersion, environment: environment)
+        dictionary.removeObject(forKey: IdentityHTTPKeys.clientSDK)
+        dictionary.removeObject(forKey: IdentityHTTPKeys.requestTimestamp)
+        dictionary[IdentityHTTPKeys.requestType] = "alias"
+        if let apiKey {
+            dictionary[IdentityHTTPKeys.apiKey] = apiKey
+        }
+        let dataDictionary = NSMutableDictionary()
+        if let sourceMPID {
+            dataDictionary[IdentityHTTPKeys.sourceMPID] = sourceMPID
+        }
+        if let destinationMPID {
+            dataDictionary[IdentityHTTPKeys.destinationMPID] = destinationMPID
+        }
+        if let startTime {
+            dataDictionary[IdentityHTTPKeys.startUnixTime] = milliseconds(from: startTime)
+        }
+        if let endTime {
+            dataDictionary[IdentityHTTPKeys.endUnixTime] = milliseconds(from: endTime)
+        }
+        if let deviceApplicationStamp {
+            dataDictionary[IdentityHTTPKeys.deviceApplicationStamp] = deviceApplicationStamp
+        }
+        dictionary[IdentityHTTPKeys.data] = dataDictionary
+        return dictionary
+    }
+
+    @objc public static func successFields(from dictionary: NSDictionary?) -> NSDictionary {
+        let result = NSMutableDictionary()
+        result[IdentityHTTPKeys.context] = dictionary?[IdentityHTTPKeys.context]
+        if let mpidValue = dictionary?[IdentityHTTPKeys.mpid], !(mpidValue is NSNull) {
+            result[IdentityHTTPKeys.mpid] = NSNumber(value: (mpidValue as AnyObject).longLongValue)
+        }
+        result[IdentityHTTPKeys.isEphemeral] = NSNumber(
+            value: (dictionary?[IdentityHTTPKeys.isEphemeral] as? NSNumber)?.boolValue ?? false
+        )
+        result[IdentityHTTPKeys.isLoggedIn] = NSNumber(
+            value: (dictionary?[IdentityHTTPKeys.isLoggedIn] as? NSNumber)?.boolValue ?? false
+        )
+        if let changeResults = dictionary?[IdentityHTTPKeys.changeResults] {
+            result[IdentityHTTPKeys.changeResults] = changeResults
+        }
+        return result
+    }
+
+    private static func milliseconds(from date: Date) -> NSNumber {
+        NSNumber(value: Int64(floor(date.timeIntervalSince1970 * 1000)))
+    }
+}
+
+@objc public final class MPIdentityHTTPIdentityChangePRIVATE: NSObject {
+    @objc public var oldValue: String?
+    @objc public var value: String?
+    @objc public var identityType: String?
+
+    @objc public init(oldValue: String?, value: String?, identityType: String?) {
+        self.oldValue = oldValue
+        self.value = value
+        self.identityType = identityType
+        super.init()
+    }
+
+    @objc public func dictionaryRepresentation() -> NSMutableDictionary {
+        let dictionary = NSMutableDictionary()
+        dictionary[IdentityHTTPKeys.oldValue] = oldValue ?? NSNull()
+        dictionary[IdentityHTTPKeys.newValue] = value ?? NSNull()
+        if let identityType {
+            dictionary[IdentityHTTPKeys.identityType] = identityType
+        }
+        return dictionary
+    }
+}
+
+private extension IdentityHTTPKeys {
+    static let typeToString: [Int: String] = [
+        MPIdentitySwift.customerId.rawValue: "customerid",
+        MPIdentitySwift.email.rawValue: "email",
+        MPIdentitySwift.facebook.rawValue: "facebook",
+        MPIdentitySwift.facebookCustomAudienceId.rawValue: "facebookcustomaudienceid",
+        MPIdentitySwift.google.rawValue: "google",
+        MPIdentitySwift.microsoft.rawValue: "microsoft",
+        MPIdentitySwift.other.rawValue: "other",
+        MPIdentitySwift.twitter.rawValue: "twitter",
+        MPIdentitySwift.yahoo.rawValue: "yahoo",
+        MPIdentitySwift.other2.rawValue: "other2",
+        MPIdentitySwift.other3.rawValue: "other3",
+        MPIdentitySwift.other4.rawValue: "other4",
+        MPIdentitySwift.other5.rawValue: "other5",
+        MPIdentitySwift.other6.rawValue: "other6",
+        MPIdentitySwift.other7.rawValue: "other7",
+        MPIdentitySwift.other8.rawValue: "other8",
+        MPIdentitySwift.other9.rawValue: "other9",
+        MPIdentitySwift.other10.rawValue: "other10",
+        MPIdentitySwift.mobileNumber.rawValue: "mobile_number",
+        MPIdentitySwift.phoneNumber2.rawValue: "phone_number_2",
+        MPIdentitySwift.phoneNumber3.rawValue: "phone_number_3",
+        MPIdentitySwift.iosAdvertiserId.rawValue: "ios_idfa",
+        MPIdentitySwift.iosVendorId.rawValue: "ios_idfv",
+        MPIdentitySwift.pushToken.rawValue: "push_token",
+        MPIdentitySwift.deviceApplicationStamp.rawValue: "device_application_stamp"
+    ]
+
+    static func string(forIdentityType identityType: Int) -> String? {
+        typeToString[identityType]
+    }
+
+    static func identityType(for string: String?) -> NSNumber? {
+        guard let string else { return nil }
+        guard let match = typeToString.first(where: { $0.value == string }) else { return nil }
+        return NSNumber(value: match.key)
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityUserStorage.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Identity/MPIdentityUserStorage.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@objc public final class MPIdentityUserStoragePRIVATE: NSObject {
+    @objc public static func date(fromMilliseconds milliseconds: Any?) -> Date {
+        let value = (milliseconds as AnyObject?)?.doubleValue ?? 0
+        return Date(timeIntervalSince1970: value/1000.0)
+    }
+
+    @objc public static func shouldSkipEmptyAttributeValue(_ value: Any?) -> Bool {
+        guard let string = value as? NSString else { return false }
+        return string.length <= 0
+    }
+
+    @objc public static func applyingIdentity(
+        _ identityString: Any?,
+        type identityType: Int,
+        toStoredArray storedArray: NSArray?
+    ) -> NSArray {
+        let identities = NSMutableArray(array: storedArray ?? [])
+        let identityTypeNumber = NSNumber(value: identityType)
+        let existingIndex = identities.indexOfObject(passingTest: { object, _, stop in
+            guard let dictionary = object as? NSDictionary,
+                  let currentType = dictionary[MessageKeys.kMPUserIdentityTypeKey] as? NSNumber,
+                  currentType.isEqual(to: identityTypeNumber)
+            else { return false }
+            stop.pointee = true
+            return true
+        })
+
+        let shouldRemove = identityString == nil
+            || identityString is NSNull
+            || (identityString as? String)?.isEmpty == true
+
+        if shouldRemove {
+            if existingIndex != NSNotFound {
+                identities.removeObject(at: existingIndex)
+            }
+            return identities
+        }
+
+        let newIdentityDictionary = NSMutableDictionary(capacity: 4)
+        newIdentityDictionary[MessageKeys.kMPUserIdentityTypeKey] = identityTypeNumber
+        newIdentityDictionary[MessageKeys.kMPUserIdentityIdKey] = identityString
+
+        if existingIndex == NSNotFound {
+            identities.add(newIdentityDictionary)
+        } else {
+            identities.replaceObject(at: existingIndex, with: newIdentityDictionary)
+        }
+        return identities
+    }
+
+    @objc public static func isUserIdentity(_ identityType: Int) -> Bool {
+        identityType <= MPIdentitySwift.phoneNumber3.rawValue
+    }
+
+    @objc public static func audienceDisabledError() -> NSError {
+        NSError(
+            domain: "mParticle Audience",
+            code: 202,
+            userInfo: ["message": "Your workspace is not enabled to retrieve user audiences."]
+        )
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Identity/MPIdentityDTOTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Identity/MPIdentityDTOTests.swift
@@ -43,6 +43,23 @@ final class MPIdentityDTOTests: XCTestCase {
         XCTAssertEqual(identities.email, "a@b.com")
     }
 
+    func testIdentitiesPreservesNonStringValues() {
+        let identities = MPIdentityHTTPIdentitiesPRIVATE(identities: [
+            NSNumber(value: MPIdentitySwift.google.rawValue): NSNumber(value: 12_345),
+            NSNumber(value: MPIdentitySwift.other.rawValue): ["nested": "value"]
+        ], attAuthorizationStatus: nil)
+        let dictionary = identities.dictionaryRepresentation()
+        XCTAssertEqual(dictionary["google"] as? NSNumber, 12_345)
+        XCTAssertEqual((dictionary["other"] as? NSDictionary)?["nested"] as? String, "value")
+    }
+
+    func testIdentityChangeDefaultInitSerializesNSNullValues() {
+        let dictionary = MPIdentityHTTPIdentityChangePRIVATE().dictionaryRepresentation()
+        XCTAssertEqual(dictionary["old_value"] as? NSNull, NSNull())
+        XCTAssertEqual(dictionary["new_value"] as? NSNull, NSNull())
+        XCTAssertNil(dictionary["identity_type"])
+    }
+
     func testIdentityChangeUsesNSNullForMissingValues() {
         let change = MPIdentityHTTPIdentityChangePRIVATE(oldValue: nil, value: nil, identityType: "email")
         let dictionary = change.dictionaryRepresentation()

--- a/mParticle-Apple-SDK-Swift/Test/Identity/MPIdentityDTOTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Identity/MPIdentityDTOTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPIdentityDTOTests: XCTestCase {
+    func testIdentityTypeRoundTrip() {
+        for type in 0...MPIdentitySwift.deviceApplicationStamp.rawValue where type != MPIdentitySwift.alias.rawValue {
+            let string = MPIdentityHTTPIdentitiesPRIVATE.string(forIdentityType: type)
+            XCTAssertNotNil(string, "missing string for \(type)")
+            XCTAssertEqual(MPIdentityHTTPIdentitiesPRIVATE.identityType(for: string), NSNumber(value: type))
+        }
+        XCTAssertNil(MPIdentityHTTPIdentitiesPRIVATE.string(forIdentityType: MPIdentitySwift.alias.rawValue))
+        XCTAssertNil(MPIdentityHTTPIdentitiesPRIVATE.identityType(for: "unknown"))
+    }
+
+    func testIdentitiesDictionaryRepresentation() {
+        let identities = MPIdentityHTTPIdentitiesPRIVATE(identities: [
+            NSNumber(value: MPIdentitySwift.email.rawValue): "a@b.com",
+            NSNumber(value: MPIdentitySwift.customerId.rawValue): "cust",
+            NSNumber(value: MPIdentitySwift.iosAdvertiserId.rawValue): "idfa"
+        ], attAuthorizationStatus: nil)
+        let dictionary = identities.dictionaryRepresentation()
+        XCTAssertEqual(dictionary["email"] as? String, "a@b.com")
+        XCTAssertEqual(dictionary["customerid"] as? String, "cust")
+        XCTAssertEqual(dictionary["ios_idfa"] as? String, "idfa")
+    }
+
+    func testIdentitiesPreservesNSNullValues() {
+        let identities = MPIdentityHTTPIdentitiesPRIVATE(identities: [
+            NSNumber(value: MPIdentitySwift.google.rawValue): NSNull(),
+            NSNumber(value: MPIdentitySwift.email.rawValue): "a@b.com"
+        ], attAuthorizationStatus: nil)
+        let dictionary = identities.dictionaryRepresentation()
+        XCTAssertEqual(dictionary["google"] as? NSNull, NSNull())
+        XCTAssertEqual(dictionary["email"] as? String, "a@b.com")
+    }
+
+    func testIdentitiesSkipsIDFAWhenATTDenied() {
+        let identities = MPIdentityHTTPIdentitiesPRIVATE(identities: [
+            NSNumber(value: MPIdentitySwift.iosAdvertiserId.rawValue): "idfa",
+            NSNumber(value: MPIdentitySwift.email.rawValue): "a@b.com"
+        ], attAuthorizationStatus: NSNumber(value: MPATTAuthorizationStatusSwift.denied.rawValue))
+        XCTAssertNil(identities.advertiserId)
+        XCTAssertEqual(identities.email, "a@b.com")
+    }
+
+    func testIdentityChangeUsesNSNullForMissingValues() {
+        let change = MPIdentityHTTPIdentityChangePRIVATE(oldValue: nil, value: nil, identityType: "email")
+        let dictionary = change.dictionaryRepresentation()
+        XCTAssertEqual(dictionary["old_value"] as? NSNull, NSNull())
+        XCTAssertEqual(dictionary["new_value"] as? NSNull, NSNull())
+        XCTAssertEqual(dictionary["identity_type"] as? String, "email")
+    }
+
+    func testSuccessFieldsParseMPID() {
+        let fields = MPIdentityHTTPRequestBuilderPRIVATE.successFields(from: [
+            "mpid": "42",
+            "context": "ctx",
+            "is_ephemeral": true,
+            "is_logged_in": true,
+            "change_results": [["modified_mpid": 1]]
+        ])
+        XCTAssertEqual(fields["mpid"] as? NSNumber, 42)
+        XCTAssertEqual(fields["context"] as? String, "ctx")
+        XCTAssertEqual((fields["is_ephemeral"] as? NSNumber)?.boolValue, true)
+        XCTAssertEqual((fields["change_results"] as? NSArray)?.count, 1)
+    }
+
+    func testClientSDKPlatform() {
+        let dictionary = MPIdentityHTTPRequestBuilderPRIVATE.clientSDKDictionary(withVersion: "9.4.0")
+        XCTAssertEqual(dictionary["sdk_vendor"] as? String, "mparticle")
+        XCTAssertEqual(dictionary["sdk_version"] as? String, "9.4.0")
+        #if os(tvOS)
+        XCTAssertEqual(dictionary["platform"] as? String, "tvos")
+        #else
+        XCTAssertEqual(dictionary["platform"] as? String, "ios")
+        #endif
+    }
+}
+
+final class MPIdentityApiLogicTests: XCTestCase {
+    func testAliasPlanRejectsInvalidUsers() {
+        XCTAssertFalse(MPIdentityAliasPlanPRIVATE.plan(
+            sourceMPID: nil,
+            destinationMPID: 2,
+            startTime: nil,
+            endTime: nil,
+            usedFirstLastSeen: false,
+            aliasMaxWindow: nil
+        ).isValid)
+        XCTAssertFalse(MPIdentityAliasPlanPRIVATE.plan(
+            sourceMPID: 1,
+            destinationMPID: 1,
+            startTime: nil,
+            endTime: nil,
+            usedFirstLastSeen: false,
+            aliasMaxWindow: nil
+        ).isValid)
+    }
+
+    func testAliasPlanFillsMissingDates() {
+        let plan = MPIdentityAliasPlanPRIVATE.plan(
+            sourceMPID: 1,
+            destinationMPID: 2,
+            startTime: nil,
+            endTime: nil,
+            usedFirstLastSeen: false,
+            aliasMaxWindow: 90
+        )
+        XCTAssertTrue(plan.isValid)
+        XCTAssertNotNil(plan.startTime)
+        XCTAssertNotNil(plan.endTime)
+    }
+
+    func testSortedIndexesByLastSeen() {
+        let dates = [
+            Date(timeIntervalSince1970: 1),
+            Date(timeIntervalSince1970: 3),
+            Date(timeIntervalSince1970: 2)
+        ]
+        XCTAssertEqual(MPIdentityApiLogicPRIVATE.sortedIndexes(byLastSeen: dates as NSArray), [1, 2, 0])
+    }
+
+    func testParsedModifyChangesSkipsInvalidTypes() {
+        let parsed = MPIdentityApiLogicPRIVATE.parsedModifyChanges([
+            ["modified_mpid": 9, "identity_type": "email"],
+            ["modified_mpid": 9, "identity_type": "not-a-type"],
+            ["identity_type": "email"]
+        ])
+        XCTAssertEqual(parsed.count, 2)
+        XCTAssertEqual(
+            (parsed[0] as? NSDictionary)?["identity_type_number"] as? NSNumber,
+            NSNumber(value: MPIdentitySwift.email.rawValue)
+        )
+        XCTAssertNil((parsed[1] as? NSDictionary)?["identity_type_number"])
+    }
+}
+
+final class MPIdentityUserStorageTests: XCTestCase {
+    func testDateFromMilliseconds() {
+        let date = MPIdentityUserStoragePRIVATE.date(fromMilliseconds: 1_000)
+        XCTAssertEqual(date.timeIntervalSince1970, 1, accuracy: 0.001)
+        XCTAssertEqual(MPIdentityUserStoragePRIVATE.date(fromMilliseconds: nil).timeIntervalSince1970, 0, accuracy: 0.001)
+    }
+
+    func testApplyingIdentityAddsReplacesAndRemoves() {
+        let added = MPIdentityUserStoragePRIVATE.applyingIdentity(
+            "a@b.com",
+            type: MPIdentitySwift.email.rawValue,
+            toStoredArray: nil
+        )
+        XCTAssertEqual(added.count, 1)
+
+        let replaced = MPIdentityUserStoragePRIVATE.applyingIdentity(
+            "c@d.com",
+            type: MPIdentitySwift.email.rawValue,
+            toStoredArray: added
+        )
+        XCTAssertEqual(replaced.count, 1)
+        XCTAssertEqual((replaced[0] as? NSDictionary)?[MessageKeys.kMPUserIdentityIdKey] as? String, "c@d.com")
+
+        let removed = MPIdentityUserStoragePRIVATE.applyingIdentity(
+            NSNull(),
+            type: MPIdentitySwift.email.rawValue,
+            toStoredArray: replaced
+        )
+        XCTAssertEqual(removed.count, 0)
+    }
+
+    func testSkipEmptyAttribute() {
+        XCTAssertTrue(MPIdentityUserStoragePRIVATE.shouldSkipEmptyAttributeValue(""))
+        XCTAssertFalse(MPIdentityUserStoragePRIVATE.shouldSkipEmptyAttributeValue("x"))
+        XCTAssertFalse(MPIdentityUserStoragePRIVATE.shouldSkipEmptyAttributeValue(1))
+    }
+
+    func testIsUserIdentity() {
+        XCTAssertTrue(MPIdentityUserStoragePRIVATE.isUserIdentity(MPIdentitySwift.email.rawValue))
+        XCTAssertTrue(MPIdentityUserStoragePRIVATE.isUserIdentity(MPIdentitySwift.phoneNumber3.rawValue))
+        XCTAssertFalse(MPIdentityUserStoragePRIVATE.isUserIdentity(MPIdentitySwift.iosAdvertiserId.rawValue))
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		35C3DC422F2402BF0077C0FD /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
 				Test/Utils/AppEnvironmentProviderTests.swift,
 				Test/Utils/HasherTests.m,
@@ -641,6 +642,7 @@
 		35C3DC442F2402C20077C0FD /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
 				Test/Utils/AppEnvironmentProviderTests.swift,
 				Test/Utils/HasherTests.m,

--- a/mParticle-Apple-SDK/Identity/MPIdentityApi.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApi.m
@@ -123,23 +123,17 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
         apiResult.user = self.currentUser;
         NSMutableArray<MPIdentityChange *> *changes = [[NSMutableArray alloc] init];
 
-        for (NSDictionary *userChange in httpResponse.changeResults) {
-            if (userChange[@"modified_mpid"] != nil && userChange[@"identity_type"] != nil) {
+        for (NSDictionary *userChange in [MPIdentityApiLogicPRIVATE parsedModifyChanges:httpResponse.changeResults]) {
+            NSNumber *identityNumber = userChange[@"identity_type_number"];
+            if (identityNumber != nil) {
                 MPIdentityChange *change = [[MPIdentityChange alloc] init];
-                
                 MParticleUser *changedUser = [[MParticleUser alloc] init];
                 changedUser.userId = userChange[@"modified_mpid"];
                 change.changedUser = changedUser;
-                
-                NSString *identityString = userChange[@"identity_type"];
-                NSNumber *identityNumber = [MPIdentityHTTPIdentities identityTypeForString:identityString];
-                if (identityNumber != nil) {
-                    change.changedIdentity = (MPIdentity)identityNumber.intValue;
-                    
-                    [changes addObject:change];
-                } else {
-                    MPILogError(@"Invalid identity type received: %@", identityString);
-                }
+                change.changedIdentity = (MPIdentity)identityNumber.intValue;
+                [changes addObject:change];
+            } else {
+                MPILogError(@"Invalid identity type received: %@", userChange[@"identity_type"]);
             }
         }
         apiResult.identityChanges = changes;
@@ -332,22 +326,15 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 }
 
 - (NSArray<MParticleUser *> *)sortedUserArrayByLastSeen:(NSMutableArray<MParticleUser *> *)userArray {
-    NSMutableArray<MParticleUser *> *sortedUserArray = [NSMutableArray arrayWithCapacity:userArray.count];
-    while (userArray.count > 0) {
-        NSDate *latestSeen = [NSDate distantPast];
-        int latestIndex = 0;
-        for (int i=0; i<userArray.count; i++) {
-            MParticleUser *user = userArray[i];
-            if ([user.lastSeen compare:latestSeen] == NSOrderedDescending) {
-                latestSeen = user.lastSeen;
-                latestIndex = i;
-            }
-        }
-        MParticleUser *latestUser = userArray[latestIndex];
-        [sortedUserArray addObject:latestUser];
-        [userArray removeObjectAtIndex:latestIndex];
+    NSMutableArray<NSDate *> *dates = [NSMutableArray arrayWithCapacity:userArray.count];
+    for (MParticleUser *user in userArray) {
+        [dates addObject:user.lastSeen ?: [NSDate distantPast]];
     }
-    
+    NSArray<NSNumber *> *indexes = [MPIdentityApiLogicPRIVATE sortedIndexesByLastSeen:dates];
+    NSMutableArray<MParticleUser *> *sortedUserArray = [NSMutableArray arrayWithCapacity:userArray.count];
+    for (NSNumber *index in indexes) {
+        [sortedUserArray addObject:userArray[index.unsignedIntegerValue]];
+    }
     return sortedUserArray;
 }
 
@@ -456,27 +443,20 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 
 - (BOOL)aliasUsers:(MPAliasRequest *)aliasRequest {
     [[MParticle sharedInstance].rokt logRoktApiDiagnostic:@"ALIAS_USERS"];
-    if (aliasRequest.sourceMPID == nil || aliasRequest.destinationMPID == nil || aliasRequest.sourceMPID.longLongValue == 0 || aliasRequest.destinationMPID.longLongValue == 0 || [aliasRequest.sourceMPID isEqual:aliasRequest.destinationMPID]) {
+    MPIdentityAliasPlanPRIVATE *plan = [MPIdentityAliasPlanPRIVATE planWithSourceMPID:aliasRequest.sourceMPID
+                                                                      destinationMPID:aliasRequest.destinationMPID
+                                                                            startTime:aliasRequest.startTime
+                                                                              endTime:aliasRequest.endTime
+                                                                   usedFirstLastSeen:aliasRequest.usedFirstLastSeen
+                                                                       aliasMaxWindow:MParticle.sharedInstance.stateMachine.aliasMaxWindow];
+    if (!plan.isValid) {
         MPILogError(@"Invalid alias request - both users must exist and not be equal.");
         return NO;
     }
-    
-    double maxDaysAgo = MParticle.sharedInstance.stateMachine.aliasMaxWindow != nil ? MParticle.sharedInstance.stateMachine.aliasMaxWindow.doubleValue : 90;
-    double secondsPerDay = 60*60*24;
-    NSDate *oldestAllowableDate = [NSDate dateWithTimeIntervalSinceNow:-1*secondsPerDay*maxDaysAgo];
-    
-    if (aliasRequest.usedFirstLastSeen) {
-        if ([aliasRequest.startTime compare:oldestAllowableDate] == NSOrderedAscending) {
-            aliasRequest.startTime = oldestAllowableDate;
-        }
-    }
-    
-    if (aliasRequest.startTime == nil || aliasRequest.endTime == nil) {
-        aliasRequest.startTime = oldestAllowableDate;
-        aliasRequest.endTime = [NSDate dateWithTimeIntervalSinceNow:0];
-    }
-    
-    if ([aliasRequest.startTime compare:aliasRequest.endTime] != NSOrderedAscending) {
+
+    aliasRequest.startTime = plan.startTime;
+    aliasRequest.endTime = plan.endTime;
+    if (plan.shouldWarnDateOrder) {
         MPILogWarning(@"Invalid alias request - Start date must occur before end date. Alias Request will likely fail");
     }
     
@@ -536,13 +516,10 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 - (instancetype)initWithJsonObject:(NSDictionary *)dictionary httpCode:(NSInteger) httpCode {
     self = [super init];
     if (self) {
+        NSDictionary *fields = [MPIdentityApiLogicPRIVATE errorFieldsFrom:dictionary httpCode:httpCode];
         _httpCode = httpCode;
-        if (dictionary) {
-            _code = [dictionary[kMPIdentityRequestKeyCode] unsignedIntegerValue];
-            _message = dictionary[kMPIdentityRequestKeyMessage];
-        } else {
-            _code = httpCode;
-        }
+        _code = [fields[@"code"] unsignedIntegerValue];
+        _message = fields[@"message"];
     }
     return self;
 }

--- a/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
@@ -236,6 +236,14 @@ static NSString *MPIdentityEnvironmentString(void) {
 
 @implementation MPIdentityHTTPIdentityChange
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _implementation = [[MPIdentityHTTPIdentityChangePRIVATE alloc] initWithOldValue:nil value:nil identityType:nil];
+    }
+    return self;
+}
+
 - (instancetype)initWithOldValue:(NSString *)oldValue value:(NSString *)value identityType:(NSString *)identityType {
     self = [super init];
     if (self) {

--- a/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
@@ -18,32 +18,23 @@
 
 @end
 
+@interface MPIdentityHTTPIdentities ()
+@property (nonatomic, strong) MPIdentityHTTPIdentitiesPRIVATE *implementation;
+@end
+
+@interface MPIdentityHTTPIdentityChange ()
+@property (nonatomic, strong) MPIdentityHTTPIdentityChangePRIVATE *implementation;
+@end
+
+static NSString *MPIdentityEnvironmentString(void) {
+    return [MParticle sharedInstance].environment == MPEnvironmentProduction ? @"production" : @"development";
+}
+
 @implementation MPIdentityHTTPBaseRequest
 
 - (NSDictionary *)dictionaryRepresentation {
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-    
-    NSDictionary *clientSDKDictionary = [MPIdentityHTTPClientSDK clientSDKDictionaryWithVersion:kMParticleSDKVersion];
-    if (clientSDKDictionary) {
-        dictionary[@"client_sdk"] = clientSDKDictionary;
-    }
-    
-    NSString *environment = [MParticle sharedInstance].environment == MPEnvironmentProduction ? @"production" : @"development";
-    if (environment) {
-        dictionary[@"environment"] = environment;
-    }
-    
-    NSString *requestId = [NSUUID UUID].UUIDString;
-    if (requestId) {
-        dictionary[@"request_id"] = requestId;
-    }
-    
-    NSNumber *requestTimestamp = @(floor([NSDate date].timeIntervalSince1970*1000));
-    if (requestTimestamp != nil) {
-        dictionary[@"request_timestamp_ms"] = @(requestTimestamp.longLongValue);
-    }
-    
-    return dictionary;
+    return [MPIdentityHTTPRequestBuilderPRIVATE baseDictionaryWithSdkVersion:kMParticleSDKVersion
+                                                                 environment:MPIdentityEnvironmentString()];
 }
 
 @end
@@ -54,15 +45,15 @@
     self = [super init];
     if (self) {
         _knownIdentities = [[MPIdentityHTTPIdentities alloc] initWithIdentities:apiRequest.identities];
-        
+
         NSNumber *mpid = [MPPersistenceController_PRIVATE mpId];
         if (mpid.longLongValue != 0) {
-            _previousMPID = [MPPersistenceController_PRIVATE mpId].stringValue;
+            _previousMPID = mpid.stringValue;
         }
-        MParticle* mparticle = MParticle.sharedInstance;
-        MPLog* logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue:mparticle.logLevel]];
+        MParticle *mparticle = MParticle.sharedInstance;
+        MPLog *logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue:mparticle.logLevel]];
         logger.customLogger = mparticle.customLogger;
-        MPUserDefaults* userDefaults = MPUserDefaultsConnector.userDefaults;
+        MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
         MPDevice *device = [[MPDevice alloc] initWithStateMachine:(id<MPStateMachineMPDeviceProtocol>)mparticle.stateMachine
                                                      userDefaults:(id<MPIdentityApiMPUserDefaultsProtocol>)userDefaults
                                                          identity:(id<MPIdentityApiMPDeviceProtocol>)mparticle.identity
@@ -72,12 +63,12 @@
         if (vendorId) {
             _knownIdentities.vendorId = vendorId;
         }
-        
+
         NSString *deviceApplicationStamp = [MParticle sharedInstance].stateMachine.consumerInfo.deviceApplicationStamp;
         if (deviceApplicationStamp) {
             _knownIdentities.deviceApplicationStamp = deviceApplicationStamp;
         }
-        
+
 #if TARGET_OS_IOS == 1
         if (![MPStateMachine_PRIVATE isAppExtension]) {
             MPNotificationController_PRIVATE *notificationController = [[MPNotificationController_PRIVATE alloc] init];
@@ -95,19 +86,10 @@
 }
 
 - (NSDictionary *)dictionaryRepresentation {
-    NSMutableDictionary *dictionary = [[super dictionaryRepresentation] mutableCopy];
-    
-    if (_previousMPID) {
-        dictionary[@"previous_mpid"] = _previousMPID;
-    }
-    
-    NSDictionary *identitiesDictionary = [_knownIdentities dictionaryRepresentation];
-    
-    if (identitiesDictionary) {
-        dictionary[@"known_identities"] = identitiesDictionary;
-    }
-    
-    return dictionary;
+    return [MPIdentityHTTPRequestBuilderPRIVATE identifyDictionaryWithSdkVersion:kMParticleSDKVersion
+                                                                     environment:MPIdentityEnvironmentString()
+                                                                    previousMPID:_previousMPID
+                                                                      identities:[_knownIdentities dictionaryRepresentation]];
 }
 
 @end
@@ -115,22 +97,7 @@
 @implementation MPIdentityHTTPClientSDK
 
 + (NSDictionary *)clientSDKDictionaryWithVersion:(NSString *)sdkVersion {
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-    
-
-    NSString *platform = @"ios";
-    #if TARGET_OS_TV == 1
-    platform = @"tvos";
-    #endif
-    
-    dictionary[@"platform"] = platform;
-    dictionary[@"sdk_vendor"] = @"mparticle";
-    
-    if (sdkVersion) {
-        dictionary[@"sdk_version"] = sdkVersion;
-    }
-    
-    return dictionary;
+    return [MPIdentityHTTPRequestBuilderPRIVATE clientSDKDictionaryWithVersion:sdkVersion];
 }
 
 @end
@@ -146,19 +113,14 @@
 }
 
 - (NSDictionary *)dictionaryRepresentation {
-    NSMutableDictionary *dictionary = [[super dictionaryRepresentation] mutableCopy];
-    
     NSMutableArray *identityChanges = [NSMutableArray array];
-    [_identityChanges enumerateObjectsUsingBlock:^(MPIdentityHTTPIdentityChange * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    [_identityChanges enumerateObjectsUsingBlock:^(MPIdentityHTTPIdentityChange *_Nonnull obj, NSUInteger idx, BOOL *stop) {
         NSDictionary *changeDictionary = [obj dictionaryRepresentation];
         [identityChanges addObject:changeDictionary];
     }];
-    
-    if (identityChanges) {
-        dictionary[@"identity_changes"] = identityChanges;
-    }
-    
-    return dictionary;
+    return [MPIdentityHTTPRequestBuilderPRIVATE modifyDictionaryWithSdkVersion:kMParticleSDKVersion
+                                                                   environment:MPIdentityEnvironmentString()
+                                                               identityChanges:identityChanges];
 }
 
 @end
@@ -176,419 +138,98 @@
 }
 
 - (NSDictionary *)dictionaryRepresentation {
-    NSMutableDictionary *dictionary = [[super dictionaryRepresentation] mutableCopy];
-    [dictionary removeObjectForKey:@"client_sdk"];
-    [dictionary removeObjectForKey:@"request_timestamp_ms"];
-    
-    dictionary[@"request_type"] = @"alias";
-    
-    dictionary[@"api_key"] = MParticle.sharedInstance.stateMachine.apiKey;
-    
-    NSMutableDictionary *dataDictionary = [NSMutableDictionary dictionary];
-    
-    if (_sourceMPID != nil) {
-        dataDictionary[@"source_mpid"] = _sourceMPID;
-    }
-    
-    if (_destinationMPID != nil) {
-        dataDictionary[@"destination_mpid"] = _destinationMPID;
-    }
-    
-    if (_startTime) {
-        NSNumber *requestTimestamp = @(floor(_startTime.timeIntervalSince1970*1000));
-        if (requestTimestamp != nil) {
-            dataDictionary[@"start_unixtime_ms"] = @(requestTimestamp.longLongValue);
-        }
-    }
-    
-    if (_endTime) {
-        NSNumber *requestTimestamp = @(floor(_endTime.timeIntervalSince1970*1000));
-        if (requestTimestamp != nil) {
-            dataDictionary[@"end_unixtime_ms"] = @(requestTimestamp.longLongValue);
-        }
-    }
-    
-    NSString *deviceApplicationStamp = [MParticle sharedInstance].stateMachine.consumerInfo.deviceApplicationStamp;
-    if (deviceApplicationStamp) {
-        dataDictionary[@"device_application_stamp"] = deviceApplicationStamp;
-    }
-    
-    dictionary[@"data"] = dataDictionary;
-    
-    return dictionary;
+    return [MPIdentityHTTPRequestBuilderPRIVATE aliasDictionaryWithSdkVersion:kMParticleSDKVersion
+                                                                  environment:MPIdentityEnvironmentString()
+                                                                       apiKey:MParticle.sharedInstance.stateMachine.apiKey
+                                                                   sourceMPID:_sourceMPID
+                                                              destinationMPID:_destinationMPID
+                                                                    startTime:_startTime
+                                                                      endTime:_endTime
+                                                       deviceApplicationStamp:[MParticle sharedInstance].stateMachine.consumerInfo.deviceApplicationStamp];
 }
 
 @end
 
-
 @implementation MPIdentityHTTPIdentities
 
-- (instancetype)initWithIdentities:(NSDictionary *)identities {
+- (instancetype)init {
     self = [super init];
     if (self) {
-        [identities enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
-            MPIdentity identityType = (MPIdentity)key.intValue;
-            
-            switch (identityType) {
-                case MPIdentityCustomerId:
-                    self->_customerId = obj;
-                    break;
-                    
-                case MPIdentityEmail:
-                    self->_email = obj;
-                    break;
-                    
-                case MPIdentityFacebook:
-                    self->_facebook = obj;
-                    break;
-                    
-                case MPIdentityFacebookCustomAudienceId:
-                    self->_facebookCustomAudienceId = obj;
-                    break;
-                    
-                case MPIdentityGoogle:
-                    self->_google = obj;
-                    break;
-                    
-                case MPIdentityMicrosoft:
-                    self->_microsoft = obj;
-                    break;
-                    
-                case MPIdentityOther:
-                    self->_other = obj;
-                    break;
-                    
-                case MPIdentityTwitter:
-                    self->_twitter = obj;
-                    break;
-                    
-                case MPIdentityYahoo:
-                    self->_yahoo = obj;
-                    break;
-                    
-                case MPIdentityOther2:
-                    self->_other2 = obj;
-                    break;
-                    
-                case MPIdentityOther3:
-                    self->_other3 = obj;
-                    break;
-                    
-                case MPIdentityOther4:
-                    self->_other4 = obj;
-                    break;
-                    
-                case MPIdentityOther5:
-                    self->_other5 = obj;
-                    break;
-                    
-                case MPIdentityOther6:
-                    self->_other6 = obj;
-                    break;
-                    
-                case MPIdentityOther7:
-                    self->_other7 = obj;
-                    break;
-                    
-                case MPIdentityOther8:
-                    self->_other8 = obj;
-                    break;
-                    
-                case MPIdentityOther9:
-                    self->_other9 = obj;
-                    break;
-                    
-                case MPIdentityOther10:
-                    self->_other10 = obj;
-                    break;
-                    
-                case MPIdentityMobileNumber:
-                    self->_mobileNumber = obj;
-                    break;
-                    
-                case MPIdentityPhoneNumber2:
-                    self->_phoneNumber2 = obj;
-                    break;
-                    
-                case MPIdentityPhoneNumber3:
-                    self->_phoneNumber3 = obj;
-                    break;
-                    
-                case MPIdentityIOSAdvertiserId: {
-                    NSNumber *currentStatus = [MParticle sharedInstance].stateMachine.attAuthorizationStatus;
-                    if (currentStatus == nil || currentStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-                        self->_advertiserId = obj;
-                    }
-                    break;
-                }
-                    
-                case MPIdentityIOSVendorId:
-                    self->_vendorId = obj;
-                    break;
-                    
-                case MPIdentityPushToken:
-                    self->_pushToken = obj;
-                    break;
-                    
-                case MPIdentityDeviceApplicationStamp:
-                    self->_deviceApplicationStamp = obj;
-                    break;
-                default:
-                    break;
-            }
-        }];
+        _implementation = [[MPIdentityHTTPIdentitiesPRIVATE alloc] init];
     }
     return self;
 }
 
-- (NSDictionary *)dictionaryRepresentation {
-    
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-    
-    if (_advertiserId) {
-        dictionary[@"ios_idfa"] = _advertiserId;
+- (instancetype)initWithIdentities:(NSDictionary *)identities {
+    self = [super init];
+    if (self) {
+        _implementation = [[MPIdentityHTTPIdentitiesPRIVATE alloc] initWithIdentities:identities
+                                                               attAuthorizationStatus:[MParticle sharedInstance].stateMachine.attAuthorizationStatus];
     }
-    
-    if (_vendorId) {
-        dictionary[@"ios_idfv"] = _vendorId;
-    }
-    
-    if (_deviceApplicationStamp) {
-        dictionary[@"device_application_stamp"] = _deviceApplicationStamp;
-    }
-    
-#if TARGET_OS_IOS == 1
-    
-    if (_pushToken) {
-        dictionary[@"push_token"] = _pushToken;
-    }
-    
-#endif
-    
-    if (_customerId) {
-        dictionary[@"customerid"] = _customerId;
-    }
-    
-    if (_email) {
-        dictionary[@"email"] = _email;
-    }
-    
-    if (_facebook) {
-        dictionary[@"facebook"] = _facebook;
-    }
-    
-    if (_facebookCustomAudienceId) {
-        dictionary[@"facebookcustomaudienceid"] = _facebookCustomAudienceId;
-    }
-    
-    if (_google) {
-        dictionary[@"google"] = _google;
-    }
-    
-    if (_microsoft) {
-        dictionary[@"microsoft"] = _microsoft;
-    }
-    
-    if (_other) {
-        dictionary[@"other"] = _other;
-    }
-    
-    if (_twitter) {
-        dictionary[@"twitter"] = _twitter;
-    }
-    
-    if (_yahoo) {
-        dictionary[@"yahoo"] = _yahoo;
-    }
-    
-    if (_other2) {
-        dictionary[@"other2"] = _other2;
-    }
-    
-    if (_other3) {
-        dictionary[@"other3"] = _other3;
-    }
-    
-    if (_other4) {
-        dictionary[@"other4"] = _other4;
-    }
-    
-    if (_other5) {
-        dictionary[@"other5"] = _other5;
-    }
-    
-    if (_other6) {
-        dictionary[@"other6"] = _other6;
-    }
-    
-    if (_other7) {
-        dictionary[@"other7"] = _other7;
-    }
-    
-    if (_other8) {
-        dictionary[@"other8"] = _other8;
-    }
-    
-    if (_other9) {
-        dictionary[@"other9"] = _other9;
-    }
-    
-    if (_other10) {
-        dictionary[@"other10"] = _other10;
-    }
-    
-    if (_mobileNumber) {
-        dictionary[@"mobile_number"] = _mobileNumber;
-    }
-    
-    if (_phoneNumber2) {
-        dictionary[@"phone_number_2"] = _phoneNumber2;
-    }
+    return self;
+}
 
-    if (_phoneNumber3) {
-        dictionary[@"phone_number_3"] = _phoneNumber3;
-    }
-    
-    
-    return dictionary;
+- (NSString *)advertiserId { return self.implementation.advertiserId; }
+- (void)setAdvertiserId:(NSString *)advertiserId { self.implementation.advertiserId = advertiserId; }
+- (NSString *)vendorId { return self.implementation.vendorId; }
+- (void)setVendorId:(NSString *)vendorId { self.implementation.vendorId = vendorId; }
+- (NSString *)deviceApplicationStamp { return self.implementation.deviceApplicationStamp; }
+- (void)setDeviceApplicationStamp:(NSString *)deviceApplicationStamp { self.implementation.deviceApplicationStamp = deviceApplicationStamp; }
+- (NSString *)pushToken { return self.implementation.pushToken; }
+- (void)setPushToken:(NSString *)pushToken { self.implementation.pushToken = pushToken; }
+- (NSString *)customerId { return self.implementation.customerId; }
+- (void)setCustomerId:(NSString *)customerId { self.implementation.customerId = customerId; }
+- (NSString *)email { return self.implementation.email; }
+- (void)setEmail:(NSString *)email { self.implementation.email = email; }
+- (NSString *)facebook { return self.implementation.facebook; }
+- (void)setFacebook:(NSString *)facebook { self.implementation.facebook = facebook; }
+- (NSString *)facebookCustomAudienceId { return self.implementation.facebookCustomAudienceId; }
+- (void)setFacebookCustomAudienceId:(NSString *)facebookCustomAudienceId { self.implementation.facebookCustomAudienceId = facebookCustomAudienceId; }
+- (NSString *)google { return self.implementation.google; }
+- (void)setGoogle:(NSString *)google { self.implementation.google = google; }
+- (NSString *)microsoft { return self.implementation.microsoft; }
+- (void)setMicrosoft:(NSString *)microsoft { self.implementation.microsoft = microsoft; }
+- (NSString *)other { return self.implementation.other; }
+- (void)setOther:(NSString *)other { self.implementation.other = other; }
+- (NSString *)twitter { return self.implementation.twitter; }
+- (void)setTwitter:(NSString *)twitter { self.implementation.twitter = twitter; }
+- (NSString *)yahoo { return self.implementation.yahoo; }
+- (void)setYahoo:(NSString *)yahoo { self.implementation.yahoo = yahoo; }
+- (NSString *)other2 { return self.implementation.other2; }
+- (void)setOther2:(NSString *)other2 { self.implementation.other2 = other2; }
+- (NSString *)other3 { return self.implementation.other3; }
+- (void)setOther3:(NSString *)other3 { self.implementation.other3 = other3; }
+- (NSString *)other4 { return self.implementation.other4; }
+- (void)setOther4:(NSString *)other4 { self.implementation.other4 = other4; }
+- (NSString *)other5 { return self.implementation.other5; }
+- (void)setOther5:(NSString *)other5 { self.implementation.other5 = other5; }
+- (NSString *)other6 { return self.implementation.other6; }
+- (void)setOther6:(NSString *)other6 { self.implementation.other6 = other6; }
+- (NSString *)other7 { return self.implementation.other7; }
+- (void)setOther7:(NSString *)other7 { self.implementation.other7 = other7; }
+- (NSString *)other8 { return self.implementation.other8; }
+- (void)setOther8:(NSString *)other8 { self.implementation.other8 = other8; }
+- (NSString *)other9 { return self.implementation.other9; }
+- (void)setOther9:(NSString *)other9 { self.implementation.other9 = other9; }
+- (NSString *)other10 { return self.implementation.other10; }
+- (void)setOther10:(NSString *)other10 { self.implementation.other10 = other10; }
+- (NSString *)mobileNumber { return self.implementation.mobileNumber; }
+- (void)setMobileNumber:(NSString *)mobileNumber { self.implementation.mobileNumber = mobileNumber; }
+- (NSString *)phoneNumber2 { return self.implementation.phoneNumber2; }
+- (void)setPhoneNumber2:(NSString *)phoneNumber2 { self.implementation.phoneNumber2 = phoneNumber2; }
+- (NSString *)phoneNumber3 { return self.implementation.phoneNumber3; }
+- (void)setPhoneNumber3:(NSString *)phoneNumber3 { self.implementation.phoneNumber3 = phoneNumber3; }
+
+- (NSDictionary *)dictionaryRepresentation {
+    return [self.implementation dictionaryRepresentation];
 }
 
 + (NSString *)stringForIdentityType:(MPIdentity)identityType {
-    switch (identityType) {
-        case MPIdentityCustomerId:
-            return @"customerid";
-            
-        case MPIdentityEmail:
-            return @"email";
-            
-        case MPIdentityFacebook:
-            return @"facebook";
-            
-        case MPIdentityFacebookCustomAudienceId:
-            return @"facebookcustomaudienceid";
-            
-        case MPIdentityGoogle:
-            return @"google";
-            
-        case MPIdentityMicrosoft:
-            return @"microsoft";
-            
-        case MPIdentityOther:
-            return @"other";
-            
-        case MPIdentityTwitter:
-            return @"twitter";
-            
-        case MPIdentityYahoo:
-            return @"yahoo";
-            
-        case MPIdentityOther2:
-            return @"other2";
-            
-        case MPIdentityOther3:
-            return @"other3";
-            
-        case MPIdentityOther4:
-            return @"other4";
-            
-        case MPIdentityOther5:
-            return @"other5";
-            
-        case MPIdentityOther6:
-            return @"other6";
-            
-        case MPIdentityOther7:
-            return @"other7";
-            
-        case MPIdentityOther8:
-            return @"other8";
-            
-        case MPIdentityOther9:
-            return @"other9";
-            
-        case MPIdentityOther10:
-            return @"other10";
-            
-        case MPIdentityMobileNumber:
-            return @"mobile_number";
-            
-        case MPIdentityPhoneNumber2:
-            return @"phone_number_2";
-            
-        case MPIdentityPhoneNumber3:
-            return @"phone_number_3";
-            
-        case MPIdentityIOSAdvertiserId:
-            return @"ios_idfa";
-            
-        case MPIdentityIOSVendorId:
-            return @"ios_idfv";
-            
-        case MPIdentityPushToken:
-            return @"push_token";
-            
-        case MPIdentityDeviceApplicationStamp:
-            return @"device_application_stamp";
-            
-        default:
-            return nil;
-    }
+    return [MPIdentityHTTPIdentitiesPRIVATE stringForIdentityType:(NSInteger)identityType];
 }
 
 + (NSNumber *)identityTypeForString:(NSString *)identityString {
-    if ([identityString isEqualToString:@"customerid"]){
-        return @(MPIdentityCustomerId);
-    } else if ([identityString isEqualToString:@"email"]){
-        return @(MPIdentityEmail);
-    } else if ([identityString isEqualToString:@"facebook"]){
-        return @(MPIdentityFacebook);
-    } else if ([identityString isEqualToString:@"facebookcustomaudienceid"]){
-        return @(MPIdentityFacebookCustomAudienceId);
-    } else if ([identityString isEqualToString:@"google"]){
-        return @(MPIdentityGoogle);
-    } else if ([identityString isEqualToString:@"microsoft"]){
-        return @(MPIdentityMicrosoft);
-    } else if ([identityString isEqualToString:@"other"]){
-        return @(MPIdentityOther);
-    } else if ([identityString isEqualToString:@"twitter"]){
-        return @(MPIdentityTwitter);
-    } else if ([identityString isEqualToString:@"yahoo"]){
-        return @(MPIdentityYahoo);
-    } else if ([identityString isEqualToString:@"other2"]){
-        return @(MPIdentityOther2);
-    } else if ([identityString isEqualToString:@"other3"]){
-        return @(MPIdentityOther3);
-    } else if ([identityString isEqualToString:@"other4"]){
-        return @(MPIdentityOther4);
-    } else if ([identityString isEqualToString:@"other5"]){
-        return @(MPIdentityOther5);
-    } else if ([identityString isEqualToString:@"other6"]){
-        return @(MPIdentityOther6);
-    } else if ([identityString isEqualToString:@"other7"]){
-        return @(MPIdentityOther7);
-    } else if ([identityString isEqualToString:@"other8"]){
-        return @(MPIdentityOther8);
-    } else if ([identityString isEqualToString:@"other9"]){
-        return @(MPIdentityOther9);
-    } else if ([identityString isEqualToString:@"other10"]){
-        return @(MPIdentityOther10);
-    } else if ([identityString isEqualToString:@"mobile_number"]){
-        return @(MPIdentityMobileNumber);
-    } else if ([identityString isEqualToString:@"phone_number_2"]){
-        return @(MPIdentityPhoneNumber2);
-    } else if ([identityString isEqualToString:@"phone_number_3"]){
-        return @(MPIdentityPhoneNumber3);
-    } else if ([identityString isEqualToString:@"ios_idfa"]){
-        return @(MPIdentityIOSAdvertiserId);
-    } else if ([identityString isEqualToString:@"ios_idfv"]){
-        return @(MPIdentityIOSVendorId);
-    } else if ([identityString isEqualToString:@"push_token"]){
-        return @(MPIdentityPushToken);
-    } else if ([identityString isEqualToString:@"device_application_stamp"]){
-        return @(MPIdentityDeviceApplicationStamp);
-    } else {
-        return nil;
-    }
+    return [MPIdentityHTTPIdentitiesPRIVATE identityTypeForString:identityString];
 }
 
 @end
@@ -598,31 +239,20 @@
 - (instancetype)initWithOldValue:(NSString *)oldValue value:(NSString *)value identityType:(NSString *)identityType {
     self = [super init];
     if (self) {
-        _oldValue = oldValue;
-        _value = value;
-        _identityType = identityType;
+        _implementation = [[MPIdentityHTTPIdentityChangePRIVATE alloc] initWithOldValue:oldValue value:value identityType:identityType];
     }
     return self;
 }
 
+- (NSString *)oldValue { return self.implementation.oldValue; }
+- (void)setOldValue:(NSString *)oldValue { self.implementation.oldValue = oldValue; }
+- (NSString *)value { return self.implementation.value; }
+- (void)setValue:(NSString *)value { self.implementation.value = value; }
+- (NSString *)identityType { return self.implementation.identityType; }
+- (void)setIdentityType:(NSString *)identityType { self.implementation.identityType = identityType; }
+
 - (NSMutableDictionary *)dictionaryRepresentation {
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-    if (_oldValue) {
-        dictionary[@"old_value"] = _oldValue;
-    } else {
-        dictionary[@"old_value"] = [NSNull null];
-    }
-    
-    if (_value) {
-        dictionary[@"new_value"] = _value;
-    }
-    else {
-        dictionary[@"new_value"] = [NSNull null];
-    }
-    if (_identityType) {
-        dictionary[@"identity_type"] = _identityType;
-    }
-    return dictionary;
+    return [self.implementation dictionaryRepresentation];
 }
 
 @end
@@ -632,14 +262,11 @@
 - (instancetype)initWithJsonObject:(NSDictionary *)dictionary {
     self = [super init];
     if (self) {
-        _context = dictionary[kMPIdentityRequestKeyContext];
-        NSString *mpidString = dictionary[kMPIdentityRequestKeyMPID];
-        if (mpidString) {
-            _mpid = [NSNumber numberWithLongLong:(long long)[mpidString longLongValue]];
-        }
-        _isEphemeral = [[dictionary objectForKey:kMPIdentityRequestKeyIsEphemeral] boolValue];
-        _isLoggedIn =  [[dictionary objectForKey:kMPIdentityRequestKeyIsLoggedIn] boolValue];
-
+        NSDictionary *fields = [MPIdentityHTTPRequestBuilderPRIVATE successFieldsFrom:dictionary];
+        _context = fields[@"context"];
+        _mpid = fields[@"mpid"];
+        _isEphemeral = [fields[@"is_ephemeral"] boolValue];
+        _isLoggedIn = [fields[@"is_logged_in"] boolValue];
     }
     return self;
 }
@@ -655,7 +282,8 @@
 - (instancetype)initWithJsonObject:(NSDictionary *)dictionary {
     self = [super initWithJsonObject:dictionary];
     if (self) {
-        _changeResults = [dictionary objectForKey:kMPIdentityRequestKeyChangeResults];
+        NSDictionary *fields = [MPIdentityHTTPRequestBuilderPRIVATE successFieldsFrom:dictionary];
+        _changeResults = fields[@"change_results"];
     }
     return self;
 }

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -50,8 +50,7 @@
 
 - (NSDate *)firstSeen {
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    NSNumber *firstSeenMs = [userDefaults mpObjectForKey:kMPFirstSeenUser userId:self.userId];
-    return [NSDate dateWithTimeIntervalSince1970:firstSeenMs.doubleValue/1000.0];
+    return [MPIdentityUserStoragePRIVATE dateFromMilliseconds:[userDefaults mpObjectForKey:kMPFirstSeenUser userId:self.userId]];
 }
 
 - (NSDate *)lastSeen {
@@ -59,8 +58,7 @@
         return [NSDate date];
     }
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    NSNumber *lastSeenMs = [userDefaults mpObjectForKey:kMPLastSeenUser userId:self.userId];
-    return [NSDate dateWithTimeIntervalSince1970:lastSeenMs.doubleValue/1000.0];
+    return [MPIdentityUserStoragePRIVATE dateFromMilliseconds:[userDefaults mpObjectForKey:kMPLastSeenUser userId:self.userId]];
 }
 
 - (NSDictionary*)identities {
@@ -123,7 +121,7 @@
 }
 
 - (void)setIdentitySync:(NSString *)identityString identityType:(MPIdentity)identityType timestamp:(NSDate *)timestamp {
-    if ([MPEnum isUserIdentity:identityType]) {
+    if ([MPIdentityUserStoragePRIVATE isUserIdentity:(NSInteger)identityType]) {
         __weak MParticleUser *weakSelf = self;
         [self.backendController setUserIdentity:identityString
                                    identityType:(MPUserIdentity)identityType
@@ -142,51 +140,12 @@
                               }];
     }
     
-    NSNumber *identityTypeNumber = @(identityType);
-    BOOL (^objectTester)(id, NSUInteger, BOOL *) = ^(id obj, NSUInteger idx, BOOL *stop) {
-        NSNumber *currentIdentityType = obj[kMPUserIdentityTypeKey];
-        BOOL foundMatch = [currentIdentityType isEqualToNumber:identityTypeNumber];
-        
-        if (foundMatch) {
-            *stop = YES;
-        }
-        
-        return foundMatch;
-    };
-    
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    NSMutableArray *identities = [[userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:[MPPersistenceController_PRIVATE mpId]] mutableCopy];
-    if (!identities) {
-        identities = [[NSMutableArray alloc] init];
-    }
-    NSUInteger existingEntryIndex;
-    
-    if (identityString == nil || (NSNull *)identityString == [NSNull null] || [identityString isEqualToString:@""]) {
-        existingEntryIndex = [identities indexOfObjectPassingTest:objectTester];
-        
-        if (existingEntryIndex != NSNotFound) {
-            [identities removeObjectAtIndex:existingEntryIndex];
-        }
-    } else {
-        existingEntryIndex = [identities indexOfObjectPassingTest:objectTester];
-        
-        if (existingEntryIndex == NSNotFound) {
-            NSMutableDictionary *newIdentityDictionary = [[NSMutableDictionary alloc] initWithCapacity:4];
-            
-            newIdentityDictionary[kMPUserIdentityTypeKey] = identityTypeNumber;
-            newIdentityDictionary[kMPUserIdentityIdKey] = identityString;
-                        
-            [identities addObject:newIdentityDictionary];
-        } else {
-            NSMutableDictionary *newIdentityDictionary = [[NSMutableDictionary alloc] initWithCapacity:4];
-            
-            newIdentityDictionary[kMPUserIdentityTypeKey] = identityTypeNumber;
-            newIdentityDictionary[kMPUserIdentityIdKey] = identityString;
-            
-            [identities replaceObjectAtIndex:existingEntryIndex withObject:newIdentityDictionary];
-        }
-    }
-        
+    NSArray *storedIdentities = [userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:[MPPersistenceController_PRIVATE mpId]];
+    NSArray *identities = [MPIdentityUserStoragePRIVATE applyingIdentity:identityString
+                                                                    type:(NSInteger)identityType
+                                                          toStoredArray:storedIdentities];
+
     [userDefaults setObject:identities forKeyedSubscript:kMPUserIdentityArrayKey];
     [userDefaults synchronize];
 }
@@ -263,7 +222,7 @@
 }
 
 - (void)setUserAttribute:(nonnull NSString *)key value:(nonnull id)value {
-    if ([value isKindOfClass:[NSString class]] && (((NSString *)value).length <= 0)) {
+    if ([MPIdentityUserStoragePRIVATE shouldSkipEmptyAttributeValue:value]) {
         MPILogDebug(@"User attribute not updated. Please use removeUserAttribute.");
         
         return;
@@ -442,9 +401,7 @@
             [self.backendController fetchAudiencesWithCompletionHandler:completionHandler];
         });
     } else {
-        NSError *audienceError = [NSError errorWithDomain:@"mParticle Audience"
-                                                     code:202
-                                                 userInfo:@{@"message":@"Your workspace is not enabled to retrieve user audiences."}];
+        NSError *audienceError = [MPIdentityUserStoragePRIVATE audienceDisabledError];
         completionHandler(nil, audienceError);
     }
 }


### PR DESCRIPTION
## What

Moves identity HTTP DTO mapping, alias/user-sort helpers, and user-identity storage into the Foundation-only Swift module while keeping **`MPIdentityDTO`, `MPIdentityApi`, and `MParticleUser` as Objective-C facades**. Public headers and selectors are unchanged so apps and kits are not broken.

Unlike [internal leaf types that can be deleted](https://github.com/mParticle/mparticle-apple-sdk/pull/857), these classes are public / kit-facing, so they stay in the ObjC target with a Swift `*PRIVATE` implementation behind them — the same pattern as identity request/filter (`#844`) and `MPStateMachine` (`#854`).

## How the ObjC-module dependency cycle is handled

Swift cannot import the ObjC module. Logic that does not need `MParticle`, persistence, kits, or UIKit lives in Swift; ObjC `.m` files marshal and forward:

- `MPIdentityHTTPIdentitiesPRIVATE` / `MPIdentityHTTPRequestBuilderPRIVATE` / `MPIdentityHTTPIdentityChangePRIVATE` — identity type ↔ wire-string mapping, ATT IDFA gating, request/success dictionaries, `NSNull` for missing change values (and for identity values that were `NSNull` in the input, matching cache hashing).
- `MPIdentityAliasPlanPRIVATE` / `MPIdentityApiLogicPRIVATE` — alias MPID/date-window validation, last-seen sort indexes, modify-change parsing, HTTP error fields.
- `MPIdentityUserStoragePRIVATE` — first/last-seen dates, stored identity-array add/replace/remove, empty-attribute skip, audience-disabled error.

**Left in ObjC (still coupled to the rest of the SDK):** identify-request construction (persisted MPID, `MPDevice` vendor ID, DAS, iOS push token), environment string from `MParticle.sharedInstance`, identify/login/logout/modify networking, kit forwarding, MPID change, persistence, `currentUser` locking, and session `sessionUserIds` merge (`componentsSeparatedByString` on `""` is `[""]`; that behavior stays on the ObjC side).

## Behavior / API

- Public class names, headers, and selectors are unchanged.
- Identity HTTP dictionaries keep the same keys, nil vs `NSNull` semantics, iOS-only `push_token`, and ATT skip of IDFA when status is present and not authorized.
- Alias requests still reject missing/zero/equal MPIDs, clamp start when `usedFirstLastSeen` is set, and fill missing dates from the alias max window.

## Validation

- `trunk check`: clean for the identity Swift/ObjC sources (pre-existing markdown lint only in `.cursor/plans`).
- Build `mParticle-Apple-SDK` (iOS + tvOS): **succeeded**.
- Static analyzer (`mParticle-Apple-SDK`, Debug, iPhone simulator): **ANALYZE SUCCEEDED**, no diagnostics.
- **ObjC identity contract:** `MPIdentityTests`, `MParticleUserTests`, `MPIdentityCachingTests` (including `NSNull` google identity in identify-request hashing).
- New `MPIdentityDTOTests.swift`: type round-trip, ATT IDFA skip, `NSNull` identities/changes, alias plan, last-seen indexes, modify-change parse, identity-array mutation, empty-attribute skip.