### PR TITLE
refactor: move request signing to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Network/MPRequestSigner.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Network/MPRequestSigner.swift
@@ -1,0 +1,58 @@
+import CryptoKit
+import Foundation
+
+@objc public final class MPRequestSigner: NSObject {
+    private static let maxQueryLength = 8192
+
+    @objc(hmacSHA256HexForMessage:key:)
+    public static func hmacSHA256Hex(message: String?, key: String?) -> String? {
+        guard let message, let key else {
+            return nil
+        }
+
+        let code = HMAC<SHA256>.authenticationCode(
+            for: bytesUpToFirstNUL(of: message),
+            using: SymmetricKey(data: bytesUpToFirstNUL(of: key))
+        )
+        return code.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @objc(signatureMessageWithHTTPMethod:date:relativePath:query:)
+    public static func signatureMessage(
+        httpMethod: String,
+        date: String,
+        relativePath: String,
+        query: String?
+    ) -> String {
+        guard let query else {
+            return "\(httpMethod)\n\(date)\n\(relativePath)"
+        }
+        return "\(httpMethod)\n\(date)\n\(relativePath)?\(query)"
+    }
+
+    @objc(signatureMessageWithHTTPMethod:date:relativePath:body:)
+    public static func signatureMessage(
+        httpMethod: String,
+        date: String,
+        relativePath: String,
+        body: String
+    ) -> String {
+        "\(httpMethod)\n\(date)\n\(relativePath)\(body)"
+    }
+
+    @objc(exceedsMaxQueryLength:)
+    public static func exceedsMaxQueryLength(_ query: String?) -> Bool {
+        guard let query else {
+            return false
+        }
+        return (query as NSString).length > maxQueryLength
+    }
+
+    private static func bytesUpToFirstNUL(of string: String) -> Data {
+        let utf8 = Array(string.utf8)
+        guard let nul = utf8.firstIndex(of: 0) else {
+            return Data(utf8)
+        }
+        return Data(utf8[..<nul])
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Network/MPRequestSignerTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Network/MPRequestSignerTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPRequestSignerTests: XCTestCase {
+    func testHmacMatchesObjCReferenceVector() {
+        let hex = MPRequestSigner.hmacSHA256Hex(
+            message: "The Quick Brown Fox Jumps Over The Lazy Dog.",
+            key: "unit-test-key"
+        )
+
+        XCTAssertEqual(hex, "89d8de8ab8d91aaf359ba160921cc15b0621216964e3766860e0788c7f8f62e2")
+    }
+
+    func testHmacIsLowercaseHexOf32Bytes() {
+        let hex = MPRequestSigner.hmacSHA256Hex(message: "message", key: "key")
+
+        XCTAssertEqual(hex?.count, 64)
+        XCTAssertEqual(hex, hex?.lowercased())
+    }
+
+    func testHmacReturnsNilForNilMessage() {
+        XCTAssertNil(MPRequestSigner.hmacSHA256Hex(message: nil, key: "key"))
+    }
+
+    func testHmacReturnsNilForNilKey() {
+        XCTAssertNil(MPRequestSigner.hmacSHA256Hex(message: "message", key: nil))
+    }
+
+    func testHmacEncodesEmptyMessage() {
+        XCTAssertNotNil(MPRequestSigner.hmacSHA256Hex(message: "", key: "key"))
+    }
+
+    func testHmacTruncatesMessageAtEmbeddedNUL() {
+        let truncated = MPRequestSigner.hmacSHA256Hex(message: "abc\0def", key: "key")
+        let reference = MPRequestSigner.hmacSHA256Hex(message: "abc", key: "key")
+
+        XCTAssertEqual(truncated, reference)
+    }
+
+    func testHmacTruncatesKeyAtEmbeddedNUL() {
+        let truncated = MPRequestSigner.hmacSHA256Hex(message: "message", key: "abc\0def")
+        let reference = MPRequestSigner.hmacSHA256Hex(message: "message", key: "abc")
+
+        XCTAssertEqual(truncated, reference)
+    }
+
+    func testSignatureMessageWithQueryJoinsWithQuestionMark() {
+        let signature = MPRequestSigner.signatureMessage(
+            httpMethod: "GET",
+            date: "Thu, 27 Aug 2026 12:00:00 GMT",
+            relativePath: "/v4/key/config",
+            query: "av=1.0&sv=9.0.0"
+        )
+
+        XCTAssertEqual(signature, "GET\nThu, 27 Aug 2026 12:00:00 GMT\n/v4/key/config?av=1.0&sv=9.0.0")
+    }
+
+    func testSignatureMessageOmitsQuestionMarkForNilQuery() {
+        let signature = MPRequestSigner.signatureMessage(
+            httpMethod: "GET",
+            date: "Thu, 27 Aug 2026 12:00:00 GMT",
+            relativePath: "/v4/key/config",
+            query: nil
+        )
+
+        XCTAssertEqual(signature, "GET\nThu, 27 Aug 2026 12:00:00 GMT\n/v4/key/config")
+    }
+
+    func testSignatureMessageKeepsEmptyQueryQuestionMark() {
+        let signature = MPRequestSigner.signatureMessage(
+            httpMethod: "GET",
+            date: "d",
+            relativePath: "/p",
+            query: ""
+        )
+
+        XCTAssertEqual(signature, "GET\nd\n/p?")
+    }
+
+    func testSignatureMessageWithBodyConcatenatesWithoutSeparator() {
+        let signature = MPRequestSigner.signatureMessage(
+            httpMethod: "POST",
+            date: "Thu, 27 Aug 2026 12:00:00 GMT",
+            relativePath: "/v1/identify",
+            body: "{\"mpid\":1}"
+        )
+
+        XCTAssertEqual(signature, "POST\nThu, 27 Aug 2026 12:00:00 GMT\n/v1/identify{\"mpid\":1}")
+    }
+
+    func testExceedsMaxQueryLengthAtBoundary() {
+        XCTAssertFalse(MPRequestSigner.exceedsMaxQueryLength(String(repeating: "a", count: 8192)))
+        XCTAssertTrue(MPRequestSigner.exceedsMaxQueryLength(String(repeating: "a", count: 8193)))
+    }
+
+    func testExceedsMaxQueryLengthIsFalseForNilAndEmpty() {
+        XCTAssertFalse(MPRequestSigner.exceedsMaxQueryLength(nil))
+        XCTAssertFalse(MPRequestSigner.exceedsMaxQueryLength(""))
+    }
+
+    func testExceedsMaxQueryLengthCountsUTF16Units() {
+        XCTAssertTrue(MPRequestSigner.exceedsMaxQueryLength(String(repeating: "😀", count: 4097)))
+        XCTAssertFalse(MPRequestSigner.exceedsMaxQueryLength(String(repeating: "😀", count: 4096)))
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -584,6 +584,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Network/MPRequestSignerTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,
 				Test/Notifications/MPPushTrackingLogicTests.swift,
 				Test/Persistence/MPPersistenceSchemaTests.swift,
@@ -632,6 +633,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Network/MPRequestSignerTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,
 				Test/Notifications/MPPushTrackingLogicTests.swift,
 				Test/Persistence/MPPersistenceSchemaTests.swift,

--- a/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
+++ b/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
@@ -1,5 +1,4 @@
 #import "MPURLRequestBuilder.h"
-#import <CommonCrypto/CommonHMAC.h>
 #import "MPIConstants.h"
 #import <UIKit/UIKit.h>
 #import "MPKitContainer.h"
@@ -28,9 +27,6 @@
 
 @end
 
-static const NSUInteger kMPURLRequestBuilderMaxQueryLength = 8192;
-
-
 @implementation MPURLRequestBuilder
 
 - (instancetype)initWithURL:(MPURL *)url {
@@ -50,23 +46,7 @@ static const NSUInteger kMPURLRequestBuilderMaxQueryLength = 8192;
 
 #pragma mark Private methods
 - (NSString *)hmacSha256Encode:(NSString *const)message key:(NSString *const)key {
-    if (!message || !key) {
-        return nil;
-    }
-    
-    const char *cKey = [key cStringUsingEncoding:NSUTF8StringEncoding];
-    const char *cMessage = [message cStringUsingEncoding:NSUTF8StringEncoding];
-    unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
-    
-    CCHmac(kCCHmacAlgSHA256, cKey, strlen(cKey), cMessage, strlen(cMessage), cHMAC);
-    
-    NSMutableString *encodedMessage = [NSMutableString stringWithCapacity:(CC_SHA256_DIGEST_LENGTH << 1)];
-    
-    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; ++i) {
-        [encodedMessage appendFormat:@"%02x", cHMAC[i]];
-    }
-    
-    return (NSString *)encodedMessage;
+    return [MPRequestSigner hmacSHA256HexForMessage:message key:key];
 }
 
 - (NSString *)userAgent {
@@ -163,30 +143,15 @@ static const NSUInteger kMPURLRequestBuilderMaxQueryLength = 8192;
             return nil;
         }
         NSString *audienceQuery = [urlRequest.URL query];
-        if (audienceQuery.length > kMPURLRequestBuilderMaxQueryLength) {
+        if ([MPRequestSigner exceedsMaxQueryLength:audienceQuery]) {
             MPILogError(@"Cannot build URL request — audience query exceeds max supported length");
             return nil;
         }
-        NSString *audienceSignature;
-        if (audienceQuery) {
-            NSMutableString *signatureBuilder = [NSMutableString stringWithCapacity:_httpMethod.length + date.length + audienceRelativePath.length + audienceQuery.length + 4];
-            [signatureBuilder appendString:_httpMethod ?: @""];
-            [signatureBuilder appendString:@"\n"];
-            [signatureBuilder appendString:date ?: @""];
-            [signatureBuilder appendString:@"\n"];
-            [signatureBuilder appendString:audienceRelativePath];
-            [signatureBuilder appendString:@"?"];
-            [signatureBuilder appendString:audienceQuery];
-            audienceSignature = [signatureBuilder copy];
-        } else {
-            NSMutableString *signatureBuilder = [NSMutableString stringWithCapacity:_httpMethod.length + date.length + audienceRelativePath.length + 3];
-            [signatureBuilder appendString:_httpMethod ?: @""];
-            [signatureBuilder appendString:@"\n"];
-            [signatureBuilder appendString:date ?: @""];
-            [signatureBuilder appendString:@"\n"];
-            [signatureBuilder appendString:audienceRelativePath];
-            audienceSignature = [signatureBuilder copy];
-        }
+        NSString *audienceSignature = [MPRequestSigner
+            signatureMessageWithHTTPMethod:_httpMethod ?: @""
+                                      date:date ?: @""
+                              relativePath:audienceRelativePath
+                                     query:audienceQuery];
         MPILogVerbose(@"Audience Signature:\n%@", audienceSignature);
         NSString *hmacSha256Encode = [self hmacSha256Encode:audienceSignature key:secret];
         if (hmacSha256Encode) {
@@ -227,7 +192,11 @@ static const NSUInteger kMPURLRequestBuilderMaxQueryLength = 8192;
                 MPILogError(@"Cannot build URL request — failed to encode post data as UTF-8");
                 return nil;
             }
-            signatureMessage = [NSString stringWithFormat:@"%@\n%@\n%@%@", _httpMethod, date, relativePath, postDataString];
+            signatureMessage = [MPRequestSigner
+                signatureMessageWithHTTPMethod:_httpMethod
+                                          date:date
+                                  relativePath:relativePath
+                                          body:postDataString];
         } else if (containsMessage) { // /events
             contentType = @"application/json";
             
@@ -244,7 +213,11 @@ static const NSUInteger kMPURLRequestBuilderMaxQueryLength = 8192;
                 [urlRequest setValue:kMPMessageTypeNetworkPerformance forHTTPHeaderField:kMPMessageTypeNetworkPerformance];
             }
             
-            signatureMessage = [NSString stringWithFormat:@"%@\n%@\n%@%@", _httpMethod, date, relativePath, _message];
+            signatureMessage = [MPRequestSigner
+                signatureMessageWithHTTPMethod:_httpMethod
+                                          date:date
+                                  relativePath:relativePath
+                                          body:_message];
         } else { // /config
             contentType = @"application/x-www-form-urlencoded";
             
@@ -263,29 +236,15 @@ static const NSUInteger kMPURLRequestBuilderMaxQueryLength = 8192;
             }
             
             NSString *query = [_url.defaultURL query];
-            if (query.length > kMPURLRequestBuilderMaxQueryLength) {
+            if ([MPRequestSigner exceedsMaxQueryLength:query]) {
                 MPILogError(@"Cannot build URL request — config query exceeds max supported length");
                 return nil;
             }
-            if (query) {
-                NSMutableString *signatureBuilder = [NSMutableString stringWithCapacity:_httpMethod.length + date.length + relativePath.length + query.length + 4];
-                [signatureBuilder appendString:_httpMethod ?: @""];
-                [signatureBuilder appendString:@"\n"];
-                [signatureBuilder appendString:date ?: @""];
-                [signatureBuilder appendString:@"\n"];
-                [signatureBuilder appendString:relativePath];
-                [signatureBuilder appendString:@"?"];
-                [signatureBuilder appendString:query];
-                signatureMessage = [signatureBuilder copy];
-            } else {
-                NSMutableString *signatureBuilder = [NSMutableString stringWithCapacity:_httpMethod.length + date.length + relativePath.length + 3];
-                [signatureBuilder appendString:_httpMethod ?: @""];
-                [signatureBuilder appendString:@"\n"];
-                [signatureBuilder appendString:date ?: @""];
-                [signatureBuilder appendString:@"\n"];
-                [signatureBuilder appendString:relativePath];
-                signatureMessage = [signatureBuilder copy];
-            }
+            signatureMessage = [MPRequestSigner
+                signatureMessageWithHTTPMethod:_httpMethod ?: @""
+                                          date:date ?: @""
+                                  relativePath:relativePath
+                                         query:query];
         }
         
         NSString *hmacSha256Encode = [self hmacSha256Encode:signatureMessage key:secret];


### PR DESCRIPTION
## The stack

1. #872 — request signing
2. #873 — URL request headers
3. #874 — endpoint host resolution
4. #875 — endpoint URL characterization tests
5. #876 — endpoint path-style decisions

Review bottom-up; merge top-down. This is **#872**.

---

First of five. Stacked on #868 — **base it on #868's head after that PR is rebased onto
`workstation/swift-migration`**; it currently branches off #861 and is missing #862.

## What moves

`MPRequestSigner` owns four things extracted from `MPURLRequestBuilder`:

- the HMAC-SHA256 hex encode,
- the `METHOD\nDATE\npath[?query]` signature shape (config, audience),
- the `METHOD\nDATE\npath<body>` shape (identity, events),
- and the 8192-character query cap.

`hmacSha256Encode:key:` keeps its selector as a one-line forward.
`MPURLRequestBuilderTests.m` calls it through a test-only category and remains the
behaviour contract.

## Two ObjC quirks preserved on purpose

1. **An embedded NUL truncates.** The original ran both strings through
   `cStringUsingEncoding:` + `strlen`, so anything after a NUL was never hashed. Swift
   reproduces that by hashing only the bytes before the first NUL — `bytesUpToFirstNUL`.
2. **A nil message or key yields nil, but an empty message still hashes.**
   `testInvalidHMACSha256Encode` pins both halves.

The query cap counts UTF-16 units to match `NSString.length`, not Swift's grapheme count.

## CommonCrypto → CryptoKit

Both are system libraries, so no podspec or `Package.swift` change. Output is
byte-identical, verified against the existing ObjC reference vector plus a new
openssl-derived one in the Swift mirror test.

## Gate

| Item | Result |
|---|---|
| 1. Zero public-ABI diff | pass — `abi-guard.sh check` clean, `Include/` diff empty |
| 2. `pod lib lint` x3 podspecs | **iOS pass** ("passed validation"); tvOS not runnable locally |
| 3. Build iOS + tvOS | **iOS pass**, no new warnings; tvOS not runnable locally |
| 4. `trunk check` | pass — no new issues |
| 5. ObjC + Swift suites | pass — ObjC 982/982, Swift 368/368 (14 new here) |

`MPURLRequestBuilder` is not in `mParticle-Apple-SDK/Include/`, so it has no ABI baseline
entry.

**tvOS is CI-only:** this machine has the tvOS 26.2 SDK but only the 26.0 simulator
runtime, so no tvOS destination resolves and pod lint's tvOS leg fails the whole lint even
though iOS passes. Environmental, not a compile failure.

**On the test suites:** both suites flake under Xcode's default parallel testing on this
machine — `MPUserDefaultsTests` races on shared `UserDefaults`, and several slow ObjC
tests time out and force an xctest restart that prints "0 failures" while silently
skipping ~75 tests. Both reproduce on the unmodified base, so the counts above were taken
with `-parallel-testing-enabled NO`. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
