### PR TITLE
feat(migration): measure Swift progress against in-scope Objective-C

### DIFF
--- a/Tools/README.md
+++ b/Tools/README.md
@@ -85,9 +85,36 @@ The self-test creates a temporary Git repository and verifies bucket
 isolation, exclusions, code/comment/blank handling, percentage rounding,
 zero-denominator handling, Objective-C++ counting, filenames with spaces,
 renames, physical diff movement across divergent histories, flat changes, and
-regressions.
+regressions. It also covers the retained manifest: comment/blank/whitespace
+parsing, removal from the percentage denominator, retained thinning reported
+without percentage movement, and rejection of stale, non-Objective-C,
+out-of-bucket, and vendored entries.
 
 ### Metric definitions
+
+Progress is measured against the Objective-C the migration actually intends to
+delete, so **100% means every in-scope Objective-C implementation is gone**, not
+that no Objective-C remains. The public/kit contract, runtime-identity, and
+boundary-glue implementations that stay Objective-C by design are listed in
+`Tools/swift-migration-retained-objc.txt`, removed from the percentage's
+denominator, and reported in their own `Objective-C retained` column.
+
+For each bucket:
+
+- **Progress** = Swift SLOC / (Swift SLOC + in-scope Objective-C SLOC).
+- **Objective-C in scope** = Objective-C SLOC still to be deleted.
+- **Objective-C retained** = Objective-C SLOC covered by the manifest, with a
+  signed delta when it moved.
+
+Retained wrappers keep their `@interface`, class name, selectors, and
+nullability, but their logic still moves to Swift and the wrapper thins to
+marshaling. That thinning shows up as a falling retained figure, not as
+percentage movement — the percentage tracks file removal, the retained column
+tracks the boundary shrinking.
+
+Both revisions are counted using the **head** revision's manifest. A PR that
+edits the manifest therefore re-measures its own base under the new definition
+instead of booking the redefinition as progress.
 
 The three production-code buckets do not overlap:
 
@@ -105,12 +132,50 @@ Objective-C remaining. Tests, examples, headers, build outputs, vendored
 libraries, and the customer-facing `MParticle/Sources` Swift overlay are
 excluded.
 
-The pull request movement table is a different metric: physical Swift lines
+The pull request movement table is a different metric, and it is **not**
+filtered by the manifest — deleting lines from a retained wrapper is real work
+and is counted. It reports physical Swift lines
 added and Objective-C/Objective-C++ lines deleted according to
 `git diff base...head --numstat -z`. The three-dot comparison measures changes
 from the merge base through the pull request head, so commits present only on
 an advanced base branch are not attributed to the pull request. These figures
 can differ from the SLOC change because Git includes comments and blank lines.
