### PR TITLE
test: make workspace-switch and kit-registry concurrency tests deterministic

### DIFF
--- a/UnitTests/ObjCTests/MPKitContainerTests.m
+++ b/UnitTests/ObjCTests/MPKitContainerTests.m
@@ -3438,12 +3438,33 @@
     dispatch_queue_t concurrentQueue = dispatch_queue_create("com.mparticle.test.concurrent", DISPATCH_QUEUE_CONCURRENT);
     
     NSInteger iterations = 100;
-    __block BOOL encounteredError = NO;
-    
+    // Shared across four concurrent blocks, so it is guarded rather than a plain
+    // __block BOOL - an unsynchronized flag is itself a data race, and reporting
+    // failures off the main thread is not safe with XCTest.
+    NSLock *errorLock = [[NSLock alloc] init];
+    __block NSException *firstException = nil;
+    __block NSString *firstExceptionSource = nil;
+
+    BOOL (^hasFailed)(void) = ^BOOL{
+        [errorLock lock];
+        BOOL failed = firstException != nil;
+        [errorLock unlock];
+        return failed;
+    };
+
+    void (^recordException)(NSException *, NSString *) = ^(NSException *exception, NSString *source) {
+        [errorLock lock];
+        if (firstException == nil) {
+            firstException = exception;
+            firstExceptionSource = source;
+        }
+        [errorLock unlock];
+    };
+
     // Multiple threads reading activeKitsRegistry
     for (NSInteger i = 0; i < 3; i++) {
         dispatch_group_async(group, concurrentQueue, ^{
-            for (NSInteger j = 0; j < iterations && !encounteredError; j++) {
+            for (NSInteger j = 0; j < iterations && !hasFailed(); j++) {
                 @try {
                     NSArray *activeKits = [kitContainer activeKitsRegistry];
                     // Access the returned array to ensure objects are valid
@@ -3451,8 +3472,7 @@
                         (void)kit.code;
                     }
                 } @catch (NSException *exception) {
-                    encounteredError = YES;
-                    XCTFail(@"Exception in activeKitsRegistry: %@", exception);
+                    recordException(exception, @"activeKitsRegistry");
                 }
             }
         });
@@ -3460,19 +3480,25 @@
     
     // Thread modifying kits configuration
     dispatch_group_async(group, concurrentQueue, ^{
-        for (NSInteger j = 0; j < iterations && !encounteredError; j++) {
+        for (NSInteger j = 0; j < iterations && !hasFailed(); j++) {
             @try {
                 [kitContainer configureKits:nil];
                 [kitContainer configureKits:configurations];
             } @catch (NSException *exception) {
-                encounteredError = YES;
-                XCTFail(@"Exception in configureKits: %@", exception);
+                recordException(exception, @"configureKits");
             }
         }
     });
     
     dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-        XCTAssertFalse(encounteredError, @"Thread safety test should complete without errors");
+        [errorLock lock];
+        NSException *exception = firstException;
+        NSString *source = firstExceptionSource;
+        [errorLock unlock];
+
+        if (exception != nil) {
+            XCTFail(@"Exception in %@: %@", source, exception);
+        }
         [expectation fulfill];
     });
     

--- a/UnitTests/ObjCTests/MParticleTests.m
+++ b/UnitTests/ObjCTests/MParticleTests.m
@@ -24,6 +24,7 @@
 @property (nonatomic, strong) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong) MPBackendController_PRIVATE *backendController;
 @property (nonatomic, strong) MParticleOptions *options;
+@property (nonatomic) BOOL initialized;
 - (BOOL)isValidBridgeName:(NSString *)bridgeName;
 - (void)handleWebviewCommand:(NSString *)command dictionary:(NSDictionary *)dictionary;
 + (void)_setWrapperSdk_internal:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion;
@@ -1194,6 +1195,20 @@
 #define WORKSPACE_SWITCHING_TIMEOUT 60
 #define WORKSPACE_SWITCHING_DELAY (int64_t)(10 * NSEC_PER_SEC)
 
