### PR TITLE
refactor: move the push device-token store to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Notifications/MPDeviceTokenStore.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Notifications/MPDeviceTokenStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// The result of a push device-token transition: the notification payload to post,
+/// and the token strings the device-ID modification call needs.
+@objc(MPDeviceTokenChange) public final class DeviceTokenChange: NSObject {
+    @objc public let userInfo: [String: Any]
+    @objc public let newTokenString: String?
+    @objc public let oldTokenString: String?
+
+    /// Mirrors `if (oldTokenString && newTokenString)` — an empty token yields a nil
+    /// string from `stringFromDeviceToken`, so it does not report a device-ID change.
+    @objc public var shouldModifyDeviceID: Bool {
+        return newTokenString != nil && oldTokenString != nil
+    }
+
+    init(newToken: Data?, oldToken: Data?) {
+        var userInfo: [String: Any] = [:]
+
+        if let newToken = newToken {
+            userInfo[Notifications.kMPRemoteNotificationDeviceTokenKey.rawValue] = newToken
+            newTokenString = MPUserDefaults.stringFromDeviceToken(newToken)
+        } else {
+            newTokenString = nil
+        }
+
+        if let oldToken = oldToken {
+            userInfo[Notifications.kMPRemoteNotificationOldDeviceTokenKey.rawValue] = oldToken
+            oldTokenString = MPUserDefaults.stringFromDeviceToken(oldToken)
+        } else {
+            oldTokenString = nil
+        }
+
+        self.userInfo = userInfo
+
+        super.init()
+    }
+}
+
+/// Owns the process-wide push device token. Replaces the file-static `NSData *deviceToken`
+/// in MPNotificationController.m; persistence stays on the ObjC side, which cannot be
+/// reached from here.
+@objc(MPDeviceTokenStore) public final class DeviceTokenStore: NSObject {
+    @objc public static let shared = DeviceTokenStore()
+
+    private let lock = NSLock()
+    private var token: Data?
+
+    @objc override public init() {
+        super.init()
+    }
+
+    @objc(currentToken)
+    public func currentToken() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return token
+    }
+
+    /// The getter path: the ObjC property reloaded the token from persistence on every
+    /// read and left the process-wide value holding whatever it found, nil included.
+    @objc(adoptPersistedToken:)
+    public func adopt(persistedToken: Data?) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        token = persistedToken
+        return token
+    }
+
+    /// Returns nil when there is nothing to do.
+    ///
+    /// Mirrors `if ([deviceToken isEqualToData:devToken]) return;`, which messages a nil
+    /// receiver while no token is stored and so returns NO — meaning a transition out of
+    /// "no token", nil-to-nil included, proceeds rather than short-circuiting.
+    @objc(changeToToken:)
+    public func change(to newToken: Data?) -> DeviceTokenChange? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = token, existing == newToken {
+            return nil
+        }
+
+        let oldToken = token
+        token = newToken
+        return DeviceTokenChange(newToken: newToken, oldToken: oldToken)
+    }
+
+    @objc(postChange:)
+    public func post(_ change: DeviceTokenChange) {
+        NotificationCenter.default.post(name: Notifications.kMPRemoteNotificationDeviceTokenNotification,
+                                        object: nil,
+                                        userInfo: change.userInfo)
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Notifications/MPDeviceTokenStoreTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Notifications/MPDeviceTokenStoreTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPDeviceTokenStoreTests: XCTestCase {
+    private var store: DeviceTokenStore!
+
+    private let newTokenKey = Notifications.kMPRemoteNotificationDeviceTokenKey.rawValue
+    private let oldTokenKey = Notifications.kMPRemoteNotificationOldDeviceTokenKey.rawValue
+
+    private let tokenA = Data([0x01, 0x02, 0x03])
+    private let tokenB = Data([0x0a, 0xff])
+
+    override func setUp() {
+        super.setUp()
+        store = DeviceTokenStore()
+    }
+
+    // MARK: - currentToken / adopt
+
+    func testCurrentTokenStartsNil() {
+        XCTAssertNil(store.currentToken())
+    }
+
+    func testAdoptStoresAndReturnsPersistedToken() {
+        XCTAssertEqual(store.adopt(persistedToken: tokenA), tokenA)
+        XCTAssertEqual(store.currentToken(), tokenA)
+    }
+
+    func testAdoptClearsTheTokenWhenNothingIsPersisted() {
+        _ = store.adopt(persistedToken: tokenA)
+
+        XCTAssertNil(store.adopt(persistedToken: nil))
+        XCTAssertNil(store.currentToken())
+    }
+
+    // MARK: - change de-duplication
+
+    func testChangeToTheSameTokenIsANoOp() {
+        _ = store.change(to: tokenA)
+
+        XCTAssertNil(store.change(to: tokenA))
+        XCTAssertEqual(store.currentToken(), tokenA)
+    }
+
+    func testChangeToADifferentTokenReportsBothSides() {
+        _ = store.change(to: tokenA)
+
+        let change = store.change(to: tokenB)
+
+        XCTAssertNotNil(change)
+        XCTAssertEqual(change?.userInfo[newTokenKey] as? Data, tokenB)
+        XCTAssertEqual(change?.userInfo[oldTokenKey] as? Data, tokenA)
+        XCTAssertEqual(store.currentToken(), tokenB)
+    }
+
+    /// The ObjC original messaged a nil receiver in its equality guard, so a nil-to-nil
+    /// transition fell through rather than short-circuiting and still posted. The payload is
+    /// empty, which MPBackendController's observer discards, but the post itself is preserved.
+    func testChangeFromNilToNilStillProducesAChange() {
+        let change = store.change(to: nil)
+
+        XCTAssertNotNil(change)
+        XCTAssertTrue(change?.userInfo.isEmpty ?? false)
+        XCTAssertNil(store.currentToken())
+    }
+
+    func testChangeFromATokenToNilReportsOnlyTheOldSide() {
+        _ = store.change(to: tokenA)
+
+        let change = store.change(to: nil)
+
+        XCTAssertNotNil(change)
+        XCTAssertNil(change?.userInfo[newTokenKey])
+        XCTAssertEqual(change?.userInfo[oldTokenKey] as? Data, tokenA)
+        XCTAssertNil(store.currentToken())
+    }
+
+    func testFirstChangeReportsOnlyTheNewSide() {
+        let change = store.change(to: tokenA)
+
+        XCTAssertEqual(change?.userInfo[newTokenKey] as? Data, tokenA)
+        XCTAssertNil(change?.userInfo[oldTokenKey])
+    }
+
+    // MARK: - shouldModifyDeviceID
+
+    func testShouldModifyDeviceIDOnlyWhenBothSidesResolve() {
+        _ = store.change(to: tokenA)
+        XCTAssertTrue(store.change(to: tokenB)?.shouldModifyDeviceID ?? false)
+    }
+
+    func testShouldNotModifyDeviceIDOnTheFirstToken() {
+        XCTAssertFalse(store.change(to: tokenA)?.shouldModifyDeviceID ?? true)
+    }
+
+    func testShouldNotModifyDeviceIDWhenTheTokenIsCleared() {
+        _ = store.change(to: tokenA)
+        XCTAssertFalse(store.change(to: nil)?.shouldModifyDeviceID ?? true)
+    }
+
+    /// `stringFromDeviceToken` returns nil for empty data, so an empty token is carried in
+    /// the payload but never reported as a device-ID change.
+    func testEmptyTokenIsPostedButNotReportedAsADeviceIDChange() {
+        _ = store.change(to: tokenA)
+
+        let change = store.change(to: Data())
+
+        XCTAssertEqual(change?.userInfo[newTokenKey] as? Data, Data())
+        XCTAssertNil(change?.newTokenString)
+        XCTAssertFalse(change?.shouldModifyDeviceID ?? true)
+    }
+
+    // MARK: - token strings
+
+    func testTokenStringsAreLowercaseHex() {
+        _ = store.change(to: tokenA)
+
+        let change = store.change(to: tokenB)
+
+        XCTAssertEqual(change?.newTokenString, "0aff")
+        XCTAssertEqual(change?.oldTokenString, "010203")
+    }
+
+    // MARK: - post
+
+    func testPostDeliversTheChangePayloadUnderTheExpectedName() {
+        _ = store.change(to: tokenA)
+        guard let change = store.change(to: tokenB) else {
+            return XCTFail("expected a change")
+        }
+
+        let expectation = expectation(forNotification: Notifications.kMPRemoteNotificationDeviceTokenNotification,
+                                      object: nil) { notification in
+            XCTAssertEqual(notification.userInfo?[self.newTokenKey] as? Data, self.tokenB)
+            XCTAssertEqual(notification.userInfo?[self.oldTokenKey] as? Data, self.tokenA)
+            return true
+        }
+
+        store.post(change)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -600,6 +600,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Notifications/MPDeviceTokenStoreTests.swift,
 				Test/Utils/AppEnvironmentProviderTests.swift,
 				Test/Utils/HasherTests.m,
 				Test/Utils/MPApplicationInfoProviderTests.swift,
@@ -642,6 +643,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Notifications/MPDeviceTokenStoreTests.swift,
 				Test/Utils/AppEnvironmentProviderTests.swift,
 				Test/Utils/HasherTests.m,
 				Test/Utils/MPApplicationInfoProviderTests.swift,

--- a/mParticle-Apple-SDK/Notifications/MPNotificationController.m
+++ b/mParticle-Apple-SDK/Notifications/MPNotificationController.m
@@ -14,10 +14,6 @@
 
 @end
 
-#if TARGET_OS_IOS == 1
-static NSData *deviceToken = nil;
-#endif
-
 @implementation MPNotificationController_PRIVATE
 
 #if TARGET_OS_IOS == 1
@@ -32,54 +28,40 @@ static NSData *deviceToken = nil;
 }
 
 #pragma mark Public static methods
+
+// Non-extractable: MPUserDefaults is reached through MPUserDefaultsConnector, an ObjC type
+// the Swift module cannot import, so persistence stays here. The store owns the token itself.
 - (NSData *)deviceToken {
 #ifndef MP_UNIT_TESTING
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    deviceToken = userDefaults[kMPDeviceTokenKey];
+    NSData *persistedToken = userDefaults[kMPDeviceTokenKey];
 #else
-    deviceToken = [@"<000000000000000000000000000000>" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *persistedToken = [@"<000000000000000000000000000000>" dataUsingEncoding:NSUTF8StringEncoding];
 #endif
-    
-    return deviceToken;
+
+    return [MPDeviceTokenStore.shared adoptPersistedToken:persistedToken];
 }
 
 - (void)setDeviceToken:(NSData *)devToken {
-    if ([deviceToken isEqualToData:devToken]) {
+    MPDeviceTokenChange *change = [MPDeviceTokenStore.shared changeToToken:devToken];
+    if (!change) {
         return;
     }
-    
-    NSData *newDeviceToken = [devToken copy];
-    NSData *oldDeviceToken = [deviceToken copy];
-    
-    deviceToken = devToken;
 
     dispatch_async([MParticle messageQueue], ^{
-        NSMutableDictionary *deviceTokenDictionary = [[NSMutableDictionary alloc] initWithCapacity:2];
-        NSString *newTokenString = nil;
-        NSString *oldTokenString = nil;
-        if (newDeviceToken) {
-            deviceTokenDictionary[kMPRemoteNotificationDeviceTokenKey] = newDeviceToken;
-            newTokenString = [MPUserDefaults stringFromDeviceToken:newDeviceToken];
-        }
-        
-        if (oldDeviceToken) {
-            deviceTokenDictionary[kMPRemoteNotificationOldDeviceTokenKey] = oldDeviceToken;
-            oldTokenString = [MPUserDefaults stringFromDeviceToken:oldDeviceToken];
+        [MPDeviceTokenStore.shared postChange:change];
+
+        // Non-extractable: MPNetworkCommunication is an ObjC type reached through MParticle's
+        // private backendController extension above.
+        if (change.shouldModifyDeviceID) {
+            [[MParticle sharedInstance].backendController.networkCommunication modifyDeviceID:@"push_token"
+                                                                                        value:change.newTokenString
+                                                                                     oldValue:change.oldTokenString];
         }
 
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMPRemoteNotificationDeviceTokenNotification
-                                                            object:nil
-                                                          userInfo:deviceTokenDictionary];
-        
-        if (oldTokenString && newTokenString) {
-            [[MParticle sharedInstance].backendController.networkCommunication modifyDeviceID:@"push_token"
-                                                                                        value:newTokenString
-                                                                                     oldValue:oldTokenString];
-        }
-        
 #ifndef MP_UNIT_TESTING
         MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-        userDefaults[kMPDeviceTokenKey] = deviceToken;
+        userDefaults[kMPDeviceTokenKey] = MPDeviceTokenStore.shared.currentToken;
         [userDefaults synchronize];
 #endif
     });


### PR DESCRIPTION
Moves the push device-token transition logic into the Foundation-only Swift
module, per `docs/swift-migration/CONVERSION-RECIPE.md`. First of three PRs in the
app-lifecycle + kit-forwarding area; one class per PR.

Not stacked — `MPNotificationController` shares no code with the custom-module
stack or the `MPApplication` work, so this can merge on its own.

## What moves

`MPDeviceTokenStore` owns the process-wide token, replacing the file-static
`NSData *deviceToken`, now behind an `NSLock`. `MPDeviceTokenChange` carries the
notification payload plus the two token strings the device-ID modification needs,
and returns `nil` when there is nothing to do.

Reused rather than redefined: the `Notifications.kMPRemoteNotificationDeviceToken*`
names already in `MPResponseConfig.swift`, and `MPUserDefaults.stringFromDeviceToken`.

## What deliberately stays in ObjC

The `.m` keeps the `@interface MParticle ()` extension, the `[MParticle messageQueue]`
dispatch, `MPUserDefaults` persistence via `MPUserDefaultsConnector`, and the
`modifyDeviceID:value:oldValue:` call — all ObjC-module internals the Swift side
cannot import. Marked with `// Non-extractable:` comments.

## Two behaviours preserved on purpose

Both are the kind a straight port silently breaks, so both have tests:

1. **nil-to-nil still posts.** `if ([deviceToken isEqualToData:devToken]) return;`
   messages a *nil receiver* while no token is stored, so it returns `NO` and falls
   through. A plain Swift `if token == newToken { return }` would swallow it.
   Mirrored as `if let existing = token, existing == newToken`.
   (`MPBackendController`'s observer discards the empty payload either way, but the
   post itself is preserved.)
2. **The persisted write re-reads the store.** The original async block wrote the
   *static*, not the captured `newDeviceToken`, so the `.m` writes
   `MPDeviceTokenStore.shared.currentToken` inside the block rather than the argument.

Also preserved: an empty token still appears in the payload but yields a nil token
string, so it is never reported as a device-ID change.

## The public API does not move

`Include/` is untouched — zero diff. This matters here specifically:
`Include/MPBackendController.h:94` vends
`@property (nonatomic, strong, nonnull) MPNotificationController_PRIVATE *notificationController;`,
so that class must stay an ObjC class and does. `abi-guard.sh check` is clean and
`abi-guard-selftest.sh` passes, so the guard is provably armed rather than merely
silent.

No `Package.swift` or podspec changes are needed: the SPM target and the Swift
podspec both glob `mParticle-Apple-SDK-Swift/Sources`, and no ObjC file or
directory was removed. The only `project.pbxproj` change is two lines adding the
new test file to the iOS and tvOS test targets.

## Gate

| Item | Result |
|---|---|
| 1. Zero public-ABI diff | pass — `abi-guard.sh check` clean, selftest PASS, `Include/` diff empty |
| 2. `pod lib lint` x3 podspecs | **iOS pass** ("passed validation"); tvOS not runnable locally |
| 3. Build iOS + tvOS | **iOS pass**; tvOS not runnable locally |
| 4. `trunk check` | pass — no new issues |
| 5. ObjC + Swift suites | pass — ObjC 979/979, Swift 298/298 (14 new) |

**Items 2 and 3 are only partly satisfied.** This machine has the tvOS 26.2 SDK but
only the tvOS 26.0 simulator runtime, so every tvOS destination is rejected with
`Unable to find a destination`, in both `xcodebuild` and pod lint's tvOS leg — which
fails the whole lint even though the iOS leg passes. Environmental, not a compile
failure. **CI is the only tvOS verification** and should be green before merge.
Same limitation as #850.

Low tvOS risk by construction: the Swift type is pure Foundation with no platform
guards, and every ObjC change sits inside the pre-existing `#if TARGET_OS_IOS == 1`.

## On the ObjC suite

An earlier run failed 3 tests, so before assuming flakiness I ran `MParticleTests`
three times on this branch and three times on unmodified `ac5fcd1f`:

| | Run 1 | Run 2 | Run 3 | Runner restarts |
|---|---|---|---|---|
| This branch | pass | pass | pass | 0 |
| Base `ac5fcd1f` | **FAILED** | pass | pass | 1 |

The unmodified base logged `Restarting after unexpected exit, crash, or test timeout`
and ended `** TEST FAILED **`; this branch never restarted the runner. The two
earlier failure sets on this branch were also disjoint (3 consent tests one run,
3 `switchWorkspace` tests another — the first a `segv`, the other two collateral
kills), and the `segv` test passes in isolation. None of them reach
`-deviceToken` / `-setDeviceToken:`. Pre-existing instability, not this change.

## Dual-test convention

There is no ObjC contract test for this class today, so the 14 new Swift tests are
the coverage. `MParticlePushNotificationTokenTests` mocks the controller and is
untouched.

Two pre-existing issues found in passing, **not** fixed here to keep the diff
honest: `MP_UNIT_TESTING` is defined nowhere in the project, so the `#else`
fake-token branch is dead code; and `UnitTests/ObjCTests/MPNotificationController+Tests.h`
declares five `handleApplication…` methods that no longer exist on the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