+
+### Retained Objective-C manifest
+
+`Tools/swift-migration-retained-objc.txt` is the reviewed list of Objective-C
+implementations the migration will not delete. It is the scope boundary, so it
+is committed and changed deliberately — never edited to make a number look
+better.
+
+```text
+# one repository-relative path per line; `#` comments and blanks ignored
+mParticle-Apple-SDK/Event/MPEvent.m
+```
+
+The report validates every entry and fails on any of these, rather than
+silently counting the file as in-scope:
+
+- a path that does not exist in the head revision (stale after a delete or
+  rename — fix the manifest in the same PR);
+- a path that is not a `.m`/`.mm` implementation; or
+- a path outside the three counted buckets, including
+  `mParticle-Apple-SDK/Libraries`.
+
+Adding an entry requires the same evidence
+`docs/swift-migration/CONVERSION-RECIPE.md` demands to classify a declaration
+as a supported contract, runtime-identity-pinned, or boundary glue: name the
+declaration, point at its `Tools/abi-baseline.txt` entry, and record the
+customer/kit/wrapper-SDK audit in the PR. A file whose declaration is an
+accidental export is **not** retained — it stays in scope and its wrapper gets
+deleted.
+
+Removing an entry is the normal end of classification 4: when a boundary is
+redesigned and the glue is deleted, delete its line with it.
+
+Standalone kits have no entries yet. Their `MPKit*` classes are resolved by
+name at runtime, so any kit-side conversion has to establish that contract
+before its implementation is listed here.
 
 ### Workflow behavior and removal
 
@@ -127,7 +192,8 @@ When the migration is complete, remove:
 - `.github/workflows/swift-migration-progress.yml`;
 - the `swift-migration-progress` job and notification dependency in
   `.github/workflows/pull-request.yml`;
-- `Tools/swift-migration-progress.sh`; and
+- `Tools/swift-migration-progress.sh`;
+- `Tools/swift-migration-retained-objc.txt`; and
 - this README section.
 
 There is no stored baseline or external service to clean up.

--- a/Tools/swift-migration-progress.sh
+++ b/Tools/swift-migration-progress.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 readonly COMMENT_MARKER='<!-- swift-migration-progress -->'
 readonly BAR_WIDTH=10
+readonly RETAINED_MANIFEST='Tools/swift-migration-retained-objc.txt'
 
 CLEANUP_DIRS=()
 CREATED_TEMP_DIR=''
@@ -98,25 +99,85 @@ build_bucket_file_list() {
 	esac
 }
 
-COUNT_SWIFT=0
-COUNT_OBJC=0
-
-count_bucket() {
+# Reads the reviewed list of Objective-C implementations the migration will not
+# delete and writes the validated, repository-relative paths to a lookup file.
+# A stale, misplaced, or non-Objective-C entry is a hard failure so the manifest
+# cannot silently stop matching the tree it describes.
+load_retained_manifest() {
 	local revision_root=$1
-	local bucket=$2
-	local cloc_path=$3
-	local working_dir=$4
-	local file_list="${working_dir}/${bucket}-files.txt"
-	local json="${working_dir}/${bucket}-cloc.json"
+	local output=$2
+	local manifest="${revision_root}/${RETAINED_MANIFEST}"
+	local line
+	local path
+	local bucket
+
+	: >"${output}"
+	if [[ ! -f ${manifest} ]]; then
+		return 0
+	fi
+
+	while IFS= read -r line || [[ -n ${line} ]]; do
+		path=${line%$'\r'}
+		path=${path#"${path%%[![:space:]]*}"}
+		path=${path%"${path##*[![:space:]]}"}
+		if [[ -z ${path} || ${path} == '#'* ]]; then
+			continue
+		fi
+		if [[ ${path} != *.m && ${path} != *.mm ]]; then
+			fail "retained manifest entry is not an Objective-C implementation: ${path}"
+		fi
+		bucket=$(classify_path "${path}")
+		if [[ -z ${bucket} ]]; then
+			fail "retained manifest entry is outside every counted bucket: ${path}"
+		fi
+		if [[ ! -f "${revision_root}/${path}" ]]; then
+			fail "retained manifest entry does not exist: ${path}"
+		fi
+		printf '%s\n' "${path}" >>"${output}"
+	done <"${manifest}"
+}
+
+# Splits one bucket's absolute file list into the in-scope and retained lists
+# cloc is run against. Matching happens on repository-relative paths so the
+# manifest reads the same as the repository layout.
+partition_bucket_file_list() {
+	local revision_root=$1
+	local combined=$2
+	local retained_paths=$3
+	local inscope_output=$4
+	local retained_output=$5
+	local relative="${combined}.relative"
+
+	awk -v prefix="${revision_root}/" '
+		index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }
+	' "${combined}" >"${relative}"
+
+	if [[ -s ${retained_paths} ]]; then
+		grep -Fxf "${retained_paths}" "${relative}" >"${relative}.retained" || true
+		grep -Fxvf "${retained_paths}" "${relative}" >"${relative}.inscope" || true
+	else
+		: >"${relative}.retained"
+		cp "${relative}" "${relative}.inscope"
+	fi
+
+	awk -v prefix="${revision_root}/" '{ print prefix $0 }' "${relative}.inscope" >"${inscope_output}"
+	awk -v prefix="${revision_root}/" '{ print prefix $0 }' "${relative}.retained" >"${retained_output}"
+}
+
+CLOC_SWIFT=0
+CLOC_OBJC=0
+
+count_file_list() {
+	local file_list=$1
+	local cloc_path=$2
+	local json=$3
 	local counts
 	local objc
 	local objcpp
 
-	mkdir -p "${working_dir}"
-	build_bucket_file_list "${revision_root}" "${bucket}" "${file_list}"
+	CLOC_SWIFT=0
+	CLOC_OBJC=0
 	if [[ ! -s ${file_list} ]]; then
-		COUNT_SWIFT=0
-		COUNT_OBJC=0
 		return
 	fi
 
@@ -128,8 +189,35 @@ count_bucket() {
 		--list-file="${file_list}" >"${json}"
 
 	counts=$(jq -r '[(.Swift.code // 0), (."Objective-C".code // 0), (."Objective-C++".code // 0)] | @tsv' "${json}")
-	IFS=$'\t' read -r COUNT_SWIFT objc objcpp <<<"${counts}"
-	COUNT_OBJC=$((objc + objcpp))
+	IFS=$'\t' read -r CLOC_SWIFT objc objcpp <<<"${counts}"
+	CLOC_OBJC=$((objc + objcpp))
+}
+
+COUNT_SWIFT=0
+COUNT_OBJC=0
+COUNT_OBJC_RETAINED=0
+
+count_bucket() {
+	local revision_root=$1
+	local bucket=$2
+	local cloc_path=$3
+	local working_dir=$4
+	local retained_paths=$5
+	local combined="${working_dir}/${bucket}-files.txt"
+	local inscope="${working_dir}/${bucket}-files-in-scope.txt"
+	local retained="${working_dir}/${bucket}-files-retained.txt"
+
+	mkdir -p "${working_dir}"
+	build_bucket_file_list "${revision_root}" "${bucket}" "${combined}"
+	partition_bucket_file_list \
+		"${revision_root}" "${combined}" "${retained_paths}" "${inscope}" "${retained}"
+
+	count_file_list "${inscope}" "${cloc_path}" "${working_dir}/${bucket}-cloc.json"
+	COUNT_SWIFT=${CLOC_SWIFT}
+	COUNT_OBJC=${CLOC_OBJC}
+
+	count_file_list "${retained}" "${cloc_path}" "${working_dir}/${bucket}-cloc-retained.json"
+	COUNT_OBJC_RETAINED=${CLOC_OBJC}
 }
 
 materialize_revision() {
@@ -157,6 +245,19 @@ percentage() {
 
 format_integer() {
 	perl -e '$number = shift; 1 while $number =~ s/^(-?\d+)(\d{3})/$1,$2/; print $number' "$1"
+}
+
+# Retained Objective-C is a floor, not a target, so it gets a plain SLOC figure
+# and a signed delta only when the boundary actually thinned or grew.
+format_retained() {
+	local base=$1
+	local head=$2
+
+	if ((head == base)); then
+		format_integer "${head}"
+		return
+	fi
+	printf '%s (%+d)' "$(format_integer "${head}")" "$((head - base))"
 }
 
 progress_bar() {
@@ -374,19 +475,22 @@ write_report() {
 		printf '%s\n' "${COMMENT_MARKER}"
 		printf '%s\n\n' '## 🐦 Swift Migration Progress'
 		printf 'Production implementation code at `%s` compared with `%s`.\n\n' "${short_head}" "${short_base}"
-		printf '%s\n' '| Area | Progress | Base | This PR | Swift SLOC | Objective-C remaining | Change |'
-		printf '%s\n' '|---|:---:|---:|---:|---:|---:|---:|'
-		printf '| Core SDK | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
+		printf '%s\n' '| Area | Progress | Base | This PR | Swift SLOC | Objective-C in scope | Objective-C retained | Change |'
+		printf '%s\n' '|---|:---:|---:|---:|---:|---:|---:|---:|'
+		printf '| Core SDK | `%s` | %s%% | %s%% | %s | %s | %s | %s %s pp |\n' \
 			"${core_bar}" "${core_base_percent}" "${core_head_percent}" \
 			"$(format_integer "${HEAD_CORE_SWIFT}")" "$(format_integer "${HEAD_CORE_OBJC}")" \
+			"$(format_retained "${BASE_CORE_OBJC_RETAINED}" "${HEAD_CORE_OBJC_RETAINED}")" \
 			"${core_delta_icon}" "${core_delta_text}"
-		printf '| SDK kit infrastructure | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
+		printf '| SDK kit infrastructure | `%s` | %s%% | %s%% | %s | %s | %s | %s %s pp |\n' \
 			"${kit_bar}" "${kit_base_percent}" "${kit_head_percent}" \
 			"$(format_integer "${HEAD_KIT_SWIFT}")" "$(format_integer "${HEAD_KIT_OBJC}")" \
+			"$(format_retained "${BASE_KIT_OBJC_RETAINED}" "${HEAD_KIT_OBJC_RETAINED}")" \
 			"${kit_delta_icon}" "${kit_delta_text}"
-		printf '| Standalone kits | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n\n' \
+		printf '| Standalone kits | `%s` | %s%% | %s%% | %s | %s | %s | %s %s pp |\n\n' \
 			"${standalone_bar}" "${standalone_base_percent}" "${standalone_head_percent}" \
 			"$(format_integer "${HEAD_STANDALONE_SWIFT}")" "$(format_integer "${HEAD_STANDALONE_OBJC}")" \
+			"$(format_retained "${BASE_STANDALONE_OBJC_RETAINED}" "${HEAD_STANDALONE_OBJC_RETAINED}")" \
 			"${standalone_delta_icon}" "${standalone_delta_text}"
 		printf '%s\n\n' "### This PR's code movement"
 		printf '%s\n' '| Area | Swift lines added | Objective-C lines removed |'
@@ -400,10 +504,14 @@ write_report() {
 		printf '%s\n\n' '<details>'
 		printf '%s\n\n' '<summary>How this is measured</summary>'
 		printf '%s\n' '- Current composition uses production source lines of code (SLOC) from `cloc`; comments and blank lines are excluded.'
-		printf '%s\n' '- Pull request movement uses physical additions/deletions from `git diff base...head --numstat`; it is intentionally separate from SLOC totals.'
+		printf '%s\n' '- Progress measures Swift against **in-scope** Objective-C only, so 100% means every Objective-C implementation the migration intends to delete is gone.'
+		printf '%s\n' '- Objective-C retained by design is excluded from the percentage and reported separately. It is the public/kit contract, runtime-identity, and boundary-glue surface listed in `Tools/swift-migration-retained-objc.txt`.'
+		printf '%s\n' '- Those retained wrappers keep their Objective-C interface but still shed logic to Swift; that shows as a falling retained figure, not as percentage movement.'
+		printf '%s\n' '- Both revisions are measured with the manifest from the head revision, so a manifest edit does not by itself move the reported change.'
+		printf '%s\n' '- Pull request movement uses physical additions/deletions from `git diff base...head --numstat`; it counts retained files too and is intentionally separate from SLOC totals.'
 		printf '%s\n' '- Core excludes SDK kit infrastructure and vendored libraries. Standalone kits include only files below `Kits/**/Sources`.'
 		printf '%s\n' '- Tests, examples, headers, build outputs, vendored libraries, and the `MParticle/Sources` Swift overlay are excluded.'
-		printf '%s\n\n' '- Objective-C++ (`.mm`) is included in Objective-C remaining and removed counts.'
+		printf '%s\n\n' '- Objective-C++ (`.mm`) is included in the Objective-C figures and removed counts.'
 		printf 'Generated with `cloc` %s. This report is informational and does not gate migration direction.\n\n' "${cloc_version}"
 		printf '%s\n' '</details>'
 	} >"${output}"
@@ -411,16 +519,22 @@ write_report() {
 
 BASE_CORE_SWIFT=0
 BASE_CORE_OBJC=0
+BASE_CORE_OBJC_RETAINED=0
 BASE_KIT_SWIFT=0
 BASE_KIT_OBJC=0
+BASE_KIT_OBJC_RETAINED=0
 BASE_STANDALONE_SWIFT=0
 BASE_STANDALONE_OBJC=0
+BASE_STANDALONE_OBJC_RETAINED=0
 HEAD_CORE_SWIFT=0
 HEAD_CORE_OBJC=0
+HEAD_CORE_OBJC_RETAINED=0
 HEAD_KIT_SWIFT=0
 HEAD_KIT_OBJC=0
+HEAD_KIT_OBJC_RETAINED=0
 HEAD_STANDALONE_SWIFT=0
 HEAD_STANDALONE_OBJC=0
+HEAD_STANDALONE_OBJC_RETAINED=0
 
 generate_report() {
 	local repo=$1
@@ -434,6 +548,7 @@ generate_report() {
 	local base_commit
 	local head_commit
 	local cloc_version
+	local retained_paths
 
 	[[ -d ${repo} ]] || fail "repository not found: ${repo}"
 	git -C "${repo}" rev-parse --git-dir >/dev/null 2>&1 || fail "not a Git repository: ${repo}"
@@ -450,25 +565,36 @@ generate_report() {
 	materialize_revision "${repo}" "${base_commit}" "${base_root}"
 	materialize_revision "${repo}" "${head_commit}" "${head_root}"
 
-	count_bucket "${base_root}" core "${cloc_path}" "${workspace}/base-core"
+	# The head revision owns the scope definition for both sides of the
+	# comparison, so editing the manifest cannot masquerade as code movement.
+	retained_paths="${workspace}/retained-paths.txt"
+	load_retained_manifest "${head_root}" "${retained_paths}"
+
+	count_bucket "${base_root}" core "${cloc_path}" "${workspace}/base-core" "${retained_paths}"
 	BASE_CORE_SWIFT=${COUNT_SWIFT}
 	BASE_CORE_OBJC=${COUNT_OBJC}
-	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit"
+	BASE_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit" "${retained_paths}"
 	BASE_KIT_SWIFT=${COUNT_SWIFT}
 	BASE_KIT_OBJC=${COUNT_OBJC}
-	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone"
+	BASE_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone" "${retained_paths}"
 	BASE_STANDALONE_SWIFT=${COUNT_SWIFT}
 	BASE_STANDALONE_OBJC=${COUNT_OBJC}
+	BASE_STANDALONE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 
-	count_bucket "${head_root}" core "${cloc_path}" "${workspace}/head-core"
+	count_bucket "${head_root}" core "${cloc_path}" "${workspace}/head-core" "${retained_paths}"
 	HEAD_CORE_SWIFT=${COUNT_SWIFT}
 	HEAD_CORE_OBJC=${COUNT_OBJC}
-	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit"
+	HEAD_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit" "${retained_paths}"
 	HEAD_KIT_SWIFT=${COUNT_SWIFT}
 	HEAD_KIT_OBJC=${COUNT_OBJC}
-	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone"
+	HEAD_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone" "${retained_paths}"
 	HEAD_STANDALONE_SWIFT=${COUNT_SWIFT}
 	HEAD_STANDALONE_OBJC=${COUNT_OBJC}
+	HEAD_STANDALONE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 
 	measure_diff_movement "${repo}" "${base_commit}" "${head_commit}" "${workspace}/movement-numstat"
 	cloc_version=$("${cloc_path}" --version | tr -d '\r\n')
@@ -492,6 +618,52 @@ assert_contains() {
 	grep -Fq "${expected}" "${file}" || fail "self-test expected to find: ${expected}"
 }
 
+assert_manifest_rejects() {
+	local root=$1
+	local expectation=$2
+	local log="${root}/rejection.log"
+
+	if (load_retained_manifest "${root}" "${root}/validated.txt") >"${log}" 2>&1; then
+		fail "self-test expected a rejected retained manifest: ${expectation}"
+	fi
+	assert_contains "${log}" "${expectation}"
+}
+
+# Exercises manifest parsing and validation against throwaway directory trees,
+# independent of the Git fixture.
+run_manifest_validation_selftest() {
+	local workspace=$1
+	local accepted="${workspace}/accepted"
+	local missing="${workspace}/missing"
+	local not_objc="${workspace}/not-objc"
+	local unbucketed="${workspace}/unbucketed"
+	local vendored="${workspace}/vendored"
+	local validated="${accepted}/validated.txt"
+
+	write_fixture_file "${accepted}" 'mParticle-Apple-SDK/Utils/Kept.m' $'@implementation Kept\n@end\n'
+	write_fixture_file "${accepted}" "${RETAINED_MANIFEST}" \
+		$'# leading comment\n\n   mParticle-Apple-SDK/Utils/Kept.m   \n\n# trailing comment\n'
+	load_retained_manifest "${accepted}" "${validated}"
+	[[ "$(wc -l <"${validated}" | tr -d ' ')" == '1' ]] ||
+		fail 'self-test expected exactly one accepted retained manifest entry'
+	assert_contains "${validated}" 'mParticle-Apple-SDK/Utils/Kept.m'
+
+	write_fixture_file "${missing}" "${RETAINED_MANIFEST}" $'mParticle-Apple-SDK/Utils/Gone.m\n'
+	assert_manifest_rejects "${missing}" 'retained manifest entry does not exist'
+
+	write_fixture_file "${not_objc}" 'mParticle-Apple-SDK-Swift/Sources/Kept.swift' $'let kept = 1\n'
+	write_fixture_file "${not_objc}" "${RETAINED_MANIFEST}" $'mParticle-Apple-SDK-Swift/Sources/Kept.swift\n'
+	assert_manifest_rejects "${not_objc}" 'not an Objective-C implementation'
+
+	write_fixture_file "${unbucketed}" 'UnitTests/ObjCTests/Kept.m' $'@implementation Kept\n@end\n'
+	write_fixture_file "${unbucketed}" "${RETAINED_MANIFEST}" $'UnitTests/ObjCTests/Kept.m\n'
+	assert_manifest_rejects "${unbucketed}" 'outside every counted bucket'
+
+	write_fixture_file "${vendored}" 'mParticle-Apple-SDK/Libraries/Vendor/Kept.m' $'@implementation Kept\n@end\n'
+	write_fixture_file "${vendored}" "${RETAINED_MANIFEST}" $'mParticle-Apple-SDK/Libraries/Vendor/Kept.m\n'
+	assert_manifest_rejects "${vendored}" 'outside every counted bucket'
+}
+
 run_selftest() {
 	local cloc_path=$1
 	local fixture
@@ -499,11 +671,13 @@ run_selftest() {
 	local migration_sha
 	local flat_sha
 	local regression_sha
+	local thin_sha
 	local advanced_base_sha
 	local pr_head_sha
 	local migration_report
 	local flat_report
 	local regression_report
+	local thin_report
 	local divergent_report
 	local flat_count
 
@@ -531,6 +705,10 @@ run_selftest() {
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Libraries/Vendor/Excluded.m' $'int excludedVendor(void) { return 1; }\n'
 	write_fixture_file "${fixture}" 'MParticle/Sources/Excluded.swift' $'let excludedOverlay = 1\n'
 	write_fixture_file "${fixture}" 'Kits/vendor/vendor-1/Tests/Excluded.m' $'int excludedKitTest(void) { return 1; }\n'
+	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Utils/Retained Contract.m' \
+		$'// contract wrapper\n\n@implementation RetainedContract\n- (int)value { return 1; }\n- (int)other { return 2; }\n@end\n'
+	write_fixture_file "${fixture}" "${RETAINED_MANIFEST}" \
+		$'# retained by design\n\nmParticle-Apple-SDK/Utils/Retained Contract.m\nKits/vendor/vendor-1/Sources/Kit.m\n'
 
 	git -C "${fixture}" add --all
 	git -C "${fixture}" commit -q -m 'base fixture'
@@ -549,9 +727,9 @@ run_selftest() {
 
 	migration_report="${fixture}/migration-report.md"
 	generate_report "${fixture}" "${base_sha}" "${migration_sha}" "${cloc_path}" "${migration_report}"
-	assert_contains "${migration_report}" '| 25.00% | 42.86% | 3 | 4 | 🚀 +17.86 pp |'
-	assert_contains "${migration_report}" '| 33.33% | 100.00% | 2 | 0 | 🚀 +66.67 pp |'
-	assert_contains "${migration_report}" '| 33.33% | 33.33% | 1 | 2 | ➖ 0.00 pp |'
+	assert_contains "${migration_report}" '| 25.00% | 42.86% | 3 | 4 | 4 | 🚀 +17.86 pp |'
+	assert_contains "${migration_report}" '| 33.33% | 100.00% | 2 | 0 | 0 | 🚀 +66.67 pp |'
+	assert_contains "${migration_report}" '| 100.00% | 100.00% | 1 | 0 | 2 | ➖ 0.00 pp |'
 	assert_contains "${migration_report}" '| Core SDK | 1 | 4 |'
 	assert_contains "${migration_report}" '| SDK kit infrastructure | 1 | 2 |'
 	assert_contains "${migration_report}" '| Standalone kits | 0 | 0 |'
@@ -571,7 +749,18 @@ run_selftest() {
 	regression_sha=$(git -C "${fixture}" rev-parse HEAD)
 	regression_report="${fixture}/regression-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${regression_sha}" "${cloc_path}" "${regression_report}"
-	assert_contains "${regression_report}" '| 42.86% | 33.33% | 3 | 6 | ↩️ -9.53 pp |'
+	assert_contains "${regression_report}" '| 42.86% | 33.33% | 3 | 6 | 4 | ↩️ -9.53 pp |'
+
+	git -C "${fixture}" switch -q -c selftest-thin "${migration_sha}"
+	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Utils/Retained Contract.m' \
+		$'// contract wrapper\n\n@implementation RetainedContract\n@end\n'
+	git -C "${fixture}" add --all
+	git -C "${fixture}" commit -q -m 'retained thinning fixture'
+	thin_sha=$(git -C "${fixture}" rev-parse HEAD)
+	thin_report="${fixture}/thin-report.md"
+	generate_report "${fixture}" "${migration_sha}" "${thin_sha}" "${cloc_path}" "${thin_report}"
+	assert_contains "${thin_report}" '| 42.86% | 42.86% | 3 | 4 | 2 (-2) | ➖ 0.00 pp |'
+	assert_contains "${thin_report}" '| Core SDK | 0 | 2 |'
 
 	git -C "${fixture}" switch -q -c selftest-pr "${migration_sha}"
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK-Swift/Sources/PR Only.swift' $'let prOne = 1\nlet prTwo = 2\n'
@@ -593,6 +782,7 @@ run_selftest() {
 	assert_contains "${divergent_report}" '| Standalone kits | 0 | 0 |'
 
 	[[ "$(percentage 0 0)" == '0.00' ]] || fail 'self-test expected a zero-denominator percentage of 0.00'
+	run_manifest_validation_selftest "${fixture}/manifest-validation"
 	printf '%s\n' 'swift-migration-progress: SELFTEST PASS'
 }
 

--- a/Tools/swift-migration-retained-objc.txt
+++ b/Tools/swift-migration-retained-objc.txt
@@ -1,0 +1,75 @@
+# Objective-C retained by design — the migration's out-of-scope boundary.
+#
+# Every path below is an Objective-C implementation the migration will NOT
+# delete, because CONVERSION-RECIPE.md classifies its declaration as a
+# supported contract, a runtime-identity-pinned type, or unavoidable boundary
+# glue. Tools/swift-migration-progress.sh removes these files from the
+# migration percentage's denominator and reports their SLOC in a separate
+# "retained" column, so 100% means "every in-scope Objective-C file is gone",
+# not "no Objective-C remains".
+#
+# Listing a file here does not freeze its contents. A contract wrapper keeps
+# its @interface, class name, selectors, and nullability, but its logic still
+# moves to Swift; the wrapper thins to marshaling. That thinning shows up as a
+# falling retained SLOC figure rather than as percentage movement.
+#
+# Format: one repository-relative path per line; `#` comments and blank lines
+# ignored. Only `.m`/`.mm` paths inside a counted bucket are accepted, and each
+# path must exist — the report fails on a stale or misplaced entry.
+#
+# Editing policy and the evidence an addition requires: Tools/README.md
+# ("Retained Objective-C manifest").
+
+# --- Supported customer contracts (CONVERSION-RECIPE.md classification 1) ---
+# Declarations reached through mParticle.h and its imports; each appears in
+# Tools/abi-baseline.txt.
+
+mParticle-Apple-SDK/mParticle.m
+mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.m
+mParticle-Apple-SDK/MParticleSession+MParticlePrivate.m
+mParticle-Apple-SDK/MPAttributionResult+MParticlePrivate.m
+mParticle-Apple-SDK/MPNetworkOptions+MParticlePrivate.m
+mParticle-Apple-SDK/MPEnums.m
+mParticle-Apple-SDK/MPRokt.m
+mParticle-Apple-SDK/Event/MPBaseEvent.m
+mParticle-Apple-SDK/Event/MPEvent.m
+mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.m
+mParticle-Apple-SDK/Ecommerce/MPProduct.m
+mParticle-Apple-SDK/Ecommerce/MPPromotion.m
+mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes.m
+mParticle-Apple-SDK/Consent/MPConsentState.m
+mParticle-Apple-SDK/Consent/MPGDPRConsent.m
+mParticle-Apple-SDK/Consent/MPCCPAConsent.m
+mParticle-Apple-SDK/Data Model/MPLocation.m
+mParticle-Apple-SDK/Identity/MPIdentityApi.m
+mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+mParticle-Apple-SDK/Identity/MParticleUser.m
+mParticle-Apple-SDK/Identity/MPAliasRequest.m
+mParticle-Apple-SDK/Identity/MPAliasResponse.m
+mParticle-Apple-SDK/Identity/MPAudience.m
+mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
+
+# --- Supported kit and wrapper-SDK contracts (classification 1) ---
+# The kit integration surface. Standalone kits compile against these types and
+# wrapper SDKs forward through them, so their runtime identity is fixed.
+
+mParticle-Apple-SDK/Identity/FilteredMParticleUser.m
+mParticle-Apple-SDK/Identity/FilteredMPIdentityApiRequest.m
+mParticle-Apple-SDK/Data Model/MPForwardRecord.m
+mParticle-Apple-SDK/Ecommerce/MPCommerceEventInstruction.m
+mParticle-Apple-SDK/Kits/MPKitAPI.m
+mParticle-Apple-SDK/Kits/MPKitExecStatus.m
+mParticle-Apple-SDK/Kits/MPKitRegister.m
+mParticle-Apple-SDK/Kits/MPSideloadedKit.m
+
+# --- Runtime-identity pinned (classification 3) ---
+# Header may become internal, but the ObjC class, NSSecureCoding conformance,
+# and legacy archive class-name mappings stay.
+
+mParticle-Apple-SDK/Utils/MPUploadSettings.m
+
+# --- Internal ObjC boundary glue (classification 4) ---
+# Bridges a module boundary the Swift target cannot cross. Retained until that
+# dependency boundary is redesigned, at which point delete the entry with it.
+
+mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m