+// Spins the main run loop until condition() is true, so main-queue work the SDK
+// schedules during start-up still runs. Returns NO if timeout elapses first.
+static BOOL MPWaitForCondition(NSTimeInterval timeout, BOOL (^condition)(void)) {
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+    while (!condition()) {
+        if ([[NSDate date] compare:deadline] == NSOrderedDescending) {
+            return NO;
+        }
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
+    return YES;
+}
+
 - (void)testSwitchWorkspaceOptions {
     XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
 
@@ -1328,30 +1343,33 @@
 
 // Kits with configurations that implement `stop` shouldn't be removed from the registry because they can be cleanly restarted
 - (void)testSwitchWorkspaceKitsWithStop {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-    
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
     MPKitRegister *registerWithStop = [[MPKitRegister alloc] initWithName:@"TestKitWithStop" className:@"MPKitTestClassNoStartImmediatelyWithStop"];
     [MParticle registerExtension:registerWithStop];
-    
+
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-    [[MParticle sharedInstance] startWithOptions:options];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        registerWithStop.wrapperInstance = [[MPKitTestClassNoStartImmediatelyWithStop alloc] init];
-        [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@43] = [[MPKitConfiguration alloc] init];
-        
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-                
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
-       
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-            [expectation fulfill];
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    MParticle *instanceBeforeSwitch = [MParticle sharedInstance];
+    [instanceBeforeSwitch startWithOptions:options];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized;
+    }), @"SDK did not finish initializing kits");
+
+    registerWithStop.wrapperInstance = [[MPKitTestClassNoStartImmediatelyWithStop alloc] init];
+    [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@43] = [[MPKitConfiguration alloc] init];
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
+
+    [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
+
+    // switchWorkspaceWithOptions: installs a replacement shared instance; once it
+    // has, the switch is far enough along to assert the registry survived it.
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeSwitch
+            && [MParticle sharedInstance].initialized;
+    }), @"Workspace switch did not complete");
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
 }
 
 - (void)testSetWrapperSdk {


### PR DESCRIPTION
> Stacked on #867. Review that one first — this PR's base is `ci/bound-simulator-and-network-hangs`, so the diff here is only the test changes.

## Why

These are the two tests that repeat most often in the ObjC crash failures blocking CI:

- `MParticleTests.testSwitchWorkspaceKitsWithStop`
- `MPKitContainerTests.testActiveKitsRegistryThreadSafety`

They turned out to have two completely different problems, and only one of them is a test problem.

## `testSwitchWorkspaceKitsWithStop` — genuinely a bad test

It waited on two nested hard-coded 10-second `dispatch_after` blocks, so it always burned **at least 20 seconds** of wall clock and depended on fixed timing rather than on the SDK actually being ready. Under CI load, "10 seconds is surely enough" is exactly the assumption that produces flakes.

It now waits on the SDK's own readiness signals — `MParticle.initialized` after `startWithOptions:`, then the replacement shared instance after `switchWorkspaceWithOptions:` — by spinning the main run loop until the condition holds, so main-queue work the SDK schedules still runs.

**The assertions are unchanged.** Same behaviour checked, no weakening.

| | Before | After |
|---|---|---|
| `testSwitchWorkspaceKitsWithStop` | 20.2s | **0.11s** |

Verified: 3/3 runs of the test alone, and 4/4 runs of the whole `MParticleTests` class (62 tests, 0 failures).

`MParticle.initialized` is exposed to the test via the existing `@interface MParticle ()` block, alongside the privates already redeclared there. No product change.

## `testActiveKitsRegistryThreadSafety` — the test is right, the SDK is wrong

This one is **not** flaky tooling. It is correctly catching a real data race, reproduced at **2 crashes in 10 runs of that test on its own**, nothing else running.

`flushSerializedKits` ([MPKitContainer.m:217](../blob/main/mParticle-Apple-SDK/Kits/MPKitContainer.m#L217)) fast-enumerates `kitsRegistry` and mutates it through `freeKit:` on the main queue **without taking `kitsSemaphore`** — the lock every other accessor of that set uses. `activeKitsRegistry` reads it under the semaphore; `configureKits:` mutates it under the semaphore. And `configureKits:nil` reaches the unlocked flush via an early return *before* the lock is acquired ([MPKitContainer.m:2027](../blob/main/mParticle-Apple-SDK/Kits/MPKitContainer.m#L2027)) — precisely what the test calls in a loop while three threads read the registry.

So the crash is mutation-during-enumeration on shared state, and the test is doing its job.

### What this PR does and does not do

Fixed here (test-side defects, real but not the cause of the crash):
- `encounteredError` was a plain `__block BOOL` written from four concurrent blocks — an unsynchronized flag is itself a data race. Now guarded by an `NSLock`, recording only the first exception.
- `XCTFail` was called from those background queues, which is not safe with XCTest. Failures are now reported from the `dispatch_group_notify` block on the main queue.

**Not fixed here:** the race itself. This test will still flake at roughly its current rate until `MPKitContainer` locking is addressed. That is deliberate — a core-concurrency change in a public SDK does not belong in a CI-stabilization PR, and AGENTS.md asks for coordination on anything touching the kit interface.

### Notes for whoever takes the race

Groundwork already checked:
- All three `flushSerializedKits` callers ([mParticle.m:611](../blob/main/mParticle-Apple-SDK/mParticle.m#L611), [mParticle.m:722](../blob/main/mParticle-Apple-SDK/mParticle.m#L722), [MPKitContainer.m:2029](../blob/main/mParticle-Apple-SDK/Kits/MPKitContainer.m#L2029)) are outside locked regions, so taking `kitsSemaphore` there would not deadlock.
- There is no `dispatch_sync` to the main queue inside any locked region.
- `freeKit:` must stay lock-free: `configureKits:` already calls it while holding the semaphore, and `dispatch_semaphore` is not recursive.
- The naive fix (wrap the main-queue flush in the semaphore) would let a long background critical section stall the main thread — the locked regions at 1149–1624 and 1656–1939 are large. Snapshotting the registry under the lock and iterating the snapshot off-lock avoids that, but `freeKit:` would still read `kitsRegistry` unlocked, so it is only a partial fix.

## Scope left alone

`testSwitchWorkspaceOptions` and the other tests in that family still use the 10-second `WORKSPACE_SWITCHING_DELAY` (three nested delays, ~30s). The macro is retained for them. The same treatment would cut roughly another 60s off the ObjC suite, but they were not among the tests flagged as flaky, so they are out of scope here.

No `CHANGELOG.md` entry: test-only, no consumer-facing SDK change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
