### PR TITLE
ci: stop simulator cloning and bound network/test hangs

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -25,6 +25,7 @@ jobs:
     name: Pod Lint ${{ matrix.kit.name }}
     needs: load-matrix
     runs-on: macos-15
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +55,7 @@ jobs:
     name: Build ${{ matrix.kit.name }}
     needs: load-matrix
     runs-on: macOS-latest
+    timeout-minutes: 60
     env:
       XCODE_VERSION: ${{ matrix.kit.xcode_version || '26.2' }}
       USE_LOCAL_VERSION: "1"
@@ -74,17 +76,30 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Resolve SPM dependencies
+        timeout-minutes: 25
         run: |
-          SCHEME=$(echo '${{ toJson(matrix.kit.schemes) }}' | jq -r '.[0].scheme')
-          LOCAL_PATH="${{ matrix.kit.local_path }}"
-          if compgen -G "$LOCAL_PATH"/*.xcodeproj > /dev/null; then
-            PROJECT="$(ls -d "$LOCAL_PATH"/*.xcodeproj | head -1)"
-            xcodebuild -resolvePackageDependencies -project "$PROJECT" \
-              -scheme "$SCHEME" -derivedDataPath DerivedData
-          else
-            # Swift package without .xcodeproj (see rokt-sdk-plus-ios).
-            (cd "$LOCAL_PATH" && xcodebuild -resolvePackageDependencies -scheme "$SCHEME" -derivedDataPath "$OLDPWD/DerivedData")
-          fi
+          # Abort a git transfer that stalls below 1 KB/s for 3 minutes rather than
+          # hanging until the job is cancelled. Resolution normally takes 2-5 minutes.
+          git config --global http.lowSpeedLimit 1000
+          git config --global http.lowSpeedTime 180
+
+          resolve_dependencies() {
+            SCHEME=$(echo '${{ toJson(matrix.kit.schemes) }}' | jq -r '.[0].scheme')
+            LOCAL_PATH="${{ matrix.kit.local_path }}"
+            if compgen -G "$LOCAL_PATH"/*.xcodeproj > /dev/null; then
+              PROJECT="$(ls -d "$LOCAL_PATH"/*.xcodeproj | head -1)"
+              xcodebuild -resolvePackageDependencies -project "$PROJECT" \
+                -scheme "$SCHEME" -derivedDataPath DerivedData
+            else
+              # Swift package without .xcodeproj (see rokt-sdk-plus-ios).
+              (cd "$LOCAL_PATH" && xcodebuild -resolvePackageDependencies -scheme "$SCHEME" -derivedDataPath "$OLDPWD/DerivedData")
+            fi
+          }
+
+          for attempt in 1 2 3; do
+            resolve_dependencies && break
+            [ $attempt -lt 3 ] && echo "Resolve attempt $attempt failed, retrying in 30s..." && sleep 30 || exit 1
+          done
 
       - name: Build kit schemes
         run: |

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -76,10 +76,15 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Resolve SPM dependencies
-        timeout-minutes: 25
+        timeout-minutes: 20
+        env:
+          ATTEMPT_TIMEOUT_SECONDS: "480"
         run: |
-          # Abort a git transfer that stalls below 1 KB/s for 3 minutes rather than
-          # hanging until the job is cancelled. Resolution normally takes 2-5 minutes.
+          # Resolution pulls stripe-ios (~2.7 GB) transitively and normally takes
+          # 2-5 minutes, but the git fetch intermittently stalls indefinitely.
+          # git's own low-speed abort does not reliably fire on that stall (SwiftPM's
+          # fetch has been observed hung for 24+ minutes with this set), so each
+          # attempt is bounded by an explicit watchdog below instead.
           git config --global http.lowSpeedLimit 1000
           git config --global http.lowSpeedTime 180
 
@@ -96,10 +101,40 @@ jobs:
             fi
           }
 
-          for attempt in 1 2 3; do
-            resolve_dependencies && break
-            [ $attempt -lt 3 ] && echo "Resolve attempt $attempt failed, retrying in 30s..." && sleep 30 || exit 1
+          # Run one attempt under a watchdog that kills the whole fetch tree if it
+          # stalls, so a hung attempt is retried instead of consuming the step budget.
+          attempt_resolve() {
+            resolve_dependencies &
+            resolve_pid=$!
+
+            (
+              sleep "${ATTEMPT_TIMEOUT_SECONDS:-480}"
+              if kill -0 "$resolve_pid" 2>/dev/null; then
+                echo "::warning::Resolve stalled past ${ATTEMPT_TIMEOUT_SECONDS:-480}s; killing fetch and retrying"
+                kill -TERM "$resolve_pid" 2>/dev/null || true
+                sleep 5
+                kill -KILL "$resolve_pid" 2>/dev/null || true
+                # xcodebuild's git children outlive it; clear them so the retry starts clean.
+                pkill -KILL -f 'xcodebuild -resolvePackageDependencies' 2>/dev/null || true
+                pkill -KILL -f 'git-remote-http' 2>/dev/null || true
+              fi
+            ) &
+            watchdog_pid=$!
+
+            resolve_status=0
+            wait "$resolve_pid" 2>/dev/null || resolve_status=$?
+
+            kill "$watchdog_pid" 2>/dev/null || true
+            wait "$watchdog_pid" 2>/dev/null || true
+            return "$resolve_status"
+          }
+
+          for attempt in 1 2; do
+            attempt_resolve && exit 0
+            [ "$attempt" -lt 2 ] && echo "Resolve attempt $attempt failed, retrying in 30s..." && sleep 30
           done
+          echo "::error::SPM dependency resolution failed after 2 attempts"
+          exit 1
 
       - name: Build kit schemes
         run: |

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -103,20 +103,21 @@ jobs:
 
           # Run one attempt under a watchdog that kills the whole fetch tree if it
           # stalls, so a hung attempt is retried instead of consuming the step budget.
+          # The watchdog only signals and TERMs; escalation and child cleanup happen
+          # in the parent after wait returns, because TERMing the resolve unblocks
+          # wait immediately and the parent then reaps the watchdog.
           attempt_resolve() {
+            timeout_marker="${RUNNER_TEMP:-/tmp}/spm-resolve-timed-out.$$"
+            rm -f "$timeout_marker"
+
             resolve_dependencies &
             resolve_pid=$!
 
             (
               sleep "${ATTEMPT_TIMEOUT_SECONDS:-480}"
               if kill -0 "$resolve_pid" 2>/dev/null; then
-                echo "::warning::Resolve stalled past ${ATTEMPT_TIMEOUT_SECONDS:-480}s; killing fetch and retrying"
+                : > "$timeout_marker"
                 kill -TERM "$resolve_pid" 2>/dev/null || true
-                sleep 5
-                kill -KILL "$resolve_pid" 2>/dev/null || true
-                # xcodebuild's git children outlive it; clear them so the retry starts clean.
-                pkill -KILL -f 'xcodebuild -resolvePackageDependencies' 2>/dev/null || true
-                pkill -KILL -f 'git-remote-http' 2>/dev/null || true
               fi
             ) &
             watchdog_pid=$!
@@ -126,6 +127,19 @@ jobs:
 
             kill "$watchdog_pid" 2>/dev/null || true
             wait "$watchdog_pid" 2>/dev/null || true
+
+            if [ -f "$timeout_marker" ]; then
+              rm -f "$timeout_marker"
+              echo "::warning::Resolve stalled past ${ATTEMPT_TIMEOUT_SECONDS:-480}s; killing fetch and retrying"
+              kill -KILL "$resolve_pid" 2>/dev/null || true
+              # xcodebuild's git children outlive it; clear them so the retry does not
+              # race the previous fetch over SwiftPM's cache locks.
+              pkill -KILL -f 'xcodebuild -resolvePackageDependencies' 2>/dev/null || true
+              pkill -KILL -f 'git-remote-http' 2>/dev/null || true
+              sleep 5
+              resolve_status=124
+            fi
+
             return "$resolve_status"
           }
 

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -42,5 +42,15 @@ jobs:
           wait_for_boot: true
           shutdown_after_job: false
 
+      - name: Wait for simulator to finish booting
+        run: xcrun simctl bootstatus '${{ steps.simulator.outputs.udid }}' -b
+
       - name: Run unit tests
-        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme ${{ matrix.scheme }} -destination 'id=${{ steps.simulator.outputs.udid }}' test
+        run: |
+          xcodebuild -project mParticle-Apple-SDK.xcodeproj \
+            -scheme ${{ matrix.scheme }} \
+            -destination 'id=${{ steps.simulator.outputs.udid }}' \
+            -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 120 \
+            test


### PR DESCRIPTION
## Problem

Two unrelated hangs have been holding up CI. Both were **unbounded**, so instead of failing they consumed a job's whole budget.

### 1. `native-tests` — iOS × `mParticle-Apple-SDK-Swift` times out

That one matrix cell repeatedly hits its 15-minute `timeout-minutes`. One test is responsible:

| Run | Job duration | `MPDeviceTests.testDictionaryDescription()` |
|---|---|---|
| 32894194540 | 15m (cancelled) | **459.0s** |
| 32901460934 | 12m | **368.8s** |
| 32895141261 | 11m | **238.2s** |
| 32918366449 | 7m | **156.0s** |

Job duration tracks that one test exactly. In the timed-out run, total test time was 465.1s across 205 tests — 459.0s of it was this test. Every other test finishes in under 1.6s.

It isn't the assertions: **the same test took 0.069s on tvOS in the same run** (32901460934). `MPDevice` reads `UIDevice.current` for `name` ([MPDevice.swift:181](../blob/main/mParticle-Apple-SDK-Swift/Sources/Utils/MPDevice.swift#L181)) and `identifierForVendor` ([MPDevice.swift:216](../blob/main/mParticle-Apple-SDK-Swift/Sources/Utils/MPDevice.swift#L216)) — XPC calls into simulator daemons.

What makes it fire is the scheme. `mParticle-Apple-SDK-Swift.xcscheme` is the **only** scheme in the repo with `parallelizable = "YES"` — the ObjC core scheme and all 8 others have no parallelization and never time out. So `xcodebuild` clones and boots extra iOS simulators on a runner that has just erased one, starving the very daemons the test then blocks on.

That flag was never a deliberate choice: the scheme file was *added* whole in dab02a47 (the squashed 9.0 merge) with the attribute already present. It's Xcode's default for newly created test targets.

### 2. `build-kits` — `Build rokt-sdk-plus-ios` stalls in git

[Job 98200404539](https://github.com/mParticle/mparticle-apple-sdk/actions/runs/32975874199/job/98200404539) produced no output for 30 minutes:

```
14:11:45  Fetching from https://github.com/stripe/stripe-ios.git
14:41:59  ##[error]The operation was canceled.
...
Terminate orphan process: pid (2206) (git)
Terminate orphan process: pid (2195) (git-remote-http)
```

`stripe-ios` is **2.7 GB**, reached transitively via `RoktSDKPlus` → `rokt-payment-extension-ios` → `stripe/stripe-ios`. There's no `Package.resolved` for the kit and no SPM caching, so it's refetched from scratch every run.

Worse, `build-kits` has no `timeout-minutes`. It was only stopped by an unrelated `cancel-in-progress` concurrency cancel — otherwise it would have held a macOS runner for the 6-hour default at 10× billing. Healthy resolves take 2–5 minutes.

## Changes

**`native-tests.yml`**
- `-parallel-testing-enabled NO` — stops the simulator cloning that causes the block.
- `xcrun simctl bootstatus … -b` — the action's `wait_for_boot` only waits for `state=Booted`, not for first-boot work to finish.
- `-test-timeouts-enabled YES -default-test-execution-time-allowance 120` — a hung test now fails in 2 minutes with an explicit diagnostic instead of silently eating the job timeout.

**`build-kits.yml`**
- `http.lowSpeedLimit` / `http.lowSpeedTime` — git aborts a transfer stalled below 1 KB/s for 3 minutes rather than hanging.
- 3-attempt retry around the resolve, matching the existing `pod-lint-kits` pattern in the same file.
- `timeout-minutes` on `build-kits` (60), `pod-lint-kits` (45), and the resolve step (25), so no hang here can run unbounded again.

## Validation

Run against PR #836's branch (the one currently failing), Xcode 26.3:

| | Serial | Parallel |
|---|---|---|
| Result | 239 tests, 0 failures | passes |
| Test time | 2.1s | 2.1s |
| **Wall clock (warm)** | **33s** | **74s** |
| xctest workers | 1 | 8 |

**Serial is 2× faster** — parallel spends its time booting 8 clones for 2 seconds of tests. On a freshly-erased simulator (matching CI's `erase_before_boot: true`) serial passed **3/3** consecutive runs.

The timeout guard was verified to actually fire: a deliberately-hung test (600s sleep, added temporarily and reverted) was killed at the allowance with `** TEST FAILED **` and `exceeded execution time allowance … The test may have hung`.

`trunk check` clean on both files (actionlint, shellcheck, shfmt, prettier all enabled).

Headroom check: the slowest genuine test on CI is `MParticleTests.testSwitchWorkspaceOptions` at ~30.2s (a hard-coded 30s wait), consistent across runs — 4× under the 120s allowance. The ObjC scheme has no `parallelizable` attribute, so `-parallel-testing-enabled NO` is a no-op there and no timeout messages appeared in any ObjC run.

### Two things I could not validate locally, flagged deliberately

1. **The hang itself doesn't reproduce locally** (0.015–0.10s here) because local simulator daemons are warm. It needs CI's cold, freshly-erased simulator. So the fix is validated by mechanism and by the tvOS/iOS contrast, not by local reproduction.
2. **The ObjC suite is already flaky on Xcode 26.3 locally**, independent of this PR. Identical commands gave 1 failure, then 17, then 1 — and the control run *without* any of these flags gave 17. Mostly `testSelectPlacements*` / `testSelectShoppableAds*` plus `testApiKeySecretThreadSafety` and `testSwitchWorkspaceKitsWithStop`. CI passes these on Xcode 16.4, so it looks toolchain-specific. Pre-existing and out of scope here, but worth a separate look.

## Verified on CI

Confirmed on the first CI run of this change ([run 33008865240](https://github.com/mParticle/mparticle-apple-sdk/actions/runs/33008865240), pushed as `claude/…` before this branch was renamed to satisfy the branch-name check):

| | Before | After |
|---|---|---|
| `MPDeviceTests.testDictionaryDescription` | 156–459s | **0.331s** |
| Simulator clones spawned | 2+ | **0** |
| Test step | up to 13m (hit timeout) | **163s** |
| Job total | 8–15m, often cancelled | **5.8m** |

`Build rokt-sdk-plus-ios` also passed, along with `Pod Lint rokt-sdk-plus-ios`, `iOS/tvOS mParticle-Apple-SDK-Swift`, and `iOS mParticle-Apple-SDK`.

## Update: the network guard needed a second pass

The first version of the network fix was **ineffective**, and CI proved it. On [run 33010942238](https://github.com/mParticle/mparticle-apple-sdk/actions/runs/33010942238) the stripe-ios fetch sat for **24.5 minutes** with `http.lowSpeedLimit`/`lowSpeedTime` set, produced no error, and never returned — so git never aborted, the retry loop never got a turn, and the step burned its full 25-minute budget before failing.

What did work was the step timeout: the hang failed *bounded* instead of running until an unrelated concurrency cancel stopped it. That part of the goal held.

The second commit bounds each attempt explicitly rather than trusting git to self-abort. A watchdog kills the resolve and its surviving `git` / `git-remote-http` children once an attempt exceeds `ATTEMPT_TIMEOUT_SECONDS` (480s, against a healthy 2–5 minute resolve), so a stalled attempt is retried instead of consuming the step. Attempts drop to 2 and the step timeout to 20 minutes, since an attempt can no longer run unbounded.

The git low-speed config stays — not sufficient alone, but harmless and still useful where it does apply.

Verified by extracting the real step body and stubbing the resolver:

| Scenario | Result |
|---|---|
| Healthy resolve | exit 0 in 1s, no kills |
| Permanent hang | killed, retried, killed, fails bounded |
| Hang then healthy retry | killed once, exit 0 |

Also defaulted the timeout in-place (`${ATTEMPT_TIMEOUT_SECONDS:-480}`) after finding that an unset variable makes `sleep ""` fail instantly and the watchdog kill the resolve immediately.

### Pre-existing failure, not caused by this PR

`native-unit-tests (tvOS, mParticle-Apple-SDK)` failed on `MParticleTests.testSwitchWorkspaceSideloadedKits`. Evidence that it's unrelated to these changes:

- **The new timeout guard did not fire** — zero `exceeded execution time allowance` messages, and the test died at ~51s against a 120s allowance.
- **The parallel flag is a no-op for this scheme** — `mParticle-Apple-SDK.xcscheme` has no `parallelizable` attribute, so it was already serial.
- **It's a process crash, not a timeout:** `Restarting after unexpected exit, crash, or test timeout`, preceded by SQLite `API call with NULL database connection pointer` / `misuse at line 153359` — a connection used after close, i.e. a real race in workspace switching.
- **The same failure predates this PR** on other branches:

| Run | Job | Failing test | Crash-restarts |
|---|---|---|---|
| 32893102331 | tvOS ObjC | `MPKitContainerTests.testActiveKitsRegistryThreadSafety` | 1 |
| 32893235701 | tvOS ObjC | `MParticleTests.testSwitchWorkspaceKitsWithStop` | 1 |
| 32893235701 | iOS ObjC | *(bundle crashed)* | 2 |

- **A/B tested locally, 12 runs per arm, interleaved:** failure rates are the same with and without the new timeout flag, and the allowance never fired once in 24 runs.

| Arm | Failures | Crashes | Allowance hits |
|---|---|---|---|
| With timeout flag | 8 / 12 | 1 | **0** |
| Without timeout flag | 9 / 12 | 3 | **0** |

  The arms also fail in near-lockstep by run index (both pass 1, 3, 11, 12; both fail 2; both fail 7-10), so failure tracks how many times the suite has already run on that simulator rather than which flags were passed — pointing at accumulated simulator state, the same class of problem as the `MPUserDefaultsTests` teardown gap noted below.
- **Five different tests across five CI failures**, and `tvOS, mParticle-Apple-SDK` is currently red on two unrelated branches (`refactor/push-tracking-logic-to-swift`, `refactor/scene-delegate-logic-to-swift`). Historical base rate for that job over 30 recent PR runs: 14 pass / 4 fail.

This ObjC crash flakiness deserves its own investigation — same class of CI drag, different cause.

## Follow-ups (not in this PR)

- **`MPUserDefaultsTests` isolation.** Its `tearDown` ([MPUserDefaultsTests.swift:66](../blob/main/mParticle-Apple-SDK-Swift/Test/Utils/MPUserDefaultsTests.swift#L66)) clears the standard-suite key but never the `UserDefaults(suiteName: "groupID")` app-group suite or the `"userKey"` it writes, so state survives on the simulator between runs. I hit 8 failures from this once on a dirty simulator (couldn't reproduce in 4 further attempts, and never on an erased sim, so CI is on the clean path). Serializing makes this the whole suite's exposure rather than one worker's — worth tightening.
- **Root-cause the hang properly:** put `name`/`vendorId` behind an injected protocol the way `stateMachine`, `userDefaults`, and `identity` already are, so a unit test can't touch simulator XPC at all.
- **Get `stripe-ios` out of the graph** (binary target / XCFramework on the `rokt-payment-extension-ios` side). This PR bounds that failure mode; it doesn't remove 2.7 GB from every CI run.
- **SPM caching** for `build-kits` — deliberately left out; a multi-GB cache needs measuring against the 10 GB per-repo budget first.

No `CHANGELOG.md` entry: CI-only, no consumer-facing SDK change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