--- a/docs/swift-migration/CONVERSION-RECIPE.md
+++ b/docs/swift-migration/CONVERSION-RECIPE.md
@@ -39,6 +39,14 @@ Record the evidence in any PR that removes an exported declaration. If the
 audit finds a supported external dependency, classify the declaration as a
 contract and keep its wrapper.
 
+Classifications 1, 3, and 4 keep an Objective-C implementation permanently, so
+they are also the migration's scope boundary. When a conversion settles one of
+those classifications, add the implementation path to
+`Tools/swift-migration-retained-objc.txt` with the audit evidence in the PR;
+that file is what makes the progress report's 100% reachable, and
+`PR-GATE.md`'s "What \"done\" means" section governs it. Classification 2 files
+stay out of the manifest — they are the work the percentage measures.
+
 ## Two-stage wrapper model
 
 1. **Move logic → Swift; keep the boundary that is still required.** Add a
@@ -88,6 +96,8 @@ because downstream code can change.
 
 Customer-facing event, identity, consent, commerce, location, options, and Rokt
 APIs remain supported contracts even when their implementations move to Swift.
+Their Objective-C declaration sites are enumerated in
+`Tools/swift-migration-retained-objc.txt`.
 
 ## Hard constraint: the Swift module cannot import ObjC
 

