### PR TITLE
refactor: move endpoint path-style decisions to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Network/MPDataPlanQuery.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Network/MPDataPlanQuery.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+@objc public final class MPDataPlanQuery: NSObject {
+    @objc public let query: String?
+    @objc public let rejectedVersion: NSNumber?
+
+    private static let minimumVersion = 1
+    private static let maximumVersion = 1000
+
+    private init(query: String?, rejectedVersion: NSNumber?) {
+        self.query = query
+        self.rejectedVersion = rejectedVersion
+        super.init()
+    }
+
+    @objc(queryWithPlanId:planVersion:)
+    public static func query(planId: String?, planVersion: NSNumber?) -> MPDataPlanQuery {
+        guard let planId else {
+            return MPDataPlanQuery(query: nil, rejectedVersion: nil)
+        }
+
+        guard let planVersion else {
+            return MPDataPlanQuery(query: "&plan_id=\(planId)", rejectedVersion: nil)
+        }
+
+        let version = planVersion.int32Value
+        guard version >= minimumVersion, version <= maximumVersion else {
+            return MPDataPlanQuery(query: "&plan_id=\(planId)", rejectedVersion: planVersion)
+        }
+
+        return MPDataPlanQuery(query: "&plan_id=\(planId)&plan_version=\(planVersion)", rejectedVersion: nil)
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Network/MPEndpointPathStyle.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Network/MPEndpointPathStyle.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@objc public final class MPEndpointPathStyle: NSObject {
+    @objc public let usesOverrideFormat: Bool
+    @objc public let versionSegment: String
+    @objc public let warnsSubdirectoryOverrideIgnored: Bool
+
+    private init(usesOverrideFormat: Bool, versionSegment: String, warnsSubdirectoryOverrideIgnored: Bool) {
+        self.usesOverrideFormat = usesOverrideFormat
+        self.versionSegment = versionSegment
+        self.warnsSubdirectoryOverrideIgnored = warnsSubdirectoryOverrideIgnored
+        super.init()
+    }
+
+    @objc(styleWithDefaultVersion:cdnVersion:usesCustomHost:overridesSubdirectory:)
+    public static func style(
+        defaultVersion: String,
+        cdnVersion: String,
+        usesCustomHost: Bool,
+        overridesSubdirectory: Bool
+    ) -> MPEndpointPathStyle {
+        MPEndpointPathStyle(
+            usesOverrideFormat: !usesCustomHost && overridesSubdirectory,
+            versionSegment: usesCustomHost ? cdnVersion : defaultVersion,
+            warnsSubdirectoryOverrideIgnored: usesCustomHost && overridesSubdirectory
+        )
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Network/MPDataPlanQueryTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Network/MPDataPlanQueryTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPDataPlanQueryTests: XCTestCase {
+    func testNoQueryWithoutAPlanId() {
+        let result = MPDataPlanQuery.query(planId: nil, planVersion: NSNumber(value: 3))
+
+        XCTAssertNil(result.query)
+        XCTAssertNil(result.rejectedVersion)
+    }
+
+    func testPlanIdAloneWhenNoVersionIsGiven() {
+        let result = MPDataPlanQuery.query(planId: "my_plan", planVersion: nil)
+
+        XCTAssertEqual(result.query, "&plan_id=my_plan")
+        XCTAssertNil(result.rejectedVersion)
+    }
+
+    func testPlanIdAndVersion() {
+        let result = MPDataPlanQuery.query(planId: "my_plan", planVersion: NSNumber(value: 7))
+
+        XCTAssertEqual(result.query, "&plan_id=my_plan&plan_version=7")
+        XCTAssertNil(result.rejectedVersion)
+    }
+
+    func testVersionBoundsAreInclusive() {
+        XCTAssertEqual(
+            MPDataPlanQuery.query(planId: "p", planVersion: NSNumber(value: 1)).query,
+            "&plan_id=p&plan_version=1"
+        )
+        XCTAssertEqual(
+            MPDataPlanQuery.query(planId: "p", planVersion: NSNumber(value: 1000)).query,
+            "&plan_id=p&plan_version=1000"
+        )
+    }
+
+    func testOutOfRangeVersionIsDroppedAndReported() {
+        for version in [0, -1, 1001, 99999] {
+            let result = MPDataPlanQuery.query(planId: "p", planVersion: NSNumber(value: version))
+
+            XCTAssertEqual(result.query, "&plan_id=p", "version \(version)")
+            XCTAssertEqual(result.rejectedVersion?.intValue, version, "version \(version)")
+        }
+    }
+
+    func testVersionIsRangeCheckedAsAnInt32() {
+        let result = MPDataPlanQuery.query(planId: "p", planVersion: NSNumber(value: 7.9))
+
+        XCTAssertEqual(result.query, "&plan_id=p&plan_version=7.9")
+        XCTAssertNil(result.rejectedVersion)
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Network/MPEndpointPathStyleTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Network/MPEndpointPathStyleTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPEndpointPathStyleTests: XCTestCase {
+    func testPlainRoutingUsesTheDefaultVersionSegment() {
+        let style = style(usesCustomHost: false, overridesSubdirectory: false)
+
+        XCTAssertFalse(style.usesOverrideFormat)
+        XCTAssertEqual(style.versionSegment, "v2")
+        XCTAssertFalse(style.warnsSubdirectoryOverrideIgnored)
+    }
+
+    func testCustomHostUsesTheCDNVersionSegment() {
+        let style = style(usesCustomHost: true, overridesSubdirectory: false)
+
+        XCTAssertFalse(style.usesOverrideFormat)
+        XCTAssertEqual(style.versionSegment, "nativeevents/v2")
+        XCTAssertFalse(style.warnsSubdirectoryOverrideIgnored)
+    }
+
+    func testSubdirectoryOverrideDropsTheVersionSegmentEntirely() {
+        let style = style(usesCustomHost: false, overridesSubdirectory: true)
+
+        XCTAssertTrue(style.usesOverrideFormat)
+        XCTAssertFalse(style.warnsSubdirectoryOverrideIgnored)
+    }
+
+    func testCustomHostBeatsTheSubdirectoryOverrideAndWarns() {
+        let style = style(usesCustomHost: true, overridesSubdirectory: true)
+
+        XCTAssertFalse(style.usesOverrideFormat)
+        XCTAssertEqual(style.versionSegment, "nativeevents/v2")
+        XCTAssertTrue(style.warnsSubdirectoryOverrideIgnored)
+    }
+
+    func testWarningFiresOnlyWhenBothAreSet() {
+        XCTAssertFalse(style(usesCustomHost: false, overridesSubdirectory: false).warnsSubdirectoryOverrideIgnored)
+        XCTAssertFalse(style(usesCustomHost: true, overridesSubdirectory: false).warnsSubdirectoryOverrideIgnored)
+        XCTAssertFalse(style(usesCustomHost: false, overridesSubdirectory: true).warnsSubdirectoryOverrideIgnored)
+        XCTAssertTrue(style(usesCustomHost: true, overridesSubdirectory: true).warnsSubdirectoryOverrideIgnored)
+    }
+
+    private func style(usesCustomHost: Bool, overridesSubdirectory: Bool) -> MPEndpointPathStyle {
+        MPEndpointPathStyle.style(
+            defaultVersion: "v2",
+            cdnVersion: "nativeevents/v2",
+            usesCustomHost: usesCustomHost,
+            overridesSubdirectory: overridesSubdirectory
+        )
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -584,7 +584,9 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
+				Test/Network/MPEndpointPathStyleTests.swift,
 				Test/Network/MPRequestSignerTests.swift,
 				Test/Network/MPURLRequestPlanTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,
@@ -635,7 +637,9 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
+				Test/Network/MPEndpointPathStyleTests.swift,
 				Test/Network/MPRequestSignerTests.swift,
 				Test/Network/MPURLRequestPlanTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -157,33 +157,28 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
                                                                         defaultHost:kMPURLHostConfig
                                                                       attAuthorized:NO];
 
-    NSString *dataPlanConfigString;
-    NSString *dataPlanId = MParticle.sharedInstance.dataPlanId;
-    if (dataPlanId != nil) {
-        NSNumber *dataPlanVersion = MParticle.sharedInstance.dataPlanVersion;
-        if (dataPlanVersion != nil && ([dataPlanVersion intValue] > 1000 || [dataPlanVersion intValue] < 1)) {
-            MPILogWarning(@"Data plan version of %i is out of range and will not be used to fetch remote data plan. Version must be between 1 and 1000.", [dataPlanVersion intValue]);
-            dataPlanVersion = nil;
-        }
-        if (dataPlanVersion != nil) {
-            dataPlanConfigString = [NSString stringWithFormat:@"&plan_id=%@&plan_version=%@", dataPlanId, dataPlanVersion];
-        } else {
-            dataPlanConfigString = [NSString stringWithFormat:@"&plan_id=%@", dataPlanId];
-        }
+    MPDataPlanQuery *dataPlanQuery = [MPDataPlanQuery queryWithPlanId:MParticle.sharedInstance.dataPlanId
+                                                          planVersion:MParticle.sharedInstance.dataPlanVersion];
+    if (dataPlanQuery.rejectedVersion != nil) {
+        MPILogWarning(@"Data plan version of %i is out of range and will not be used to fetch remote data plan. Version must be between 1 and 1000.", dataPlanQuery.rejectedVersion.intValue);
     }
+    NSString *dataPlanConfigString = dataPlanQuery.query;
     NSString *configURLFormat = [urlFormat stringByAppendingString:@"?av=%@&sv=%@"];
     NSString *urlString = [NSString stringWithFormat:configURLFormat, kMPURLScheme, kMPURLHostConfig, kMPConfigVersion, stateMachine.apiKey, kMPConfigURL, [application.version percentEscape], kMParticleSDKVersion];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
-    if (customHost && networkOptions.overridesConfigSubdirectory) {
+    MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPConfigVersion
+                                                                  cdnVersion:@"config/v4"
+                                                              usesCustomHost:customHost != nil
+                                                       overridesSubdirectory:networkOptions.overridesConfigSubdirectory];
+    if (style.warnsSubdirectoryOverrideIgnored) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesConfigSubdirectory is unsupported for CDN routing; overridesConfigSubdirectory will be ignored.");
     }
-    NSString *configVersion = customHost ? @"config/v4" : kMPConfigVersion;
-    urlString = [NSString stringWithFormat:configURLFormat, kMPURLScheme, configHost, configVersion, stateMachine.apiKey, kMPConfigURL, [application.version percentEscape], kMParticleSDKVersion];
-
-    if (!customHost && networkOptions.overridesConfigSubdirectory) {
-        NSString *configURLFormat = [urlFormatOverride stringByAppendingString:@"?av=%@&sv=%@"];
-        urlString = [NSString stringWithFormat:configURLFormat, kMPURLScheme, configHost, stateMachine.apiKey, kMPConfigURL, [application.version percentEscape], kMParticleSDKVersion];
+    if (style.usesOverrideFormat) {
+        NSString *overrideFormat = [urlFormatOverride stringByAppendingString:@"?av=%@&sv=%@"];
+        urlString = [NSString stringWithFormat:overrideFormat, kMPURLScheme, configHost, stateMachine.apiKey, kMPConfigURL, [application.version percentEscape], kMParticleSDKVersion];
+    } else {
+        urlString = [NSString stringWithFormat:configURLFormat, kMPURLScheme, configHost, style.versionSegment, stateMachine.apiKey, kMPConfigURL, [application.version percentEscape], kMParticleSDKVersion];
     }
     if (dataPlanConfigString) {
         urlString = [NSString stringWithFormat:@"%@%@", urlString, dataPlanConfigString];
@@ -207,15 +202,17 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     NSString *urlString = [NSString stringWithFormat:urlFormat, kMPURLScheme, self.defaultEventHost, kMPEventsVersion, uploadSettings.apiKey, kMPEventsURL];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
-    BOOL usingCustomBaseURL = [MParticle sharedInstance].networkOptions.customBaseURL != nil;
-    if (usingCustomBaseURL && uploadSettings.overridesEventsSubdirectory) {
+    MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPEventsVersion
+                                                                  cdnVersion:@"nativeevents/v2"
+                                                              usesCustomHost:[MParticle sharedInstance].networkOptions.customBaseURL != nil
+                                                       overridesSubdirectory:uploadSettings.overridesEventsSubdirectory];
+    if (style.warnsSubdirectoryOverrideIgnored) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesEventsSubdirectory is unsupported for CDN routing; overridesEventsSubdirectory will be ignored.");
     }
-    NSString *eventsVersion = usingCustomBaseURL ? @"nativeevents/v2" : kMPEventsVersion;
-    if (!usingCustomBaseURL && uploadSettings.overridesEventsSubdirectory) {
+    if (style.usesOverrideFormat) {
         urlString = [NSString stringWithFormat:urlFormatOverride, kMPURLScheme, eventHost, uploadSettings.apiKey, kMPEventsURL];
     } else {
-        urlString = [NSString stringWithFormat:urlFormat, kMPURLScheme, eventHost, eventsVersion, uploadSettings.apiKey, kMPEventsURL];
+        urlString = [NSString stringWithFormat:urlFormat, kMPURLScheme, eventHost, style.versionSegment, uploadSettings.apiKey, kMPEventsURL];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
@@ -243,16 +240,19 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     NSString *urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, self.defaultEventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
-    if (customHost && networkOptions.overridesEventsSubdirectory) {
+    MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPAudienceVersion
+                                                                  cdnVersion:@"nativeevents/v1"
+                                                              usesCustomHost:customHost != nil
+                                                       overridesSubdirectory:networkOptions.overridesEventsSubdirectory];
+    if (style.warnsSubdirectoryOverrideIgnored) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesEventsSubdirectory is unsupported for CDN routing; overridesEventsSubdirectory will be ignored.");
     }
-    NSString *audienceVersion = customHost ? @"nativeevents/v1" : kMPAudienceVersion;
-    if (!customHost && networkOptions.overridesEventsSubdirectory) {
+    if (style.usesOverrideFormat) {
         audienceURLFormat = [urlFormatOverride stringByAppendingString:@"?mpid=%@"];
         urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
     } else {
         audienceURLFormat = [urlFormat stringByAppendingString:@"?mpid=%@"];
-        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, audienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
+        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, style.versionSegment, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
@@ -311,14 +311,17 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     NSString *urlString = [NSString stringWithFormat:identityURLFormat, kMPURLScheme, self.defaultIdentityHost, kMPIdentityVersion, pathComponent];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
-    if (identityCustomHost && identityNetworkOptions.overridesIdentitySubdirectory) {
+    MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPIdentityVersion
+                                                                  cdnVersion:@"identity/v1"
+                                                              usesCustomHost:identityCustomHost != nil
+                                                       overridesSubdirectory:identityNetworkOptions.overridesIdentitySubdirectory];
+    if (style.warnsSubdirectoryOverrideIgnored) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesIdentitySubdirectory is unsupported for CDN routing; overridesIdentitySubdirectory will be ignored.");
     }
-    NSString *identityVersion = identityCustomHost ? @"identity/v1" : kMPIdentityVersion;
-    if (!identityCustomHost && identityNetworkOptions.overridesIdentitySubdirectory) {
+    if (style.usesOverrideFormat) {
         urlString = [NSString stringWithFormat:identityURLFormatOverride, kMPURLScheme, identityHost, pathComponent];
     } else {
-        urlString = [NSString stringWithFormat:identityURLFormat, kMPURLScheme, identityHost, identityVersion, pathComponent];
+        urlString = [NSString stringWithFormat:identityURLFormat, kMPURLScheme, identityHost, style.versionSegment, pathComponent];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
@@ -348,14 +351,17 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     NSString *urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, self.defaultIdentityHost, kMPIdentityVersion, [MPPersistenceController_PRIVATE mpId],  pathComponent];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
-    if (modifyCustomHost && modifyNetworkOptions.overridesIdentitySubdirectory) {
+    MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPIdentityVersion
+                                                                  cdnVersion:@"identity/v1"
+                                                              usesCustomHost:modifyCustomHost != nil
+                                                       overridesSubdirectory:modifyNetworkOptions.overridesIdentitySubdirectory];
+    if (style.warnsSubdirectoryOverrideIgnored) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesIdentitySubdirectory is unsupported for CDN routing; overridesIdentitySubdirectory will be ignored.");
     }
-    NSString *modifyVersion = modifyCustomHost ? @"identity/v1" : kMPIdentityVersion;
-    if (!modifyCustomHost && modifyNetworkOptions.overridesIdentitySubdirectory) {
+    if (style.usesOverrideFormat) {
         urlString = [NSString stringWithFormat:modifyURLFormatOverride, kMPURLScheme, identityHost, [MPPersistenceController_PRIVATE mpId], pathComponent];
     } else {
-        urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, identityHost, modifyVersion, [MPPersistenceController_PRIVATE mpId], pathComponent];
+        urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, identityHost, style.versionSegment, [MPPersistenceController_PRIVATE mpId], pathComponent];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
@@ -389,14 +395,17 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         overrides = uploadSettings.overridesEventsSubdirectory;
     }
 
-    if (usingCustomBaseURLAlias && overrides) {
+    MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPIdentityVersion
+                                                                  cdnVersion:@"nativeevents/v1"
+                                                              usesCustomHost:usingCustomBaseURLAlias
+                                                       overridesSubdirectory:overrides];
+    if (style.warnsSubdirectoryOverrideIgnored) {
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesAliasSubdirectory/overridesEventsSubdirectory is unsupported for CDN routing; subdirectory override will be ignored.");
     }
-    NSString *aliasVersion = usingCustomBaseURLAlias ? @"nativeevents/v1" : kMPIdentityVersion;
-    if (!usingCustomBaseURLAlias && overrides) {
+    if (style.usesOverrideFormat) {
         urlString = [NSString stringWithFormat:aliasURLFormatOverride, kMPURLScheme, eventHost, uploadSettings.apiKey, pathComponent];
     } else {
-        urlString = [NSString stringWithFormat:aliasURLFormat, kMPURLScheme, eventHost, aliasVersion, kMPIdentityKey, uploadSettings.apiKey, pathComponent];
+        urlString = [NSString stringWithFormat:aliasURLFormat, kMPURLScheme, eventHost, style.versionSegment, kMPIdentityKey, uploadSettings.apiKey, pathComponent];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];


### PR DESCRIPTION
## The stack

1. #872 — request signing
2. #873 — URL request headers
3. #874 — endpoint host resolution
4. #875 — endpoint URL characterization tests
5. #876 — endpoint path-style decisions

Review bottom-up; merge top-down. This is **#876**.

---

Last of five, stacked on the previous. This completes the network URL/header area for this
phase.

## What moves

- **`MPEndpointPathStyle`** answers the same three-way question all six endpoint families
  ask: does `customBaseURL` routing apply (use the CDN version segment), does a
  subdirectory override apply (drop the version segment and use the override format), and
  should we warn that a subdirectory override is being ignored under CDN routing. That
  decision was copied six times in the `.m` with only the version constants differing.
- **`MPDataPlanQuery`** owns the config query's data-plan suffix — plan id alone, plan id
  with a version, or nothing — plus the 1–1000 range check. It reports a rejected version
  back so the `.m` keeps emitting the identical warning with the identical text.

## The `stringWithFormat:` calls deliberately stay in ObjC

Those format strings contain the two audience arity defects pinned by the previous PR.
Reproducing them in Swift would mean writing deliberately-wrong string interpolation.
Leaving them untouched means **this PR cannot change a single URL byte**, while the
decisions actually worth testing move.

Verified against the previous PR's characterization tests: all six `MPNetworkOptions`
combinations produce byte-identical requested and canonical URLs across all six endpoint
families.

## Behaviours preserved, each with a test

- `customBaseURL` beats a subdirectory override rather than combining with it, and only
  that combination warns.
- An out-of-range plan version drops the version but keeps `plan_id`, rather than dropping
  the whole query.
- The range check runs on `intValue` while the query interpolates the `NSNumber`, so a plan
  version of `7.9` passes the check and is sent verbatim as `plan_version=7.9`.

## Gate

| Item | Result |
|---|---|
| 1. Zero public-ABI diff | pass — `abi-guard.sh check` clean, `Include/` diff empty |
| 2. `pod lib lint` x3 podspecs | **iOS pass**; tvOS not runnable locally |
| 3. Build iOS + tvOS | **iOS pass**, no new warnings; tvOS not runnable locally |
| 4. `trunk check` | pass — no new issues |
| 5. ObjC + Swift suites | pass — ObjC 988/988, Swift 416/416 (11 new here) |

tvOS and test-flakiness caveats as in the first PR of the stack.

## What is left in the network layer

Not in this stack, deliberately: the certificate-pinning decision in `MPConnector`, the
upload-response status classification and ATT `device_info` rewrite in
`performMessageUpload:`/`performAliasUpload:`, `maxAgeForCache:`, and the whole of
`MPNetworkPerformance` (100% Foundation, ~170 SLOC, a clean whole-file conversion).
`NSURLSession` callbacks and identity/config/event orchestration stay on
`MPNetworkCommunication_PRIVATE` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
