### PR TITLE
refactor: move endpoint host resolution to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Network/MPEndpointHostResolver.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Network/MPEndpointHostResolver.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@objc public final class MPEndpointHostResolver: NSObject {
+    @objc(defaultHostWithSubdomain:apiKey:)
+    public static func defaultHost(subdomain: String, apiKey: String?) -> String {
+        let podPrefix = apiKey?.components(separatedBy: "-") ?? []
+        guard podPrefix.count > 1 else {
+            return "\(subdomain).us1.mparticle.com"
+        }
+        return "\(subdomain).\(podPrefix[0]).mparticle.com"
+    }
+
+    @objc(resolvedHostWithCustomBaseURLHost:trackingHost:host:defaultHost:attAuthorized:)
+    public static func resolvedHost(
+        customBaseURLHost: String?,
+        trackingHost: String?,
+        host: String?,
+        defaultHost: String,
+        attAuthorized: Bool
+    ) -> String {
+        if let customBaseURLHost {
+            return customBaseURLHost
+        }
+        if let trackingHost, attAuthorized {
+            return trackingHost
+        }
+        return host ?? defaultHost
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Network/MPEndpointHostResolverTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Network/MPEndpointHostResolverTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPEndpointHostResolverTests: XCTestCase {
+    // MARK: - Pod routing
+
+    func testDefaultHostUsesThePodPrefixFromTheAPIKey() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "nativesdks", apiKey: "eu1-0123456789abcdef"),
+            "nativesdks.eu1.mparticle.com"
+        )
+    }
+
+    func testDefaultHostFallsBackToUS1ForAKeyWithoutAPrefix() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "identity", apiKey: "0123456789abcdef"),
+            "identity.us1.mparticle.com"
+        )
+    }
+
+    func testDefaultHostFallsBackToUS1ForNilAndEmptyKeys() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "nativesdks", apiKey: nil),
+            "nativesdks.us1.mparticle.com"
+        )
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "nativesdks", apiKey: ""),
+            "nativesdks.us1.mparticle.com"
+        )
+    }
+
+    func testDefaultHostTakesOnlyTheFirstSegmentOfAMultiHyphenKey() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "tracking-identity", apiKey: "us2-abc-def"),
+            "tracking-identity.us2.mparticle.com"
+        )
+    }
+
+    func testDefaultHostKeepsAnEmptyLeadingSegment() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "nativesdks", apiKey: "-abc"),
+            "nativesdks..mparticle.com"
+        )
+    }
+
+    func testDefaultHostAppliesTheTrackingSubdomainVerbatim() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.defaultHost(subdomain: "tracking-nativesdks", apiKey: "us1-key"),
+            "tracking-nativesdks.us1.mparticle.com"
+        )
+    }
+
+    // MARK: - Precedence ladder
+
+    func testCustomBaseURLHostWinsOverEveryOtherOption() {
+        XCTAssertEqual(
+            MPEndpointHostResolver.resolvedHost(
+                customBaseURLHost: "cdn.example.com",
+                trackingHost: "tracking.example.com",
+                host: "host.example.com",
+                defaultHost: "default.mparticle.com",
+                attAuthorized: true
+            ),
+            "cdn.example.com"
+        )
+    }
+
+    func testTrackingHostIsUsedOnlyWhenATTIsAuthorized() {
+        XCTAssertEqual(resolved(trackingHost: "tracking.example.com", attAuthorized: true), "tracking.example.com")
+        XCTAssertEqual(resolved(trackingHost: "tracking.example.com", attAuthorized: false), "default.mparticle.com")
+    }
+
+    func testHostIsUsedWhenThereIsNoApplicableTrackingHost() {
+        XCTAssertEqual(resolved(host: "host.example.com", attAuthorized: false), "host.example.com")
+        XCTAssertEqual(
+            resolved(trackingHost: "tracking.example.com", host: "host.example.com", attAuthorized: false),
+            "host.example.com"
+        )
+    }
+
+    func testDefaultHostIsTheLastResort() {
+        XCTAssertEqual(resolved(), "default.mparticle.com")
+    }
+
+    func testAnEmptyHostOverridesTheDefaultRatherThanFallingThrough() {
+        XCTAssertEqual(resolved(host: ""), "")
+        XCTAssertEqual(resolved(trackingHost: "", attAuthorized: true), "")
+        XCTAssertEqual(resolved(customBaseURLHost: ""), "")
+    }
+
+    // MARK: - Helpers
+
+    private func resolved(
+        customBaseURLHost: String? = nil,
+        trackingHost: String? = nil,
+        host: String? = nil,
+        attAuthorized: Bool = false
+    ) -> String {
+        MPEndpointHostResolver.resolvedHost(
+            customBaseURLHost: customBaseURLHost,
+            trackingHost: trackingHost,
+            host: host,
+            defaultHost: "default.mparticle.com",
+            attAuthorized: attAuthorized
+        )
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -584,6 +584,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Network/MPEndpointHostResolverTests.swift,
 				Test/Network/MPRequestSignerTests.swift,
 				Test/Network/MPURLRequestPlanTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,
@@ -634,6 +635,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Network/MPEndpointHostResolverTests.swift,
 				Test/Network/MPRequestSignerTests.swift,
 				Test/Network/MPURLRequestPlanTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -116,30 +116,22 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 #pragma mark Private accessors
 
 - (NSString *)defaultHostWithSubdomain:(NSString *)subdomain apiKey:(NSString *)apiKey {
-    NSArray *splitKey = [apiKey componentsSeparatedByString:@"-"];
-    if (splitKey.count <= 1) {
-        // Handle case with no prefix, default to US1 (old keys)
-        return [NSString stringWithFormat:@"%@.us1.mparticle.com", subdomain];
-    }
-    return [NSString stringWithFormat:@"%@.%@.mparticle.com", subdomain, splitKey[0]];
+    return [MPEndpointHostResolver defaultHostWithSubdomain:subdomain apiKey:apiKey];
+}
+
+- (BOOL)attAuthorized {
+    MPStateMachine_PRIVATE *stateMachine = [MParticle sharedInstance].stateMachine;
+    return stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized;
 }
 
 - (NSString *)defaultEventHost {
-    MPStateMachine_PRIVATE *stateMachine = [MParticle sharedInstance].stateMachine;
-    if (stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-        return [self defaultHostWithSubdomain:kMPURLHostEventTrackingSubdomain apiKey:stateMachine.apiKey];
-    } else {
-        return [self defaultHostWithSubdomain:kMPURLHostEventSubdomain apiKey:stateMachine.apiKey];
-    }
+    NSString *subdomain = [self attAuthorized] ? kMPURLHostEventTrackingSubdomain : kMPURLHostEventSubdomain;
+    return [self defaultHostWithSubdomain:subdomain apiKey:[MParticle sharedInstance].stateMachine.apiKey];
 }
 
 - (NSString *)defaultIdentityHost {
-    MPStateMachine_PRIVATE *stateMachine = [MParticle sharedInstance].stateMachine;
-    if (stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-        return [self defaultHostWithSubdomain:kMPURLHostIdentityTrackingSubdomain apiKey:stateMachine.apiKey];
-    } else {
-        return [self defaultHostWithSubdomain:kMPURLHostIdentitySubdomain apiKey:stateMachine.apiKey];
-    }
+    NSString *subdomain = [self attAuthorized] ? kMPURLHostIdentityTrackingSubdomain : kMPURLHostIdentitySubdomain;
+    return [self defaultHostWithSubdomain:subdomain apiKey:[MParticle sharedInstance].stateMachine.apiKey];
 }
 
 - (MPURL *)configURL {
@@ -159,7 +151,11 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     if (customHost && networkOptions.configHost) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL is set; configHost is ignored.");
     }
-    NSString *configHost = customHost ?: (networkOptions.configHost ?: kMPURLHostConfig);
+    NSString *configHost = [MPEndpointHostResolver resolvedHostWithCustomBaseURLHost:customHost
+                                                                       trackingHost:nil
+                                                                               host:networkOptions.configHost
+                                                                        defaultHost:kMPURLHostConfig
+                                                                      attAuthorized:NO];
 
     NSString *dataPlanConfigString;
     NSString *dataPlanId = MParticle.sharedInstance.dataPlanId;
@@ -203,12 +199,11 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 - (MPURL *)eventURLForUpload:(MPUpload *)mpUpload {
     MPUploadSettings *uploadSettings = (MPUploadSettings *)mpUpload.uploadSettings;
-    NSString *eventHost;
-    if (uploadSettings.eventsTrackingHost && [MParticle sharedInstance].stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-        eventHost = uploadSettings.eventsTrackingHost;
-    } else {
-        eventHost = uploadSettings.eventsHost ?: self.defaultEventHost;
-    }
+    NSString *eventHost = [MPEndpointHostResolver resolvedHostWithCustomBaseURLHost:nil
+                                                                      trackingHost:uploadSettings.eventsTrackingHost
+                                                                              host:uploadSettings.eventsHost
+                                                                       defaultHost:self.defaultEventHost
+                                                                     attAuthorized:[self attAuthorized]];
     NSString *urlString = [NSString stringWithFormat:urlFormat, kMPURLScheme, self.defaultEventHost, kMPEventsVersion, uploadSettings.apiKey, kMPEventsURL];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
@@ -239,7 +234,11 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     if (customHost && networkOptions.eventsHost) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL is set; eventsHost is ignored.");
     }
-    NSString *eventHost = customHost ?: (networkOptions.eventsHost ?: self.defaultEventHost);
+    NSString *eventHost = [MPEndpointHostResolver resolvedHostWithCustomBaseURLHost:customHost
+                                                                      trackingHost:nil
+                                                                              host:networkOptions.eventsHost
+                                                                       defaultHost:self.defaultEventHost
+                                                                     attAuthorized:NO];
     NSString *audienceURLFormat = [audienceFormat stringByAppendingString:@"?mpid=%@"];
     NSString *urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, self.defaultEventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
@@ -299,21 +298,16 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 }
 
 - (MPURL *)identityURL:(NSString *)pathComponent {
-    MParticle *mParticle = [MParticle sharedInstance];
-    MPStateMachine_PRIVATE *stateMachine = mParticle.stateMachine;
-    MPNetworkOptions *identityNetworkOptions = mParticle.networkOptions;
+    MPNetworkOptions *identityNetworkOptions = [MParticle sharedInstance].networkOptions;
     NSString *identityCustomHost = identityNetworkOptions.customBaseURL.host;
-    NSString *identityHost;
-    if (identityCustomHost) {
-        if (identityNetworkOptions.identityHost || identityNetworkOptions.identityTrackingHost) {
-            MPILogWarning(@"MPNetworkOptions: customBaseURL is set; identityHost/identityTrackingHost are ignored.");
-        }
-        identityHost = identityCustomHost;
-    } else if (identityNetworkOptions.identityTrackingHost && stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-        identityHost = identityNetworkOptions.identityTrackingHost;
-    } else {
-        identityHost = identityNetworkOptions.identityHost ?: self.defaultIdentityHost;
+    if (identityCustomHost && (identityNetworkOptions.identityHost || identityNetworkOptions.identityTrackingHost)) {
+        MPILogWarning(@"MPNetworkOptions: customBaseURL is set; identityHost/identityTrackingHost are ignored.");
     }
+    NSString *identityHost = [MPEndpointHostResolver resolvedHostWithCustomBaseURLHost:identityCustomHost
+                                                                         trackingHost:identityNetworkOptions.identityTrackingHost
+                                                                                 host:identityNetworkOptions.identityHost
+                                                                          defaultHost:self.defaultIdentityHost
+                                                                        attAuthorized:[self attAuthorized]];
     NSString *urlString = [NSString stringWithFormat:identityURLFormat, kMPURLScheme, self.defaultIdentityHost, kMPIdentityVersion, pathComponent];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
@@ -341,21 +335,16 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 - (MPURL *)modifyURL {
     NSString *pathComponent = @"modify";
-    MParticle *mParticle = [MParticle sharedInstance];
-    MPStateMachine_PRIVATE *stateMachine = mParticle.stateMachine;
-    MPNetworkOptions *modifyNetworkOptions = mParticle.networkOptions;
+    MPNetworkOptions *modifyNetworkOptions = [MParticle sharedInstance].networkOptions;
     NSString *modifyCustomHost = modifyNetworkOptions.customBaseURL.host;
-    NSString *identityHost;
-    if (modifyCustomHost) {
-        if (modifyNetworkOptions.identityHost || modifyNetworkOptions.identityTrackingHost) {
-            MPILogWarning(@"MPNetworkOptions: customBaseURL is set; identityHost/identityTrackingHost are ignored.");
-        }
-        identityHost = modifyCustomHost;
-    } else if (modifyNetworkOptions.identityTrackingHost && stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-        identityHost = modifyNetworkOptions.identityTrackingHost;
-    } else {
-        identityHost = modifyNetworkOptions.identityHost ?: self.defaultIdentityHost;
+    if (modifyCustomHost && (modifyNetworkOptions.identityHost || modifyNetworkOptions.identityTrackingHost)) {
+        MPILogWarning(@"MPNetworkOptions: customBaseURL is set; identityHost/identityTrackingHost are ignored.");
     }
+    NSString *identityHost = [MPEndpointHostResolver resolvedHostWithCustomBaseURLHost:modifyCustomHost
+                                                                         trackingHost:modifyNetworkOptions.identityTrackingHost
+                                                                                 host:modifyNetworkOptions.identityHost
+                                                                          defaultHost:self.defaultIdentityHost
+                                                                        attAuthorized:[self attAuthorized]];
     NSString *urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, self.defaultIdentityHost, kMPIdentityVersion, [MPPersistenceController_PRIVATE mpId],  pathComponent];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
@@ -385,12 +374,11 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     MPUploadSettings *uploadSettings = (MPUploadSettings *)mpUpload.uploadSettings;
     NSString *pathComponent = @"alias";
 
-    NSString *eventHost;
-    if (uploadSettings.aliasTrackingHost && [MParticle sharedInstance].stateMachine.attAuthorizationStatus.integerValue == MPATTAuthorizationStatusAuthorized) {
-        eventHost = uploadSettings.aliasTrackingHost;
-    } else {
-        eventHost = uploadSettings.aliasHost ?: self.defaultEventHost;
-    }
+    NSString *eventHost = [MPEndpointHostResolver resolvedHostWithCustomBaseURLHost:nil
+                                                                      trackingHost:uploadSettings.aliasTrackingHost
+                                                                              host:uploadSettings.aliasHost
+                                                                       defaultHost:self.defaultEventHost
+                                                                     attAuthorized:[self attAuthorized]];
     NSString *urlString = [NSString stringWithFormat:aliasURLFormat, kMPURLScheme, self.defaultEventHost, kMPIdentityVersion, kMPIdentityKey, uploadSettings.apiKey, pathComponent];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 


### PR DESCRIPTION
## The stack

1. #872 — request signing
2. #873 — URL request headers
3. #874 — endpoint host resolution
4. #875 — endpoint URL characterization tests
5. #876 — endpoint path-style decisions

Review bottom-up; merge top-down. This is **#874**.

---

Third of five, stacked on the previous.

## What moves

`MPEndpointHostResolver` owns two things:

- **`defaultHost(subdomain:apiKey:)`** parses the pod prefix out of the API key. A key with
  no hyphen, an empty key and a nil key all route to `us1`, matching
  `componentsSeparatedByString:` on nil returning nil and the original `count <= 1` test.
- **`resolvedHost(...)`** is the one precedence ladder behind all five endpoint families:
  `customBaseURL` host, then the tracking host when ATT is authorized, then the configured
  host, then the default. Config and audience pass a nil tracking host, which is what the
  ObjC did by having no tracking branch at all.

The `.m` keeps every read of `MPStateMachine`, `MPNetworkOptions` and `MPUploadSettings`,
and every `MPILogWarning`, at the same call sites with the same text. A new private
`-attAuthorized` collapses the four copies of the ATT comparison; it is not declared in any
header.

## Two behaviours worth naming, both preserved

- **An empty-string host overrides the default rather than falling through**, because
  ObjC's `?:` treats `@""` as a live object. Covered by a test so a future Swift rewrite
  cannot quietly "fix" it.
- **The audience endpoint ignores `eventsTrackingHost` entirely**, unlike events — it only
  picks up the tracking subdomain indirectly through `defaultEventHost`. Reproduced, not
  corrected.

`self.defaultEventHost` / `defaultIdentityHost` are now evaluated eagerly as the
`defaultHost:` argument instead of behind `?:`. Both are pure functions of the ATT status
and API key, and both were already called unconditionally on the following line to build
`defaultURL`, so nothing observable changes.

The alias endpoint's `eventsOnly` fallback stays a plain `?:` — a two-way default with no
tracking or custom host, where the resolver would only add noise.

## Gate

| Item | Result |
|---|---|
| 1. Zero public-ABI diff | pass — `abi-guard.sh check` clean, `Include/` diff empty |
| 2. `pod lib lint` x3 podspecs | **iOS pass**; tvOS not runnable locally |
| 3. Build iOS + tvOS | **iOS pass**, no new warnings; tvOS not runnable locally |
| 4. `trunk check` | pass — no new issues |
| 5. ObjC + Swift suites | pass — ObjC 982/982, Swift 405/405 (13 new here) |

The first build of this slice left two `unused variable 'stateMachine'` warnings behind in
`identityURL:` and `modifyURL`; both locals are gone and the build is warning-clean.

tvOS and test-flakiness caveats as in the first PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