--- a/docs/swift-migration/PR-GATE.md
+++ b/docs/swift-migration/PR-GATE.md
@@ -48,6 +48,34 @@ phase after it without exception.
    Swift must add a Swift mirror test for that extracted logic (see
    `CONVERSION-RECIPE.md`'s dual-test convention).
 
+## What "done" means
+
+The migration does not end at zero Objective-C. The public customer API, the
+kit and wrapper-SDK contract surface, runtime-identity-pinned classes, and the
+boundary glue in `CONVERSION-RECIPE.md`'s classifications 1, 3, and 4 stay
+Objective-C by design — that is the intended end state, not unfinished work.
+
+The migration is complete when every **in-scope** Objective-C implementation is
+gone: the classification 2 wrappers and the internal types behind them. The
+retained boundary is enumerated in `Tools/swift-migration-retained-objc.txt`,
+and the progress report on each PR excludes it from the percentage so 100%
+is reachable and means what it says.
+
+Two consequences for a conversion PR:
+
+- Classifying a declaration as a retained contract means adding its
+  implementation to the manifest, with the audit evidence
+  `CONVERSION-RECIPE.md` requires recorded in the PR. Item 1's baseline-update
+  policy governs the other direction: an accidental export that gets removed is
+  **not** retained.
+- Deleting or renaming a retained implementation means updating the manifest in
+  the same PR. The report fails on a stale entry.
+
+Retaining a wrapper does not freeze it. A contract wrapper keeps its
+`@interface`, class name, selectors, and nullability while its logic moves to
+Swift, so the report tracks its remaining Objective-C SLOC in a separate
+retained column rather than in the percentage.
+
 ## Scope note
 
 This gate applies to every migration PR and is not re-specified per phase.


### PR DESCRIPTION
## Why

The progress report divided Swift SLOC by **all** production Objective-C. That
denominator includes the surface we are deliberately keeping in Objective-C —
the public customer API, the kit and wrapper-SDK contracts, runtime-identity
pinned classes, and boundary glue (`CONVERSION-RECIPE.md` classifications 1, 3,
and 4). 100% was unreachable by construction, so the bar was measuring against
a target the migration is not pursuing.

## What changed

`Tools/swift-migration-retained-objc.txt` is a new reviewed manifest of the 34
Objective-C implementations that stay. The report removes them from the
percentage's denominator and reports their SLOC in a separate
`Objective-C retained` column. **100% now means every in-scope Objective-C
implementation is gone.**

### Effect on the current tree

| Area | Before | After | ObjC before | ObjC in scope | ObjC retained |
|---|---:|---:|---:|---:|---:|
| Core SDK | 24.50% | **34.65%** | 15,103 | 9,243 | 5,860 |
| SDK kit infrastructure | 0.00% | 0.00% | 3,725 | 3,340 | 385 |
| Standalone kits | 1.06% | 1.06% | 14,231 | 14,231 | 0 |

Every row reconciles exactly: in scope + retained = the previous remaining
figure. Kit infrastructure holds at 0.00% because it has no Swift yet.

### How the manifest was derived

Not by heuristic. Every entry backs a declaration in `Tools/abi-baseline.txt`
or is named in `CONVERSION-RECIPE.md`'s compatibility inventory:

- **Supported customer contracts** — `mParticle.m`, the `+MParticlePrivate`
  implementations of `MParticleOptions` / `MParticleSession` /
  `MPAttributionResult` / `MPNetworkOptions`, `MPEnums.m`'s exported constants,
  and the event, commerce, consent, identity, location, and Rokt declaration
  sites reached through `mParticle.h`.
- **Supported kit and wrapper-SDK contracts** — `MPKitAPI`, `MPKitExecStatus`,
  `MPKitRegister`, `MPSideloadedKit`, `MPForwardRecord`,
  `MPCommerceEventInstruction`, and the `Filtered*` types.
- **Runtime-identity pinned** — `MPUploadSettings` (classification 3).
- **Boundary glue** — `MPUserDefaultsConnector` (classification 4).

Deliberately **not** retained: the `_PRIVATE` accidental exports the recipe
lists as wrapper-removal candidates — `MPBackendController`,
`MPPersistenceController`, `MPNetworkCommunication`, `MPStateMachine`,
`MPNotificationController`, `MPKitContainer`, `SceneDelegateHandler`. Those are
~9k SLOC and stay in scope, which is why Core lands at 34.65% rather than
somewhere near done.

Standalone kits get no entries. Their `MPKit*` classes are resolved by name at
runtime, and no kit-side conversion has established that contract yet.

### Design decisions worth reviewing

- **Retaining a wrapper does not freeze it.** A contract wrapper keeps its
  `@interface`, class name, selectors, and nullability while its logic still
  moves to Swift. That thinning shows as a **falling retained figure**, not as
  percentage movement — so the ~5.9k retained SLOC stays visible instead of
  being written off. This is the main tradeoff: file-granular exclusion is the
  only thing `cloc` can express, so wrapper-internal progress lives in its own
  column rather than in the bar.
- **Both revisions are counted with the head revision's manifest**, so editing
  the manifest cannot book a redefinition as progress. This PR's own report
  reads `➖ 0.00 pp` on all three rows, which is the correct answer — no code
  moved.
- **Diff movement is left unfiltered.** Deleting lines from a retained wrapper
  is real work and still shows in the movement table.
- **Stale entries fail the report** rather than silently reverting a file to
  in-scope: a path missing at head, a non-`.m`/`.mm` path, or a path outside the
  three counted buckets all exit non-zero.

### Docs

- `PR-GATE.md` gains a **What "done" means** section, plus the requirement to
  keep the manifest in sync when classifying or deleting a retained wrapper.
- `CONVERSION-RECIPE.md` links classification 1/3/4 to the manifest.
- `Tools/README.md` documents the metric, the manifest format, the editing
  policy and the evidence an addition requires, and adds the manifest to the
  end-of-migration cleanup list.

## Gate results

| # | Item | Result |
|---|---|---|
| 1 | `Tools/abi-guard.sh check` | ✅ PASSED — no public ABI diff. Baseline untouched. `abi-guard-selftest.sh` also PASS. |
| 2 | `pod lib lint` on all 3 podspecs | ⚪️ Not run — diff touches only `Tools/` and `docs/`; no sources, headers, podspecs, or project files. Also blocked locally: this machine has the tvOS 26.2 SDK but only the 26.0 simulator runtime, so the tvOS leg cannot run here. CI is the sole tvOS verification. |
| 3 | Build green on iOS + tvOS | ⚪️ Not run — same reason; nothing compiled changed. Same tvOS runtime gap applies. |
| 4 | `trunk check` | ✅ Clean on all 5 changed files. `shellcheck -x` also clean. |
| 5 | ObjC + Swift unit suites | ⚪️ Not run — no SDK source changed. Tooling is covered instead by `swift-migration-progress.sh selftest`. |

**Tooling verification actually performed** (with `cloc` 2.10, SHA-256 verified
against the value pinned in `swift-migration-progress.yml`):

- `swift-migration-progress.sh selftest` → **PASS**. Fixture extended with a
  retained contract wrapper and a manifest; new coverage for denominator
  removal, retained thinning reported with a signed delta and zero percentage
  movement, comment/blank/whitespace parsing, and rejection of stale,
  non-Objective-C, out-of-bucket, and vendored entries.
- Real report generated on this tree — numbers in the table above.
- Stale-entry guard exercised against the real repository, not just the
  fixture: exits 1 with
  `retained manifest entry does not exist: <path>`.

No `CHANGELOG.md` entry — no public surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
