### PR TITLE
ci(migration): split Swift progress into short and long-term goals

### DIFF
--- a/Tools/README.md
+++ b/Tools/README.md
@@ -85,9 +85,39 @@ The self-test creates a temporary Git repository and verifies bucket
 isolation, exclusions, code/comment/blank handling, percentage rounding,
 zero-denominator handling, Objective-C++ counting, filenames with spaces,
 renames, physical diff movement across divergent histories, flat changes, and
-regressions.
+regressions. It also covers the retained manifest: comment/blank/whitespace
+parsing, removal from the percentage denominator, retained thinning reported
+without percentage movement, and rejection of stale, non-Objective-C,
+out-of-bucket, and vendored entries.
 
 ### Metric definitions
+
+Every bucket reports two goal rows, because the migration has two horizons:
+
+- **Short term — in scope.** Swift SLOC / (Swift SLOC + in-scope Objective-C).
+  In-scope excludes the implementations listed in
+  `Tools/swift-migration-retained-objc.txt` — the public/kit contract,
+  runtime-identity, and boundary-glue files that stay Objective-C by design.
+  **100% here is the end of this project**: every Objective-C implementation the
+  migration intends to delete is gone.
+- **Long term — all Objective-C.** Swift SLOC / (Swift SLOC + all Objective-C),
+  the original full-denominator number. **100% here means the public API itself
+  becomes Swift**, which is a breaking change reserved for a future major
+  release. It is kept so that goal stays measurable rather than being redefined
+  away.
+
+The gap between the two rows is the retained surface. Its SLOC is also printed
+explicitly under the table, with a signed delta when it moved.
+
+Retained wrappers keep their `@interface`, class name, selectors, and
+nullability, but their logic still moves to Swift and the wrapper thins to
+marshaling. That thinning moves the long-term row and the retained figure while
+leaving the short-term row flat — the short-term goal tracks file removal, the
+long-term goal tracks every Objective-C line.
+
+Both revisions are counted using the **head** revision's manifest. A PR that
+edits the manifest therefore re-measures its own base under the new definition
+instead of booking the redefinition as progress.
 
 The three production-code buckets do not overlap:
 
@@ -105,12 +135,52 @@ Objective-C remaining. Tests, examples, headers, build outputs, vendored
 libraries, and the customer-facing `MParticle/Sources` Swift overlay are
 excluded.
 
-The pull request movement table is a different metric: physical Swift lines
+The pull request movement table is a different metric, and it is **not**
+filtered by the manifest — deleting lines from a retained wrapper is real work
+and is counted. It reports physical Swift lines
 added and Objective-C/Objective-C++ lines deleted according to
 `git diff base...head --numstat -z`. The three-dot comparison measures changes
 from the merge base through the pull request head, so commits present only on
 an advanced base branch are not attributed to the pull request. These figures
 can differ from the SLOC change because Git includes comments and blank lines.
+
+### Retained Objective-C manifest
+
+`Tools/swift-migration-retained-objc.txt` is the reviewed list of Objective-C
+implementations this phase of the migration will not delete. It is the boundary
+between the two goal rows, so it is committed and changed deliberately — never
+edited to make a number look better.
+
+```text
+# one repository-relative path per line; `#` comments and blanks ignored
+mParticle-Apple-SDK/Event/MPEvent.m
+```
+
+The report validates every entry and fails on any of these, rather than
+silently counting the file as in-scope:
+
+- a path that does not exist in the head revision (stale after a delete or
+  rename — fix the manifest in the same PR);
+- a path that is not a `.m`/`.mm` implementation; or
+- a path outside the three counted buckets, including
+  `mParticle-Apple-SDK/Libraries`.
+
+Adding an entry requires the same evidence
+`docs/swift-migration/CONVERSION-RECIPE.md` demands to classify a declaration
+as a supported contract, runtime-identity-pinned, or boundary glue: name the
+declaration, point at its `Tools/abi-baseline.txt` entry, and record the
+customer/kit/wrapper-SDK audit in the PR. A file whose declaration is an
+accidental export is **not** retained — it stays in scope and its wrapper gets
+deleted.
+
+Removing an entry is the normal end of classification 4: when a boundary is
+redesigned and the glue is deleted, delete its line with it. A future major
+release that takes the public API itself to Swift would empty the manifest,
+which is the point at which the two goal rows converge.
+
+Standalone kits have no entries yet. Their `MPKit*` classes are resolved by
+name at runtime, so any kit-side conversion has to establish that contract
+before its implementation is listed here.
 
 ### Workflow behavior and removal
 
@@ -127,7 +197,8 @@ When the migration is complete, remove:
 - `.github/workflows/swift-migration-progress.yml`;
 - the `swift-migration-progress` job and notification dependency in
   `.github/workflows/pull-request.yml`;
-- `Tools/swift-migration-progress.sh`; and
+- `Tools/swift-migration-progress.sh`;
+- `Tools/swift-migration-retained-objc.txt`; and
 - this README section.
 
 There is no stored baseline or external service to clean up.

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -119,6 +119,15 @@ Both revisions are counted using the **head** revision's manifest. A PR that
 edits the manifest therefore re-measures its own base under the new definition
 instead of booking the redefinition as progress.
 
+Path matching alone would misread a retained file that a PR **renames or
+deletes**: its base-side path is absent from the head manifest, so the base
+would count it as in-scope and the short-term row would rise on work nobody
+did. The base count therefore also treats as retained any base-manifest entry
+whose file no longer exists at head, which covers both cases. An entry dropped
+from the manifest while its file survives is left alone on purpose — that is a
+deliberate reclassification, and the head definition should apply to both
+revisions.
+
 The three production-code buckets do not overlap:
 
 - **Core SDK:** Swift in `mParticle-Apple-SDK-Swift/Sources`, and Objective-C

--- a/Tools/swift-migration-progress.sh
+++ b/Tools/swift-migration-progress.sh
@@ -99,6 +99,19 @@ build_bucket_file_list() {
 	esac
 }
 
+# Trims one manifest line and prints the path it holds, or nothing for a blank
+# line or a comment.
+clean_manifest_line() {
+	local path=${1%$'\r'}
+
+	path=${path#"${path%%[![:space:]]*}"}
+	path=${path%"${path##*[![:space:]]}"}
+	if [[ ${path} == '#'* ]]; then
+		return 0
+	fi
+	printf '%s' "${path}"
+}
+
 # Reads the reviewed list of Objective-C implementations the migration will not
 # delete and writes the validated, repository-relative paths to a lookup file.
 # A stale, misplaced, or non-Objective-C entry is a hard failure so the manifest
@@ -117,10 +130,8 @@ load_retained_manifest() {
 	fi
 
 	while IFS= read -r line || [[ -n ${line} ]]; do
-		path=${line%$'\r'}
-		path=${path#"${path%%[![:space:]]*}"}
-		path=${path%"${path##*[![:space:]]}"}
-		if [[ -z ${path} || ${path} == '#'* ]]; then
+		path=$(clean_manifest_line "${line}")
+		if [[ -z ${path} ]]; then
 			continue
 		fi
 		if [[ ${path} != *.m && ${path} != *.mm ]]; then
@@ -134,6 +145,43 @@ load_retained_manifest() {
 			fail "retained manifest entry does not exist: ${path}"
 		fi
 		printf '%s\n' "${path}" >>"${output}"
+	done <"${manifest}"
+}
+
+# The head revision owns the scope definition, but path matching alone would
+# misread a retained implementation this pull request renamed or deleted: its
+# base-side path is absent from the head manifest and would count as in-scope,
+# inflating short-term progress with work nobody did. Carry over the base
+# manifest entries whose file no longer exists at head, which covers both the
+# rename and the boundary-deletion case. Entries whose file survives at head
+# are left out on purpose — dropping one is a deliberate reclassification, and
+# the head definition should then apply to both revisions.
+#
+# The base manifest is read leniently. It may be missing entirely, or describe
+# paths that predate the current layout, and neither is this comparison's
+# problem to police.
+load_base_retained_paths() {
+	local base_root=$1
+	local head_root=$2
+	local head_paths=$3
+	local output=$4
+	local manifest="${base_root}/${RETAINED_MANIFEST}"
+	local line
+	local path
+
+	cp "${head_paths}" "${output}"
+	if [[ ! -f ${manifest} ]]; then
+		return 0
+	fi
+
+	while IFS= read -r line || [[ -n ${line} ]]; do
+		path=$(clean_manifest_line "${line}")
+		if [[ -z ${path} ]]; then
+			continue
+		fi
+		if [[ -f "${base_root}/${path}" && ! -f "${head_root}/${path}" ]]; then
+			printf '%s\n' "${path}" >>"${output}"
+		fi
 	done <"${manifest}"
 }
 
@@ -507,7 +555,7 @@ write_report() {
 		printf '%s\n' '- **Long term — all Objective-C** keeps the full denominator. Reaching 100% there means the public API itself becomes Swift, which is a breaking change reserved for a future major release.'
 		printf '%s\n' '- The gap between the two rows is the retained public/kit contract, runtime-identity, and boundary-glue surface listed in `Tools/swift-migration-retained-objc.txt`.'
 		printf '%s\n' '- Retained wrappers keep their Objective-C interface but still shed logic to Swift. That thinning moves the long-term row and the retained figure, not the short-term row.'
-		printf '%s\n' '- Both revisions are measured with the manifest from the head revision, so a manifest edit does not by itself move the reported change.'
+		printf '%s\n' '- Both revisions are measured with the manifest from the head revision, so a manifest edit does not by itself move the reported change. A retained file this pull request renamed or deleted still counts as retained at the base.'
 		printf '%s\n' '- Pull request movement uses physical additions/deletions from `git diff base...head --numstat`; it counts retained files too and is intentionally separate from SLOC totals.'
 		printf '%s\n' '- Core excludes SDK kit infrastructure and vendored libraries. Standalone kits include only files below `Kits/**/Sources`.'
 		printf '%s\n' '- Tests, examples, headers, build outputs, vendored libraries, and the `MParticle/Sources` Swift overlay are excluded.'
@@ -548,7 +596,8 @@ generate_report() {
 	local base_commit
 	local head_commit
 	local cloc_version
-	local retained_paths
+	local head_retained_paths
+	local base_retained_paths
 
 	[[ -d ${repo} ]] || fail "repository not found: ${repo}"
 	git -C "${repo}" rev-parse --git-dir >/dev/null 2>&1 || fail "not a Git repository: ${repo}"
@@ -567,31 +616,34 @@ generate_report() {
 
 	# The head revision owns the scope definition for both sides of the
 	# comparison, so editing the manifest cannot masquerade as code movement.
-	retained_paths="${workspace}/retained-paths.txt"
-	load_retained_manifest "${head_root}" "${retained_paths}"
+	head_retained_paths="${workspace}/retained-paths-head.txt"
+	base_retained_paths="${workspace}/retained-paths-base.txt"
+	load_retained_manifest "${head_root}" "${head_retained_paths}"
+	load_base_retained_paths \
+		"${base_root}" "${head_root}" "${head_retained_paths}" "${base_retained_paths}"
 
-	count_bucket "${base_root}" core "${cloc_path}" "${workspace}/base-core" "${retained_paths}"
+	count_bucket "${base_root}" core "${cloc_path}" "${workspace}/base-core" "${base_retained_paths}"
 	BASE_CORE_SWIFT=${COUNT_SWIFT}
 	BASE_CORE_OBJC=${COUNT_OBJC}
 	BASE_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
-	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit" "${retained_paths}"
+	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit" "${base_retained_paths}"
 	BASE_KIT_SWIFT=${COUNT_SWIFT}
 	BASE_KIT_OBJC=${COUNT_OBJC}
 	BASE_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
-	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone" "${retained_paths}"
+	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone" "${base_retained_paths}"
 	BASE_STANDALONE_SWIFT=${COUNT_SWIFT}
 	BASE_STANDALONE_OBJC=${COUNT_OBJC}
 	BASE_STANDALONE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 
-	count_bucket "${head_root}" core "${cloc_path}" "${workspace}/head-core" "${retained_paths}"
+	count_bucket "${head_root}" core "${cloc_path}" "${workspace}/head-core" "${head_retained_paths}"
 	HEAD_CORE_SWIFT=${COUNT_SWIFT}
 	HEAD_CORE_OBJC=${COUNT_OBJC}
 	HEAD_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
-	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit" "${retained_paths}"
+	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit" "${head_retained_paths}"
 	HEAD_KIT_SWIFT=${COUNT_SWIFT}
 	HEAD_KIT_OBJC=${COUNT_OBJC}
 	HEAD_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
-	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone" "${retained_paths}"
+	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone" "${head_retained_paths}"
 	HEAD_STANDALONE_SWIFT=${COUNT_SWIFT}
 	HEAD_STANDALONE_OBJC=${COUNT_OBJC}
 	HEAD_STANDALONE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
@@ -672,12 +724,16 @@ run_selftest() {
 	local flat_sha
 	local regression_sha
 	local thin_sha
+	local renamed_sha
+	local retired_sha
 	local advanced_base_sha
 	local pr_head_sha
 	local migration_report
 	local flat_report
 	local regression_report
 	local thin_report
+	local renamed_report
+	local retired_report
 	local divergent_report
 	local flat_count
 
@@ -773,6 +829,40 @@ run_selftest() {
 	assert_contains "${thin_report}" \
 		'Objective-C retained by design: Core SDK 2 (-2) · SDK kit infrastructure 0 · Standalone kits 2.'
 	assert_contains "${thin_report}" '| Core SDK | 0 | 2 |'
+
+	# Renaming a retained implementation and updating the manifest moves no
+	# logic, so every goal row and the retained figure must stay flat.
+	git -C "${fixture}" switch -q -c selftest-rename "${migration_sha}"
+	git -C "${fixture}" mv \
+		'mParticle-Apple-SDK/Utils/Retained Contract.m' \
+		'mParticle-Apple-SDK/Utils/Renamed Contract.m'
+	write_fixture_file "${fixture}" "${RETAINED_MANIFEST}" \
+		$'# retained by design\n\nmParticle-Apple-SDK/Utils/Renamed Contract.m\nKits/vendor/vendor-1/Sources/Kit.m\n'
+	git -C "${fixture}" add --all
+	git -C "${fixture}" commit -q -m 'retained rename fixture'
+	renamed_sha=$(git -C "${fixture}" rev-parse HEAD)
+	renamed_report="${fixture}/renamed-report.md"
+	generate_report "${fixture}" "${migration_sha}" "${renamed_sha}" "${cloc_path}" "${renamed_report}"
+	assert_contains "${renamed_report}" '| 42.86% | 42.86% | 3 | 4 | ➖ 0.00 pp |'
+	assert_contains "${renamed_report}" '| 27.27% | 27.27% | 3 | 8 | ➖ 0.00 pp |'
+	assert_contains "${renamed_report}" \
+		'Objective-C retained by design: Core SDK 4 · SDK kit infrastructure 0 · Standalone kits 2.'
+
+	# Retiring a retained implementation is long-term progress only; the
+	# short-term goal never counted it.
+	git -C "${fixture}" switch -q -c selftest-retire "${migration_sha}"
+	rm "${fixture}/mParticle-Apple-SDK/Utils/Retained Contract.m"
+	write_fixture_file "${fixture}" "${RETAINED_MANIFEST}" \
+		$'# retained by design\n\nKits/vendor/vendor-1/Sources/Kit.m\n'
+	git -C "${fixture}" add --all
+	git -C "${fixture}" commit -q -m 'retained retirement fixture'
+	retired_sha=$(git -C "${fixture}" rev-parse HEAD)
+	retired_report="${fixture}/retired-report.md"
+	generate_report "${fixture}" "${migration_sha}" "${retired_sha}" "${cloc_path}" "${retired_report}"
+	assert_contains "${retired_report}" '| 42.86% | 42.86% | 3 | 4 | ➖ 0.00 pp |'
+	assert_contains "${retired_report}" '| 27.27% | 42.86% | 3 | 4 | 🚀 +15.59 pp |'
+	assert_contains "${retired_report}" \
+		'Objective-C retained by design: Core SDK 0 (-4) · SDK kit infrastructure 0 · Standalone kits 2.'
 
 	git -C "${fixture}" switch -q -c selftest-pr "${migration_sha}"
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK-Swift/Sources/PR Only.swift' $'let prOne = 1\nlet prTwo = 2\n'

--- a/Tools/swift-migration-progress.sh
+++ b/Tools/swift-migration-progress.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 readonly COMMENT_MARKER='<!-- swift-migration-progress -->'
 readonly BAR_WIDTH=10
+readonly RETAINED_MANIFEST='Tools/swift-migration-retained-objc.txt'
 
 CLEANUP_DIRS=()
 CREATED_TEMP_DIR=''
@@ -98,25 +99,85 @@ build_bucket_file_list() {
 	esac
 }
 
-COUNT_SWIFT=0
-COUNT_OBJC=0
-
-count_bucket() {
+# Reads the reviewed list of Objective-C implementations the migration will not
+# delete and writes the validated, repository-relative paths to a lookup file.
+# A stale, misplaced, or non-Objective-C entry is a hard failure so the manifest
+# cannot silently stop matching the tree it describes.
+load_retained_manifest() {
 	local revision_root=$1
-	local bucket=$2
-	local cloc_path=$3
-	local working_dir=$4
-	local file_list="${working_dir}/${bucket}-files.txt"
-	local json="${working_dir}/${bucket}-cloc.json"
+	local output=$2
+	local manifest="${revision_root}/${RETAINED_MANIFEST}"
+	local line
+	local path
+	local bucket
+
+	: >"${output}"
+	if [[ ! -f ${manifest} ]]; then
+		return 0
+	fi
+
+	while IFS= read -r line || [[ -n ${line} ]]; do
+		path=${line%$'\r'}
+		path=${path#"${path%%[![:space:]]*}"}
+		path=${path%"${path##*[![:space:]]}"}
+		if [[ -z ${path} || ${path} == '#'* ]]; then
+			continue
+		fi
+		if [[ ${path} != *.m && ${path} != *.mm ]]; then
+			fail "retained manifest entry is not an Objective-C implementation: ${path}"
+		fi
+		bucket=$(classify_path "${path}")
+		if [[ -z ${bucket} ]]; then
+			fail "retained manifest entry is outside every counted bucket: ${path}"
+		fi
+		if [[ ! -f "${revision_root}/${path}" ]]; then
+			fail "retained manifest entry does not exist: ${path}"
+		fi
+		printf '%s\n' "${path}" >>"${output}"
+	done <"${manifest}"
+}
+
+# Splits one bucket's absolute file list into the in-scope and retained lists
+# cloc is run against. Matching happens on repository-relative paths so the
+# manifest reads the same as the repository layout.
+partition_bucket_file_list() {
+	local revision_root=$1
+	local combined=$2
+	local retained_paths=$3
+	local inscope_output=$4
+	local retained_output=$5
+	local relative="${combined}.relative"
+
+	awk -v prefix="${revision_root}/" '
+		index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }
+	' "${combined}" >"${relative}"
+
+	if [[ -s ${retained_paths} ]]; then
+		grep -Fxf "${retained_paths}" "${relative}" >"${relative}.retained" || true
+		grep -Fxvf "${retained_paths}" "${relative}" >"${relative}.inscope" || true
+	else
+		: >"${relative}.retained"
+		cp "${relative}" "${relative}.inscope"
+	fi
+
+	awk -v prefix="${revision_root}/" '{ print prefix $0 }' "${relative}.inscope" >"${inscope_output}"
+	awk -v prefix="${revision_root}/" '{ print prefix $0 }' "${relative}.retained" >"${retained_output}"
+}
+
+CLOC_SWIFT=0
+CLOC_OBJC=0
+
+count_file_list() {
+	local file_list=$1
+	local cloc_path=$2
+	local json=$3
 	local counts
 	local objc
 	local objcpp
 
-	mkdir -p "${working_dir}"
-	build_bucket_file_list "${revision_root}" "${bucket}" "${file_list}"
+	CLOC_SWIFT=0
+	CLOC_OBJC=0
 	if [[ ! -s ${file_list} ]]; then
-		COUNT_SWIFT=0
-		COUNT_OBJC=0
 		return
 	fi
 
@@ -128,8 +189,35 @@ count_bucket() {
 		--list-file="${file_list}" >"${json}"
 
 	counts=$(jq -r '[(.Swift.code // 0), (."Objective-C".code // 0), (."Objective-C++".code // 0)] | @tsv' "${json}")
-	IFS=$'\t' read -r COUNT_SWIFT objc objcpp <<<"${counts}"
-	COUNT_OBJC=$((objc + objcpp))
+	IFS=$'\t' read -r CLOC_SWIFT objc objcpp <<<"${counts}"
+	CLOC_OBJC=$((objc + objcpp))
+}
+
+COUNT_SWIFT=0
+COUNT_OBJC=0
+COUNT_OBJC_RETAINED=0
+
+count_bucket() {
+	local revision_root=$1
+	local bucket=$2
+	local cloc_path=$3
+	local working_dir=$4
+	local retained_paths=$5
+	local combined="${working_dir}/${bucket}-files.txt"
+	local inscope="${working_dir}/${bucket}-files-in-scope.txt"
+	local retained="${working_dir}/${bucket}-files-retained.txt"
+
+	mkdir -p "${working_dir}"
+	build_bucket_file_list "${revision_root}" "${bucket}" "${combined}"
+	partition_bucket_file_list \
+		"${revision_root}" "${combined}" "${retained_paths}" "${inscope}" "${retained}"
+
+	count_file_list "${inscope}" "${cloc_path}" "${working_dir}/${bucket}-cloc.json"
+	COUNT_SWIFT=${CLOC_SWIFT}
+	COUNT_OBJC=${CLOC_OBJC}
+
+	count_file_list "${retained}" "${cloc_path}" "${working_dir}/${bucket}-cloc-retained.json"
+	COUNT_OBJC_RETAINED=${CLOC_OBJC}
 }
 
 materialize_revision() {
@@ -157,6 +245,19 @@ percentage() {
 
 format_integer() {
 	perl -e '$number = shift; 1 while $number =~ s/^(-?\d+)(\d{3})/$1,$2/; print $number' "$1"
+}
+
+# Retained Objective-C is a floor, not a target, so it gets a plain SLOC figure
+# and a signed delta only when the boundary actually thinned or grew.
+format_retained() {
+	local base=$1
+	local head=$2
+
+	if ((head == base)); then
+		format_integer "${head}"
+		return
+	fi
+	printf '%s (%+d)' "$(format_integer "${head}")" "$((head - base))"
 }
 
 progress_bar() {
@@ -325,69 +426,71 @@ measure_diff_movement() {
 	done <"${diff_file}"
 }
 
+# Emits both goal rows for one area: the short-term target (in-scope
+# Objective-C only) and the long-term target (all Objective-C, which the
+# retained public API surface can only satisfy in a future major release).
+write_area_rows() {
+	local label=$1
+	local base_swift=$2
+	local base_inscope=$3
+	local base_retained=$4
+	local head_swift=$5
+	local head_inscope=$6
+	local head_retained=$7
+	local base_total=$((base_inscope + base_retained))
+	local head_total=$((head_inscope + head_retained))
+	local base_percent
+	local head_percent
+	local bar
+
+	base_percent=$(percentage "${base_swift}" "${base_inscope}")
+	head_percent=$(percentage "${head_swift}" "${head_inscope}")
+	bar=$(progress_bar "${head_percent}")
+	calculate_delta "${base_percent}" "${head_percent}"
+	printf '| %s | Short term — in scope | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
+		"${label}" "${bar}" "${base_percent}" "${head_percent}" \
+		"$(format_integer "${head_swift}")" "$(format_integer "${head_inscope}")" \
+		"${DELTA_ICON}" "${DELTA_TEXT}"
+
+	base_percent=$(percentage "${base_swift}" "${base_total}")
+	head_percent=$(percentage "${head_swift}" "${head_total}")
+	bar=$(progress_bar "${head_percent}")
+	calculate_delta "${base_percent}" "${head_percent}"
+	printf '| %s | Long term — all Objective-C | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
+		"${label}" "${bar}" "${base_percent}" "${head_percent}" \
+		"$(format_integer "${head_swift}")" "$(format_integer "${head_total}")" \
+		"${DELTA_ICON}" "${DELTA_TEXT}"
+}
+
 write_report() {
 	local output=$1
 	local base=$2
 	local head=$3
 	local cloc_version=$4
-	local core_base_percent
-	local core_head_percent
-	local kit_base_percent
-	local kit_head_percent
-	local standalone_base_percent
-	local standalone_head_percent
-	local core_bar
-	local kit_bar
-	local standalone_bar
-	local core_delta_icon
-	local core_delta_text
-	local kit_delta_icon
-	local kit_delta_text
-	local standalone_delta_icon
-	local standalone_delta_text
 	local short_base=${base:0:12}
 	local short_head=${head:0:12}
-
-	core_base_percent=$(percentage "${BASE_CORE_SWIFT}" "${BASE_CORE_OBJC}")
-	core_head_percent=$(percentage "${HEAD_CORE_SWIFT}" "${HEAD_CORE_OBJC}")
-	kit_base_percent=$(percentage "${BASE_KIT_SWIFT}" "${BASE_KIT_OBJC}")
-	kit_head_percent=$(percentage "${HEAD_KIT_SWIFT}" "${HEAD_KIT_OBJC}")
-	standalone_base_percent=$(percentage "${BASE_STANDALONE_SWIFT}" "${BASE_STANDALONE_OBJC}")
-	standalone_head_percent=$(percentage "${HEAD_STANDALONE_SWIFT}" "${HEAD_STANDALONE_OBJC}")
-
-	core_bar=$(progress_bar "${core_head_percent}")
-	kit_bar=$(progress_bar "${kit_head_percent}")
-	standalone_bar=$(progress_bar "${standalone_head_percent}")
-
-	calculate_delta "${core_base_percent}" "${core_head_percent}"
-	core_delta_icon=${DELTA_ICON}
-	core_delta_text=${DELTA_TEXT}
-	calculate_delta "${kit_base_percent}" "${kit_head_percent}"
-	kit_delta_icon=${DELTA_ICON}
-	kit_delta_text=${DELTA_TEXT}
-	calculate_delta "${standalone_base_percent}" "${standalone_head_percent}"
-	standalone_delta_icon=${DELTA_ICON}
-	standalone_delta_text=${DELTA_TEXT}
 
 	mkdir -p "$(dirname "${output}")"
 	{
 		printf '%s\n' "${COMMENT_MARKER}"
 		printf '%s\n\n' '## 🐦 Swift Migration Progress'
 		printf 'Production implementation code at `%s` compared with `%s`.\n\n' "${short_head}" "${short_base}"
-		printf '%s\n' '| Area | Progress | Base | This PR | Swift SLOC | Objective-C remaining | Change |'
-		printf '%s\n' '|---|:---:|---:|---:|---:|---:|---:|'
-		printf '| Core SDK | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
-			"${core_bar}" "${core_base_percent}" "${core_head_percent}" \
-			"$(format_integer "${HEAD_CORE_SWIFT}")" "$(format_integer "${HEAD_CORE_OBJC}")" \
-			"${core_delta_icon}" "${core_delta_text}"
-		printf '| SDK kit infrastructure | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
-			"${kit_bar}" "${kit_base_percent}" "${kit_head_percent}" \
-			"$(format_integer "${HEAD_KIT_SWIFT}")" "$(format_integer "${HEAD_KIT_OBJC}")" \
-			"${kit_delta_icon}" "${kit_delta_text}"
-		printf '| Standalone kits | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n\n' \
-			"${standalone_bar}" "${standalone_base_percent}" "${standalone_head_percent}" \
-			"$(format_integer "${HEAD_STANDALONE_SWIFT}")" "$(format_integer "${HEAD_STANDALONE_OBJC}")" \
-			"${standalone_delta_icon}" "${standalone_delta_text}"
+		printf '%s\n' '| Area | Goal | Progress | Base | This PR | Swift SLOC | Objective-C remaining | Change |'
+		printf '%s\n' '|---|---|:---:|---:|---:|---:|---:|---:|'
+		write_area_rows 'Core SDK' \
+			"${BASE_CORE_SWIFT}" "${BASE_CORE_OBJC}" "${BASE_CORE_OBJC_RETAINED}" \
+			"${HEAD_CORE_SWIFT}" "${HEAD_CORE_OBJC}" "${HEAD_CORE_OBJC_RETAINED}"
+		write_area_rows 'SDK kit infrastructure' \
+			"${BASE_KIT_SWIFT}" "${BASE_KIT_OBJC}" "${BASE_KIT_OBJC_RETAINED}" \
+			"${HEAD_KIT_SWIFT}" "${HEAD_KIT_OBJC}" "${HEAD_KIT_OBJC_RETAINED}"
+		write_area_rows 'Standalone kits' \
+			"${BASE_STANDALONE_SWIFT}" "${BASE_STANDALONE_OBJC}" "${BASE_STANDALONE_OBJC_RETAINED}" \
+			"${HEAD_STANDALONE_SWIFT}" "${HEAD_STANDALONE_OBJC}" "${HEAD_STANDALONE_OBJC_RETAINED}"
+		printf '\n'
+		printf 'Objective-C retained by design: Core SDK %s · SDK kit infrastructure %s · Standalone kits %s.\n\n' \
+			"$(format_retained "${BASE_CORE_OBJC_RETAINED}" "${HEAD_CORE_OBJC_RETAINED}")" \
+			"$(format_retained "${BASE_KIT_OBJC_RETAINED}" "${HEAD_KIT_OBJC_RETAINED}")" \
+			"$(format_retained "${BASE_STANDALONE_OBJC_RETAINED}" "${HEAD_STANDALONE_OBJC_RETAINED}")"
 		printf '%s\n\n' "### This PR's code movement"
 		printf '%s\n' '| Area | Swift lines added | Objective-C lines removed |'
 		printf '%s\n' '|---|---:|---:|'
@@ -400,10 +503,15 @@ write_report() {
 		printf '%s\n\n' '<details>'
 		printf '%s\n\n' '<summary>How this is measured</summary>'
 		printf '%s\n' '- Current composition uses production source lines of code (SLOC) from `cloc`; comments and blank lines are excluded.'
-		printf '%s\n' '- Pull request movement uses physical additions/deletions from `git diff base...head --numstat`; it is intentionally separate from SLOC totals.'
+		printf '%s\n' '- **Short term — in scope** excludes the Objective-C the migration will not delete, so 100% is the end of this project: every in-scope implementation gone.'
+		printf '%s\n' '- **Long term — all Objective-C** keeps the full denominator. Reaching 100% there means the public API itself becomes Swift, which is a breaking change reserved for a future major release.'
+		printf '%s\n' '- The gap between the two rows is the retained public/kit contract, runtime-identity, and boundary-glue surface listed in `Tools/swift-migration-retained-objc.txt`.'
+		printf '%s\n' '- Retained wrappers keep their Objective-C interface but still shed logic to Swift. That thinning moves the long-term row and the retained figure, not the short-term row.'
+		printf '%s\n' '- Both revisions are measured with the manifest from the head revision, so a manifest edit does not by itself move the reported change.'
+		printf '%s\n' '- Pull request movement uses physical additions/deletions from `git diff base...head --numstat`; it counts retained files too and is intentionally separate from SLOC totals.'
 		printf '%s\n' '- Core excludes SDK kit infrastructure and vendored libraries. Standalone kits include only files below `Kits/**/Sources`.'
 		printf '%s\n' '- Tests, examples, headers, build outputs, vendored libraries, and the `MParticle/Sources` Swift overlay are excluded.'
-		printf '%s\n\n' '- Objective-C++ (`.mm`) is included in Objective-C remaining and removed counts.'
+		printf '%s\n\n' '- Objective-C++ (`.mm`) is included in the Objective-C figures and removed counts.'
 		printf 'Generated with `cloc` %s. This report is informational and does not gate migration direction.\n\n' "${cloc_version}"
 		printf '%s\n' '</details>'
 	} >"${output}"
@@ -411,16 +519,22 @@ write_report() {
 
 BASE_CORE_SWIFT=0
 BASE_CORE_OBJC=0
+BASE_CORE_OBJC_RETAINED=0
 BASE_KIT_SWIFT=0
 BASE_KIT_OBJC=0
+BASE_KIT_OBJC_RETAINED=0
 BASE_STANDALONE_SWIFT=0
 BASE_STANDALONE_OBJC=0
+BASE_STANDALONE_OBJC_RETAINED=0
 HEAD_CORE_SWIFT=0
 HEAD_CORE_OBJC=0
+HEAD_CORE_OBJC_RETAINED=0
 HEAD_KIT_SWIFT=0
 HEAD_KIT_OBJC=0
+HEAD_KIT_OBJC_RETAINED=0
 HEAD_STANDALONE_SWIFT=0
 HEAD_STANDALONE_OBJC=0
+HEAD_STANDALONE_OBJC_RETAINED=0
 
 generate_report() {
 	local repo=$1
@@ -434,6 +548,7 @@ generate_report() {
 	local base_commit
 	local head_commit
 	local cloc_version
+	local retained_paths
 
 	[[ -d ${repo} ]] || fail "repository not found: ${repo}"
 	git -C "${repo}" rev-parse --git-dir >/dev/null 2>&1 || fail "not a Git repository: ${repo}"
@@ -450,25 +565,36 @@ generate_report() {
 	materialize_revision "${repo}" "${base_commit}" "${base_root}"
 	materialize_revision "${repo}" "${head_commit}" "${head_root}"
 
-	count_bucket "${base_root}" core "${cloc_path}" "${workspace}/base-core"
+	# The head revision owns the scope definition for both sides of the
+	# comparison, so editing the manifest cannot masquerade as code movement.
+	retained_paths="${workspace}/retained-paths.txt"
+	load_retained_manifest "${head_root}" "${retained_paths}"
+
+	count_bucket "${base_root}" core "${cloc_path}" "${workspace}/base-core" "${retained_paths}"
 	BASE_CORE_SWIFT=${COUNT_SWIFT}
 	BASE_CORE_OBJC=${COUNT_OBJC}
-	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit"
+	BASE_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit" "${retained_paths}"
 	BASE_KIT_SWIFT=${COUNT_SWIFT}
 	BASE_KIT_OBJC=${COUNT_OBJC}
-	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone"
+	BASE_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone" "${retained_paths}"
 	BASE_STANDALONE_SWIFT=${COUNT_SWIFT}
 	BASE_STANDALONE_OBJC=${COUNT_OBJC}
+	BASE_STANDALONE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 
-	count_bucket "${head_root}" core "${cloc_path}" "${workspace}/head-core"
+	count_bucket "${head_root}" core "${cloc_path}" "${workspace}/head-core" "${retained_paths}"
 	HEAD_CORE_SWIFT=${COUNT_SWIFT}
 	HEAD_CORE_OBJC=${COUNT_OBJC}
-	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit"
+	HEAD_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit" "${retained_paths}"
 	HEAD_KIT_SWIFT=${COUNT_SWIFT}
 	HEAD_KIT_OBJC=${COUNT_OBJC}
-	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone"
+	HEAD_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone" "${retained_paths}"
 	HEAD_STANDALONE_SWIFT=${COUNT_SWIFT}
 	HEAD_STANDALONE_OBJC=${COUNT_OBJC}
+	HEAD_STANDALONE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 
 	measure_diff_movement "${repo}" "${base_commit}" "${head_commit}" "${workspace}/movement-numstat"
 	cloc_version=$("${cloc_path}" --version | tr -d '\r\n')
@@ -492,6 +618,52 @@ assert_contains() {
 	grep -Fq "${expected}" "${file}" || fail "self-test expected to find: ${expected}"
 }
 
+assert_manifest_rejects() {
+	local root=$1
+	local expectation=$2
+	local log="${root}/rejection.log"
+
+	if (load_retained_manifest "${root}" "${root}/validated.txt") >"${log}" 2>&1; then
+		fail "self-test expected a rejected retained manifest: ${expectation}"
+	fi
+	assert_contains "${log}" "${expectation}"
+}
+
+# Exercises manifest parsing and validation against throwaway directory trees,
+# independent of the Git fixture.
+run_manifest_validation_selftest() {
+	local workspace=$1
+	local accepted="${workspace}/accepted"
+	local missing="${workspace}/missing"
+	local not_objc="${workspace}/not-objc"
+	local unbucketed="${workspace}/unbucketed"
+	local vendored="${workspace}/vendored"
+	local validated="${accepted}/validated.txt"
+
+	write_fixture_file "${accepted}" 'mParticle-Apple-SDK/Utils/Kept.m' $'@implementation Kept\n@end\n'
+	write_fixture_file "${accepted}" "${RETAINED_MANIFEST}" \
+		$'# leading comment\n\n   mParticle-Apple-SDK/Utils/Kept.m   \n\n# trailing comment\n'
+	load_retained_manifest "${accepted}" "${validated}"
+	[[ "$(wc -l <"${validated}" | tr -d ' ')" == '1' ]] ||
+		fail 'self-test expected exactly one accepted retained manifest entry'
+	assert_contains "${validated}" 'mParticle-Apple-SDK/Utils/Kept.m'
+
+	write_fixture_file "${missing}" "${RETAINED_MANIFEST}" $'mParticle-Apple-SDK/Utils/Gone.m\n'
+	assert_manifest_rejects "${missing}" 'retained manifest entry does not exist'
+
+	write_fixture_file "${not_objc}" 'mParticle-Apple-SDK-Swift/Sources/Kept.swift' $'let kept = 1\n'
+	write_fixture_file "${not_objc}" "${RETAINED_MANIFEST}" $'mParticle-Apple-SDK-Swift/Sources/Kept.swift\n'
+	assert_manifest_rejects "${not_objc}" 'not an Objective-C implementation'
+
+	write_fixture_file "${unbucketed}" 'UnitTests/ObjCTests/Kept.m' $'@implementation Kept\n@end\n'
+	write_fixture_file "${unbucketed}" "${RETAINED_MANIFEST}" $'UnitTests/ObjCTests/Kept.m\n'
+	assert_manifest_rejects "${unbucketed}" 'outside every counted bucket'
+
+	write_fixture_file "${vendored}" 'mParticle-Apple-SDK/Libraries/Vendor/Kept.m' $'@implementation Kept\n@end\n'
+	write_fixture_file "${vendored}" "${RETAINED_MANIFEST}" $'mParticle-Apple-SDK/Libraries/Vendor/Kept.m\n'
+	assert_manifest_rejects "${vendored}" 'outside every counted bucket'
+}
+
 run_selftest() {
 	local cloc_path=$1
 	local fixture
@@ -499,11 +671,13 @@ run_selftest() {
 	local migration_sha
 	local flat_sha
 	local regression_sha
+	local thin_sha
 	local advanced_base_sha
 	local pr_head_sha
 	local migration_report
 	local flat_report
 	local regression_report
+	local thin_report
 	local divergent_report
 	local flat_count
 
@@ -531,6 +705,10 @@ run_selftest() {
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Libraries/Vendor/Excluded.m' $'int excludedVendor(void) { return 1; }\n'
 	write_fixture_file "${fixture}" 'MParticle/Sources/Excluded.swift' $'let excludedOverlay = 1\n'
 	write_fixture_file "${fixture}" 'Kits/vendor/vendor-1/Tests/Excluded.m' $'int excludedKitTest(void) { return 1; }\n'
+	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Utils/Retained Contract.m' \
+		$'// contract wrapper\n\n@implementation RetainedContract\n- (int)value { return 1; }\n- (int)other { return 2; }\n@end\n'
+	write_fixture_file "${fixture}" "${RETAINED_MANIFEST}" \
+		$'# retained by design\n\nmParticle-Apple-SDK/Utils/Retained Contract.m\nKits/vendor/vendor-1/Sources/Kit.m\n'
 
 	git -C "${fixture}" add --all
 	git -C "${fixture}" commit -q -m 'base fixture'
@@ -549,9 +727,15 @@ run_selftest() {
 
 	migration_report="${fixture}/migration-report.md"
 	generate_report "${fixture}" "${base_sha}" "${migration_sha}" "${cloc_path}" "${migration_report}"
+	assert_contains "${migration_report}" '| Core SDK | Short term — in scope |'
+	assert_contains "${migration_report}" '| Core SDK | Long term — all Objective-C |'
 	assert_contains "${migration_report}" '| 25.00% | 42.86% | 3 | 4 | 🚀 +17.86 pp |'
+	assert_contains "${migration_report}" '| 16.67% | 27.27% | 3 | 8 | 🚀 +10.60 pp |'
 	assert_contains "${migration_report}" '| 33.33% | 100.00% | 2 | 0 | 🚀 +66.67 pp |'
+	assert_contains "${migration_report}" '| 100.00% | 100.00% | 1 | 0 | ➖ 0.00 pp |'
 	assert_contains "${migration_report}" '| 33.33% | 33.33% | 1 | 2 | ➖ 0.00 pp |'
+	assert_contains "${migration_report}" \
+		'Objective-C retained by design: Core SDK 4 · SDK kit infrastructure 0 · Standalone kits 2.'
 	assert_contains "${migration_report}" '| Core SDK | 1 | 4 |'
 	assert_contains "${migration_report}" '| SDK kit infrastructure | 1 | 2 |'
 	assert_contains "${migration_report}" '| Standalone kits | 0 | 0 |'
@@ -563,7 +747,7 @@ run_selftest() {
 	flat_report="${fixture}/flat-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${flat_sha}" "${cloc_path}" "${flat_report}"
 	flat_count=$(grep -Fc '➖ 0.00 pp' "${flat_report}")
-	[[ ${flat_count} -eq 3 ]] || fail 'self-test expected three flat migration buckets'
+	[[ ${flat_count} -eq 6 ]] || fail 'self-test expected six flat migration goal rows'
 
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Event/Regression.m' $'@implementation Regression\n@end\n'
 	git -C "${fixture}" add 'mParticle-Apple-SDK/Event/Regression.m'
@@ -572,6 +756,23 @@ run_selftest() {
 	regression_report="${fixture}/regression-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${regression_sha}" "${cloc_path}" "${regression_report}"
 	assert_contains "${regression_report}" '| 42.86% | 33.33% | 3 | 6 | ↩️ -9.53 pp |'
+	assert_contains "${regression_report}" '| 27.27% | 23.08% | 3 | 10 | ↩️ -4.19 pp |'
+
+	git -C "${fixture}" switch -q -c selftest-thin "${migration_sha}"
+	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Utils/Retained Contract.m' \
+		$'// contract wrapper\n\n@implementation RetainedContract\n@end\n'
+	git -C "${fixture}" add --all
+	git -C "${fixture}" commit -q -m 'retained thinning fixture'
+	thin_sha=$(git -C "${fixture}" rev-parse HEAD)
+	thin_report="${fixture}/thin-report.md"
+	generate_report "${fixture}" "${migration_sha}" "${thin_sha}" "${cloc_path}" "${thin_report}"
+	# Thinning a retained wrapper is invisible to the short-term goal and real
+	# progress toward the long-term one.
+	assert_contains "${thin_report}" '| 42.86% | 42.86% | 3 | 4 | ➖ 0.00 pp |'
+	assert_contains "${thin_report}" '| 27.27% | 33.33% | 3 | 6 | 🚀 +6.06 pp |'
+	assert_contains "${thin_report}" \
+		'Objective-C retained by design: Core SDK 2 (-2) · SDK kit infrastructure 0 · Standalone kits 2.'
+	assert_contains "${thin_report}" '| Core SDK | 0 | 2 |'
 
 	git -C "${fixture}" switch -q -c selftest-pr "${migration_sha}"
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK-Swift/Sources/PR Only.swift' $'let prOne = 1\nlet prTwo = 2\n'
@@ -593,6 +794,7 @@ run_selftest() {
 	assert_contains "${divergent_report}" '| Standalone kits | 0 | 0 |'
 
 	[[ "$(percentage 0 0)" == '0.00' ]] || fail 'self-test expected a zero-denominator percentage of 0.00'
+	run_manifest_validation_selftest "${fixture}/manifest-validation"
 	printf '%s\n' 'swift-migration-progress: SELFTEST PASS'
 }
 

--- a/Tools/swift-migration-retained-objc.txt
+++ b/Tools/swift-migration-retained-objc.txt
@@ -1,0 +1,78 @@
+# Objective-C retained by design — the migration's out-of-scope boundary.
+#
+# Every path below is an Objective-C implementation this phase of the migration
+# will NOT delete, because CONVERSION-RECIPE.md classifies its declaration as a
+# supported contract, a runtime-identity-pinned type, or unavoidable boundary
+# glue.
+#
+# Tools/swift-migration-progress.sh reports two goals per area. The short-term
+# goal excludes these files, so its 100% is the end of this project. The
+# long-term goal keeps the full denominator; its 100% means the public API
+# itself becomes Swift, which is a breaking change for a future major release.
+# This manifest is the gap between the two.
+#
+# Listing a file here does not freeze its contents. A contract wrapper keeps
+# its @interface, class name, selectors, and nullability, but its logic still
+# moves to Swift; the wrapper thins to marshaling. That thinning moves the
+# long-term goal and the retained SLOC figure, not the short-term goal.
+#
+# Format: one repository-relative path per line; `#` comments and blank lines
+# ignored. Only `.m`/`.mm` paths inside a counted bucket are accepted, and each
+# path must exist — the report fails on a stale or misplaced entry.
+#
+# Editing policy and the evidence an addition requires: Tools/README.md
+# ("Retained Objective-C manifest").
+
+# --- Supported customer contracts (CONVERSION-RECIPE.md classification 1) ---
+# Declarations reached through mParticle.h and its imports; each appears in
+# Tools/abi-baseline.txt.
+
+mParticle-Apple-SDK/mParticle.m
+mParticle-Apple-SDK/MParticleOptions+MParticlePrivate.m
+mParticle-Apple-SDK/MParticleSession+MParticlePrivate.m
+mParticle-Apple-SDK/MPAttributionResult+MParticlePrivate.m
+mParticle-Apple-SDK/MPNetworkOptions+MParticlePrivate.m
+mParticle-Apple-SDK/MPEnums.m
+mParticle-Apple-SDK/MPRokt.m
+mParticle-Apple-SDK/Event/MPBaseEvent.m
+mParticle-Apple-SDK/Event/MPEvent.m
+mParticle-Apple-SDK/Ecommerce/MPCommerceEvent.m
+mParticle-Apple-SDK/Ecommerce/MPProduct.m
+mParticle-Apple-SDK/Ecommerce/MPPromotion.m
+mParticle-Apple-SDK/Ecommerce/MPTransactionAttributes.m
+mParticle-Apple-SDK/Consent/MPConsentState.m
+mParticle-Apple-SDK/Consent/MPGDPRConsent.m
+mParticle-Apple-SDK/Consent/MPCCPAConsent.m
+mParticle-Apple-SDK/Data Model/MPLocation.m
+mParticle-Apple-SDK/Identity/MPIdentityApi.m
+mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+mParticle-Apple-SDK/Identity/MParticleUser.m
+mParticle-Apple-SDK/Identity/MPAliasRequest.m
+mParticle-Apple-SDK/Identity/MPAliasResponse.m
+mParticle-Apple-SDK/Identity/MPAudience.m
+mParticle-Apple-SDK/Utils/NSDictionary+MPCaseInsensitive.m
+
+# --- Supported kit and wrapper-SDK contracts (classification 1) ---
+# The kit integration surface. Standalone kits compile against these types and
+# wrapper SDKs forward through them, so their runtime identity is fixed.
+
+mParticle-Apple-SDK/Identity/FilteredMParticleUser.m
+mParticle-Apple-SDK/Identity/FilteredMPIdentityApiRequest.m
+mParticle-Apple-SDK/Data Model/MPForwardRecord.m
+mParticle-Apple-SDK/Ecommerce/MPCommerceEventInstruction.m
+mParticle-Apple-SDK/Kits/MPKitAPI.m
+mParticle-Apple-SDK/Kits/MPKitExecStatus.m
+mParticle-Apple-SDK/Kits/MPKitRegister.m
+mParticle-Apple-SDK/Kits/MPSideloadedKit.m
+
+# --- Runtime-identity pinned (classification 3) ---
+# Header may become internal, but the ObjC class, NSSecureCoding conformance,
+# and legacy archive class-name mappings stay.
+
+mParticle-Apple-SDK/Utils/MPUploadSettings.m
+
+# --- Internal ObjC boundary glue (classification 4) ---
+# Bridges a module boundary the Swift target cannot cross. Retained until that
+# dependency boundary is redesigned, at which point delete the entry with it.
+
+mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m

--- a/docs/swift-migration/CONVERSION-RECIPE.md
+++ b/docs/swift-migration/CONVERSION-RECIPE.md
@@ -39,6 +39,14 @@ Record the evidence in any PR that removes an exported declaration. If the
 audit finds a supported external dependency, classify the declaration as a
 contract and keep its wrapper.
 
+Classifications 1, 3, and 4 keep an Objective-C implementation permanently, so
+they are also the migration's scope boundary. When a conversion settles one of
+those classifications, add the implementation path to
+`Tools/swift-migration-retained-objc.txt` with the audit evidence in the PR;
+that file is what separates the progress report's short-term goal from its
+long-term one, and `PR-GATE.md`'s "What \"done\" means" section governs it. Classification 2 files
+stay out of the manifest — they are the work the percentage measures.
+
 ## Two-stage wrapper model
 
 1. **Move logic → Swift; keep the boundary that is still required.** Add a
@@ -88,6 +96,8 @@ because downstream code can change.
 
 Customer-facing event, identity, consent, commerce, location, options, and Rokt
 APIs remain supported contracts even when their implementations move to Swift.
+Their Objective-C declaration sites are enumerated in
+`Tools/swift-migration-retained-objc.txt`.
 
 ## Hard constraint: the Swift module cannot import ObjC
 

--- a/docs/swift-migration/PR-GATE.md
+++ b/docs/swift-migration/PR-GATE.md
@@ -48,6 +48,40 @@ phase after it without exception.
    Swift must add a Swift mirror test for that extracted logic (see
    `CONVERSION-RECIPE.md`'s dual-test convention).
 
+## What "done" means
+
+The migration does not end at zero Objective-C. The public customer API, the
+kit and wrapper-SDK contract surface, runtime-identity-pinned classes, and the
+boundary glue in `CONVERSION-RECIPE.md`'s classifications 1, 3, and 4 stay
+Objective-C by design — that is the intended end state, not unfinished work.
+
+This project is complete when every **in-scope** Objective-C implementation is
+gone: the classification 2 wrappers and the internal types behind them. The
+retained boundary is enumerated in `Tools/swift-migration-retained-objc.txt`.
+
+The progress report on each PR therefore carries two goal rows per area:
+
+- **Short term — in scope** excludes the retained boundary, so 100% is
+  reachable and marks the end of this project.
+- **Long term — all Objective-C** keeps the full denominator. 100% there
+  requires taking the public API itself to Swift — a breaking change reserved
+  for a future major release, tracked rather than redefined away.
+
+Two consequences for a conversion PR:
+
+- Classifying a declaration as a retained contract means adding its
+  implementation to the manifest, with the audit evidence
+  `CONVERSION-RECIPE.md` requires recorded in the PR. Item 1's baseline-update
+  policy governs the other direction: an accidental export that gets removed is
+  **not** retained.
+- Deleting or renaming a retained implementation means updating the manifest in
+  the same PR. The report fails on a stale entry.
+
+Retaining a wrapper does not freeze it. A contract wrapper keeps its
+`@interface`, class name, selectors, and nullability while its logic moves to
+Swift, so the report tracks its remaining Objective-C SLOC in a separate
+retained column rather than in the percentage.
+
 ## Scope note
 
 This gate applies to every migration PR and is not re-specified per phase.


### PR DESCRIPTION
## Why

The progress report divided Swift SLOC by **all** production Objective-C. That
denominator includes the surface we keep in Objective-C on purpose — the public
customer API, the kit and wrapper-SDK contracts, runtime-identity pinned
classes, and boundary glue (`CONVERSION-RECIPE.md` classifications 1, 3, and 4).
100% was unreachable by construction, so the bar measured against a target this
project is not pursuing.

## What changed

Each area now reports **two goal rows** instead of one number:

- **Short term — in scope** — excludes the retained boundary. 100% here marks
  the end of this project: every Objective-C implementation the migration
  intends to delete is gone.
- **Long term — all Objective-C** — the original full-denominator figure,
  unchanged. 100% here means the public API itself becomes Swift, a breaking
  change for a future major release. Kept so that goal stays tracked rather
  than redefined away.

### The report on this tree

| Area | Goal | Base | This PR | Swift SLOC | ObjC remaining | Change |
|---|---|---:|---:|---:|---:|---:|
| Core SDK | Short term — in scope | 34.65% | 34.65% | 4,900 | 9,243 | ➖ 0.00 pp |
| Core SDK | Long term — all Objective-C | 24.50% | 24.50% | 4,900 | 15,103 | ➖ 0.00 pp |
| SDK kit infrastructure | Short term — in scope | 0.00% | 0.00% | 0 | 3,340 | ➖ 0.00 pp |
| SDK kit infrastructure | Long term — all Objective-C | 0.00% | 0.00% | 0 | 3,725 | ➖ 0.00 pp |
| Standalone kits | Short term — in scope | 1.06% | 1.06% | 152 | 14,231 | ➖ 0.00 pp |
| Standalone kits | Long term — all Objective-C | 1.06% | 1.06% | 152 | 14,231 | ➖ 0.00 pp |

`Objective-C retained by design: Core SDK 5,860 · SDK kit infrastructure 385 · Standalone kits 0.`

The long-term rows reproduce the previous report's numbers exactly. Every area
reconciles: in scope + retained = the long-term remaining figure. Kit
infrastructure sits at 0.00% on both because it has no Swift yet.

### The manifest

`Tools/swift-migration-retained-objc.txt` is a new reviewed manifest of the 34
Objective-C implementations that stay. It is the gap between the two goal rows,
and its SLOC is printed under the table with a signed delta when it moves.

Nothing in it was picked by heuristic. Every entry backs a declaration in
`Tools/abi-baseline.txt` or is named in `CONVERSION-RECIPE.md`'s compatibility
inventory:

- **Supported customer contracts** — `mParticle.m`, the `+MParticlePrivate`
  implementations of `MParticleOptions` / `MParticleSession` /
  `MPAttributionResult` / `MPNetworkOptions`, `MPEnums.m`'s exported constants,
  and the event, commerce, consent, identity, location, and Rokt declaration
  sites reached through `mParticle.h`.
- **Supported kit and wrapper-SDK contracts** — `MPKitAPI`, `MPKitExecStatus`,
  `MPKitRegister`, `MPSideloadedKit`, `MPForwardRecord`,
  `MPCommerceEventInstruction`, and the `Filtered*` types.
- **Runtime-identity pinned** — `MPUploadSettings` (classification 3).
- **Boundary glue** — `MPUserDefaultsConnector` (classification 4).

Deliberately **not** retained: the `_PRIVATE` accidental exports the recipe
lists as wrapper-removal candidates — `MPBackendController`,
`MPPersistenceController`, `MPNetworkCommunication`, `MPStateMachine`,
`MPNotificationController`, `MPKitContainer`, `SceneDelegateHandler`. That is
~9k SLOC still in scope, which is why the short-term Core row lands at 34.65%
rather than somewhere near done. A naive "has a header in `Include/`" rule would
have wrongly excluded all of them.

Standalone kits get no entries. Their `MPKit*` classes are resolved by name at
runtime, and no kit-side conversion has established that contract yet — so both
their goal rows are identical for now.

### Behavioral details worth reviewing

- **Retaining a wrapper does not freeze it.** A contract wrapper keeps its
  `@interface`, class name, selectors, and nullability while its logic moves to
  Swift. That thinning moves the **long-term** row and the retained figure while
  leaving the short-term row flat — so the ~5.9k retained SLOC stays measurable
  instead of being written off.
- **Both revisions are counted with the head revision's manifest**, so editing
  the manifest cannot book a redefinition as progress. This PR's own report
  reads `➖ 0.00 pp` on all six rows, which is the correct answer — no code
  moved.
- **Diff movement is left unfiltered.** Deleting lines from a retained wrapper
  is real work and still shows in the movement table.
- **Stale entries fail the report** rather than silently reverting a file to
  in-scope: a path missing at head, a non-`.m`/`.mm` path, or a path outside the
  three counted buckets all exit non-zero.

### Docs

- `PR-GATE.md` gains a **What "done" means** section covering both horizons,
  plus the requirement to keep the manifest in sync when classifying or
  deleting a retained wrapper.
- `CONVERSION-RECIPE.md` links classifications 1/3/4 to the manifest.
- `Tools/README.md` documents both goals, the manifest format, the editing
  policy and the evidence an addition requires, and adds the manifest to the
  end-of-migration cleanup list.

## Gate results

| # | Item | Result |
|---|---|---|
| 1 | `Tools/abi-guard.sh check` | ✅ PASSED — no public ABI diff. Baseline untouched. `abi-guard-selftest.sh` also PASS. |
| 2 | `pod lib lint` on all 3 podspecs | ⚪️ Not run — diff touches only `Tools/` and `docs/`; no sources, headers, podspecs, or project files. Also blocked locally: this machine has the tvOS 26.2 SDK but only the 26.0 simulator runtime, so the tvOS leg cannot run here. CI is the sole tvOS verification. |
| 3 | Build green on iOS + tvOS | ⚪️ Not run — same reason; nothing compiled changed. Same tvOS runtime gap applies. |
| 4 | `trunk check` | ✅ Clean on all 5 changed files. `shellcheck -x` also clean. |
| 5 | ObjC + Swift unit suites | ⚪️ Not run — no SDK source changed. Tooling is covered instead by `swift-migration-progress.sh selftest`. |

**Tooling verification actually performed** (with `cloc` 2.10, SHA-256 verified
against the value pinned in `swift-migration-progress.yml`):

- `swift-migration-progress.sh selftest` → **PASS**. Fixture extended with a
  retained contract wrapper and a manifest; new coverage for the two goal rows,
  denominator exclusion, retained thinning moving only the long-term row,
  comment/blank/whitespace parsing, and rejection of stale, non-Objective-C,
  out-of-bucket, and vendored entries.
- Real report generated on this tree — the table above.
- Stale-entry guard exercised against the real repository, not just the
  fixture: exits 1 with
  `retained manifest entry does not exist: <path>`.

No `CHANGELOG.md` entry — no public surface change.

Supersedes #864 (wrong branch prefix for the semantic-branch check, and `feat`
rather than `ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
