### PR TITLE
fix: close the kitsRegistry flush race and stabilise the ObjC test suite

### DIFF
--- a/UnitTests/ObjCTests/MPKitContainerTests.m
+++ b/UnitTests/ObjCTests/MPKitContainerTests.m
@@ -3530,28 +3530,48 @@
     dispatch_queue_t concurrentQueue = dispatch_queue_create("com.mparticle.test.brackets", DISPATCH_QUEUE_CONCURRENT);
     
     NSInteger iterations = 100;
-    __block BOOL encounteredError = NO;
-    
+    // Shared across four concurrent blocks, so it is guarded rather than a plain
+    // __block BOOL - an unsynchronized flag is itself a data race, and reporting
+    // failures off the main thread is not safe with XCTest.
+    NSLock *errorLock = [[NSLock alloc] init];
+    __block NSException *firstException = nil;
+    __block NSString *firstExceptionSource = nil;
+
+    BOOL (^hasFailed)(void) = ^BOOL{
+        [errorLock lock];
+        BOOL failed = firstException != nil;
+        [errorLock unlock];
+        return failed;
+    };
+
+    void (^recordException)(NSException *, NSString *) = ^(NSException *exception, NSString *source) {
+        [errorLock lock];
+        if (firstException == nil) {
+            firstException = exception;
+            firstExceptionSource = source;
+        }
+        [errorLock unlock];
+    };
+
     // Multiple threads reading brackets
     for (NSInteger i = 0; i < 3; i++) {
         dispatch_group_async(group, concurrentQueue, ^{
-            for (NSInteger j = 0; j < iterations && !encounteredError; j++) {
+            for (NSInteger j = 0; j < iterations && !hasFailed(); j++) {
                 @try {
                     for (NSNumber *integrationId in integrationIds) {
                         id bracket = [kitContainer bracketForKit:integrationId];
                         (void)bracket; // Use the result to prevent optimization
                     }
                 } @catch (NSException *exception) {
-                    encounteredError = YES;
-                    XCTFail(@"Exception in bracketForKit: %@", exception);
+                    recordException(exception, @"bracketForKit");
                 }
             }
         });
     }
-    
+
     // Thread modifying brackets
     dispatch_group_async(group, concurrentQueue, ^{
-        for (NSInteger j = 0; j < iterations && !encounteredError; j++) {
+        for (NSInteger j = 0; j < iterations && !hasFailed(); j++) {
             @try {
                 for (NSNumber *integrationId in integrationIds) {
                     // Alternate between adding and removing brackets
@@ -3562,14 +3582,20 @@
                     }
                 }
             } @catch (NSException *exception) {
-                encounteredError = YES;
-                XCTFail(@"Exception in updateBracketsWithConfiguration: %@", exception);
+                recordException(exception, @"updateBracketsWithConfiguration");
             }
         }
     });
-    
+
     dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-        XCTAssertFalse(encounteredError, @"Thread safety test should complete without errors");
+        [errorLock lock];
+        NSException *exception = firstException;
+        NSString *source = firstExceptionSource;
+        [errorLock unlock];
+
+        if (exception != nil) {
+            XCTFail(@"Exception in %@: %@", source, exception);
+        }
         [expectation fulfill];
     });
     

--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -62,6 +62,15 @@ static NSNumber * const kTestRoktKitId = @181;
 @property (nonatomic, strong) MPIdentityApiManager *apiManager;
 @end
 
+// A shared CI runner can miss a sub-second budget for work that hops through
+// [MParticle messageQueue]. XCTest and OCMock both return as soon as the expectation
+// is satisfied, so a generous ceiling costs nothing when the machine is fast and stops
+// a slow moment from failing every async test in this class at once.
+static const NSTimeInterval kMPRoktAsyncTimeout = 5.0;
+// A rejection has to wait out its whole window to prove the call never came, so it
+// stays tighter - but still five times the old budget.
+static const NSTimeInterval kMPRoktRejectionWindow = 1.0;
+
 @interface MPRoktTests : XCTestCase
 @property (nonatomic, strong) MPRokt *rokt;
 @property (nonatomic, strong) id mockRokt;
@@ -79,9 +88,39 @@ static NSNumber * const kTestRoktKitId = @181;
     self.mockRokt = OCMPartialMock(self.rokt);
 }
 
+// Waits for work already queued on the SDK's message queue to finish, spinning the main
+// run loop so blocks that queue back onto main can also complete. Bounded, so a wedged
+// queue slows teardown instead of hanging the suite.
+- (void)mp_drainSDKWork {
+    dispatch_queue_t messageQueue = [MParticle messageQueue];
+    if (messageQueue == nil) {
+        return;
+    }
+
+    dispatch_semaphore_t drained = dispatch_semaphore_create(0);
+    dispatch_async(messageQueue, ^{
+        dispatch_semaphore_signal(drained);
+    });
+
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2.0];
+    while (dispatch_semaphore_wait(drained, DISPATCH_TIME_NOW) != 0 &&
+           [[NSDate date] compare:deadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+    }
+}
+
 - (void)tearDown {
-    self.rokt = nil;
+    // Drain queued SDK work before the mocks are disposed. A pending forward still holds
+    // references to these mocks, and OCMock's stopMocking destroys the dynamic class it
+    // installed - so tearing the mocks down first leaves those blocks pointing at a class
+    // the objc runtime no longer knows, and a later test aborts the whole runner with
+    // "Attempt to use unknown class".
+    [self mp_drainSDKWork];
+
+    // Stop the partial mock before releasing the object it wraps, not after.
     [self.mockRokt stopMocking];
+    self.rokt = nil;
     [self.mockInstance stopMocking];
     [self.mockContainer stopMocking];
     [self.identityMock stopMocking];
@@ -170,7 +209,7 @@ static NSNumber * const kTestRoktKitId = @181;
                      attributes:attributes];
     
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -235,7 +274,7 @@ static NSNumber * const kTestRoktKitId = @181;
                         onEvent:exampleOnEvent];
     
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -284,7 +323,7 @@ static NSNumber * const kTestRoktKitId = @181;
                         onEvent:nil];
 
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -329,7 +368,7 @@ static NSNumber * const kTestRoktKitId = @181;
                      attributes:attributes];
     
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -381,7 +420,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectPlacements:identifier attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -404,7 +443,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectPlacements:@"checkout" attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -415,7 +454,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectPlacements:@"checkout" attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -427,7 +466,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectPlacements:@"checkout" attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -450,7 +489,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectPlacements:@"checkout" attributes:@{@"f.name": @"Brandon"}];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -477,7 +516,7 @@ static NSNumber * const kTestRoktKitId = @181;
         [noFailure fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -495,7 +534,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     XCTAssertNoThrow([self.rokt selectPlacements:identifier attributes:attributes]);
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -593,7 +632,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt selectPlacements:identifier attributes:attributes];
     
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -620,7 +659,7 @@ static NSNumber * const kTestRoktKitId = @181;
     
     [self.rokt selectPlacements:identifier attributes:attributes];
     
-    [self.identityMock verifyWithDelay:0.2];
+    [self.identityMock verifyWithDelay:kMPRoktAsyncTimeout];
 }
 
 - (void)testTriggeredIdentifyWithMismatchedEmailIdentity {
@@ -651,7 +690,7 @@ static NSNumber * const kTestRoktKitId = @181;
     
     [self.rokt selectPlacements:identifier attributes:attributes];
     
-    [self.identityMock verifyWithDelay:0.2];
+    [self.identityMock verifyWithDelay:kMPRoktAsyncTimeout];
 }
 
 - (void)testTriggeredIdentifyWithMismatchedOtherIdentity {
@@ -722,7 +761,7 @@ static NSNumber * const kTestRoktKitId = @181;
     
     [self.rokt selectPlacements:identifier attributes:attributes];
     
-    [self.identityMock verifyWithDelay:0.2];
+    [self.identityMock verifyWithDelay:kMPRoktAsyncTimeout];
 }
 
 - (void)testDontTriggerIdentifyWithNoRoktHashedEmailUserIdentityType {
@@ -754,7 +793,7 @@ static NSNumber * const kTestRoktKitId = @181;
     
     [self.rokt selectPlacements:identifier attributes:attributes];
     
-    [self.identityMock verifyWithDelay:0.2];
+    [self.identityMock verifyWithDelay:kMPRoktRejectionWindow];
 }
 
 - (void)testTriggeredIdentifyWithNoRoktHashedEmailUserIdentityType {
@@ -786,7 +825,7 @@ static NSNumber * const kTestRoktKitId = @181;
     
     [self.rokt selectPlacements:identifier attributes:attributes];
     
-    [self.identityMock verifyWithDelay:0.2];
+    [self.identityMock verifyWithDelay:kMPRoktAsyncTimeout];
 }
 
 - (void)testPurchaseFinalized {
@@ -821,7 +860,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [[MParticle sharedInstance].rokt purchaseFinalized:identifier catalogItemId:catalogItemId success:success];
     
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -863,7 +902,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt events:identifier onEvent:onEventCallback];
 
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -898,7 +937,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt events:identifier onEvent:nil];
 
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -945,7 +984,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt events:identifier onEvent:onEventCallback];
 
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify callback was invoked
     XCTAssertTrue(callbackInvoked, @"Callback should have been invoked");
@@ -986,7 +1025,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt globalEvents:onEventCallback];
 
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);
@@ -1031,7 +1070,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt globalEvents:onEventCallback];
     
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     
     // Verify callback was invoked
     XCTAssertTrue(callbackInvoked, @"Callback should have been invoked");
@@ -1072,7 +1111,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt registerPaymentExtension:paymentExtension];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -1118,7 +1157,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectShoppableAds:identifier attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -1162,7 +1201,7 @@ static NSNumber * const kTestRoktKitId = @181;
                            config:roktConfig
                           onEvent:exampleOnEvent];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -1194,7 +1233,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectShoppableAds:identifier attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -1227,7 +1266,7 @@ static NSNumber * const kTestRoktKitId = @181;
         [noFailure fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -1249,7 +1288,7 @@ static NSNumber * const kTestRoktKitId = @181;
 
     [self.rokt selectShoppableAds:identifier attributes:attributes];
 
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
     OCMVerifyAll(self.mockContainer);
 }
 
@@ -1372,7 +1411,7 @@ static NSNumber * const kTestRoktKitId = @181;
     [self.rokt setSessionId:sessionId];
 
     // Wait for async operation
-    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+    [self waitForExpectationsWithTimeout:kMPRoktAsyncTimeout handler:nil];
 
     // Verify
     OCMVerifyAll(self.mockContainer);

--- a/UnitTests/ObjCTests/MParticleTests.m
+++ b/UnitTests/ObjCTests/MParticleTests.m
@@ -1193,7 +1193,6 @@
 #pragma mark Workspace Switching Tests
 
 #define WORKSPACE_SWITCHING_TIMEOUT 60
-#define WORKSPACE_SWITCHING_DELAY (int64_t)(10 * NSEC_PER_SEC)
 
 // Spins the main run loop until condition() is true, so main-queue work the SDK
 // schedules during start-up still runs. Returns NO if timeout elapses first.
@@ -1210,47 +1209,43 @@ static BOOL MPWaitForCondition(NSTimeInterval timeout, BOOL (^condition)(void)) 
 }
 
 - (void)testSwitchWorkspaceOptions {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-
     MParticle *instance = [MParticle sharedInstance];
     XCTAssertNotNil(instance);
     XCTAssertNil(instance.options);
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key1" secret:@"unit-test-secret1"];
-        [instance startWithOptions:options1];
-        XCTAssertNotNil(instance.options);
-        XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
-        XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
+    MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key1" secret:@"unit-test-secret1"];
+    [instance startWithOptions:options1];
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key2" secret:@"unit-test-secret2"];
-            [instance switchWorkspaceWithOptions:options2];
-            
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-                MParticle *instance3 = [MParticle sharedInstance];
-                MParticle *instance4 = [MParticle sharedInstance];
-                XCTAssertNotNil(instance.options);
-                XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
-                XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
-                
-                XCTAssertNotNil(instance3.options);
-                XCTAssertEqualObjects(instance3.options.apiKey, @"unit-test-key2");
-                XCTAssertEqualObjects(instance3.options.apiSecret, @"unit-test-secret2");
-                XCTAssertNotEqual(instance, instance3);
-                XCTAssertEqual(instance3, instance4);
-                
-                [expectation fulfill];
-            });
-        });
-    });
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return instance.initialized && instance.options != nil;
+    }), @"SDK did not finish initializing");
+    XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
+    XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
 
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key2" secret:@"unit-test-secret2"];
+    [instance switchWorkspaceWithOptions:options2];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        MParticle *current = [MParticle sharedInstance];
+        return current != instance && current.initialized && current.options != nil;
+    }), @"Workspace switch did not complete");
+
+    MParticle *instance3 = [MParticle sharedInstance];
+    MParticle *instance4 = [MParticle sharedInstance];
+
+    // The replaced instance keeps the options it was started with.
+    XCTAssertNotNil(instance.options);
+    XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
+    XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
+
+    XCTAssertNotNil(instance3.options);
+    XCTAssertEqualObjects(instance3.options.apiKey, @"unit-test-key2");
+    XCTAssertEqualObjects(instance3.options.apiSecret, @"unit-test-secret2");
+    XCTAssertNotEqual(instance, instance3);
+    XCTAssertEqual(instance3, instance4);
 }
 
 - (void)testSwitchWorkspaceSideloadedKits {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-     
     // Start with a sideloaded kit
     MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     MPKitTestClassSideloaded *kitTestSideloaded1 = [[MPKitTestClassSideloaded alloc] init];
@@ -1258,40 +1253,44 @@ static BOOL MPWaitForCondition(NSTimeInterval timeout, BOOL (^condition)(void)) 
     
     [[MParticle sharedInstance] startWithOptions:options1];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-        XCTAssertEqualObjects(MPKitContainer_PRIVATE.registeredKits.anyObject.wrapperInstance, kitTestSideloaded1);
-       
-        // Switch workspace with a new sideloaded kit
-        MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-        MPKitTestClassSideloaded *kitTestSideloaded2 = [[MPKitTestClassSideloaded alloc] init];
-        options2.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:kitTestSideloaded2]];
-        
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options2];
-        
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-            XCTAssertEqualObjects(MPKitContainer_PRIVATE.registeredKits.anyObject.wrapperInstance, kitTestSideloaded2);
-            
-            // Switch workspace with no sideloaded kits
-            MParticleOptions *options3 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-            [[MParticle sharedInstance] switchWorkspaceWithOptions:options3];
-            
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-                XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
-                
-                [expectation fulfill];
-            });
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:(WORKSPACE_SWITCHING_TIMEOUT) handler:nil];
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized
+            && MPKitContainer_PRIVATE.registeredKits.count == 1;
+    }), @"Sideloaded kit was not registered");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
+    XCTAssertEqualObjects(MPKitContainer_PRIVATE.registeredKits.anyObject.wrapperInstance, kitTestSideloaded1);
+
+    // Switch workspace with a new sideloaded kit
+    MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+    MPKitTestClassSideloaded *kitTestSideloaded2 = [[MPKitTestClassSideloaded alloc] init];
+    options2.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:kitTestSideloaded2]];
+
+    MParticle *instanceBeforeFirstSwitch = [MParticle sharedInstance];
+    [instanceBeforeFirstSwitch switchWorkspaceWithOptions:options2];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeFirstSwitch
+            && [MParticle sharedInstance].initialized
+            && MPKitContainer_PRIVATE.registeredKits.anyObject.wrapperInstance == kitTestSideloaded2;
+    }), @"Replacement sideloaded kit was not registered");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
+    XCTAssertEqualObjects(MPKitContainer_PRIVATE.registeredKits.anyObject.wrapperInstance, kitTestSideloaded2);
+
+    // Switch workspace with no sideloaded kits
+    MParticleOptions *options3 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+    MParticle *instanceBeforeSecondSwitch = [MParticle sharedInstance];
+    [instanceBeforeSecondSwitch switchWorkspaceWithOptions:options3];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeSecondSwitch
+            && [MParticle sharedInstance].initialized
+            && MPKitContainer_PRIVATE.registeredKits.count == 0;
+    }), @"Sideloaded kits were not cleared by the workspace switch");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
 }
 
 // Kits without configurations should NOT be removed from the registry even if they implement `stop` becuase it means they weren't used by the previous workspace
 - (void)testSwitchWorkspaceKitsNoConfigurations {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-    
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
     [MParticle registerExtension:[[MPKitRegister alloc] initWithName:@"TestKitNoStop" className:@"MPKitTestClassNoStartImmediately"]];
     [MParticle registerExtension:[[MPKitRegister alloc] initWithName:@"TestKitWithStop" className:@"MPKitTestClassNoStartImmediatelyWithStop"]];
@@ -1300,23 +1299,23 @@ static BOOL MPWaitForCondition(NSTimeInterval timeout, BOOL (^condition)(void)) 
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     [[MParticle sharedInstance] startWithOptions:options];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
-       
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
-            [expectation fulfill];
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized;
+    }), @"SDK did not finish initializing");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
+
+    MParticle *instanceBeforeSwitch = [MParticle sharedInstance];
+    [instanceBeforeSwitch switchWorkspaceWithOptions:options];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeSwitch
+            && [MParticle sharedInstance].initialized;
+    }), @"Workspace switch did not complete");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
 }
 
 // Kits with configurations that don't implement `stop` should be removed from the registry because they can't be cleanly restarted
 - (void)testSwitchWorkspaceKitsWithoutStop {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-    
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
     MPKitRegister *registerNoStop = [[MPKitRegister alloc] initWithName:@"TestKitNoStop" className:@"MPKitTestClassNoStartImmediately"];
     [MParticle registerExtension:registerNoStop];
@@ -1324,21 +1323,26 @@ static BOOL MPWaitForCondition(NSTimeInterval timeout, BOOL (^condition)(void)) 
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     [[MParticle sharedInstance] startWithOptions:options];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        registerNoStop.wrapperInstance = [[MPKitTestClassNoStartImmediately alloc] init];
-        [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@42] = [[MPKitConfiguration alloc] init];
-        
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-                
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
-       
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
-            [expectation fulfill];
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized;
+    }), @"SDK did not finish initializing");
+
+    registerNoStop.wrapperInstance = [[MPKitTestClassNoStartImmediately alloc] init];
+    [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@42] = [[MPKitConfiguration alloc] init];
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
+
+    MParticle *instanceBeforeSwitch = [MParticle sharedInstance];
+    [instanceBeforeSwitch switchWorkspaceWithOptions:options];
+
+    // The registry is emptied by the flush the switch triggers, which lands on the main
+    // queue, so wait for the observable outcome rather than for the switch alone.
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeSwitch
+            && [MParticle sharedInstance].initialized
+            && MPKitContainer_PRIVATE.registeredKits.count == 0;
+    }), @"Kits were not released by the workspace switch");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
 }
 
 // Kits with configurations that implement `stop` shouldn't be removed from the registry because they can be cleanly restarted

--- a/mParticle-Apple-SDK/Include/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Include/MPKitContainer.h
@@ -39,6 +39,7 @@
 
 + (BOOL)registerKit:(nonnull id<MPExtensionKitProtocol>)kitRegister;
 + (nullable NSSet<id<MPExtensionKitProtocol>> *)registeredKits;
++ (void)notifyWhenKitTeardownComplete:(nonnull dispatch_queue_t)queue block:(nonnull void (^)(void))block;
 
 - (void)flushSerializedKits;
 - (void)removeAllSideloadedKits;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -70,6 +70,12 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 
 @interface MPKitContainer_PRIVATE () {
     dispatch_semaphore_t kitsSemaphore;
+    // brackets is per-instance state (unlike kitsRegistry, which is static/shared), so its
+    // lock is scoped to the instance too. It is a separate semaphore from kitsSemaphore,
+    // not reused, because updateBracketsWithConfiguration:integrationId: is called from
+    // inside configureKits:'s kitsSemaphore-locked region - dispatch_semaphore is not
+    // reentrant, so guarding brackets with kitsSemaphore itself would deadlock there.
+    dispatch_semaphore_t bracketsSemaphore;
     NSMutableDictionary<NSNumber *, MPBracket *> *brackets;
     NSInteger sideloadedKitCodeNextValue;
 }
@@ -100,6 +106,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         NSMutableDictionary *linkInfo = _attributionInfo;
         _initializedTime = [NSDate date];
         kitsSemaphore = dispatch_semaphore_create(1);
+        bracketsSemaphore = dispatch_semaphore_create(1);
         brackets = [[NSMutableDictionary alloc] init];
         sideloadedKitCodeNextValue = sideloadedKitCodeStartValue;
         MParticle* mparticle = MParticle.sharedInstance;
@@ -210,8 +217,11 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 
 - (MPBracket *)bracketForKit:(NSNumber *)integrationId {
     NSAssert(integrationId != nil, @"Required parameter. It cannot be nil.");
-    
-    return brackets[integrationId];
+
+    dispatch_semaphore_wait(bracketsSemaphore, DISPATCH_TIME_FOREVER);
+    MPBracket *bracket = brackets[integrationId];
+    dispatch_semaphore_signal(bracketsSemaphore);
+    return bracket;
 }
 
 - (void)flushSerializedKits {
@@ -249,29 +259,42 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
     [self freeKitRegister:kitRegister integrationId:integrationId];
 }
 
+// configureKits: calls freeKit:/freeKitRegister: while holding kitsSemaphore (see the
+// deactivateKits cleanup there), and dispatch_semaphore is not recursive, so this method
+// cannot take the lock itself. The wrapperInstance = nil detach below has to run inline
+// regardless, since that is what synchronizes with isActiveAndNotDisabled:'s reads of
+// wrapperInstance on other threads under the same lock. Everything after the detach -
+// stop(), disk cleanup, posting mParticleKitDidBecomeInactiveNotification - runs arbitrary
+// kit and observer code, so it is deferred to the main queue instead of running inline:
+// doing that work while still holding kitsSemaphore (as configureKits: does) would stall
+// every other thread waiting on the lock for as long as it takes, or deadlock outright if
+// an observer calls back into a kitsSemaphore-guarded method.
 - (void)freeKitRegister:(id<MPExtensionKitProtocol>)kitRegister integrationId:(NSNumber *)integrationId {
     NSAssert(integrationId != nil, @"Required parameter. It cannot be nil.");
 
     if (kitRegister.wrapperInstance) {
-        if ([kitRegister.wrapperInstance respondsToSelector:@selector(stop)]) {
-            [kitRegister.wrapperInstance stop];
-        }
-        
+        id<MPKitProtocol> wrapperInstance = kitRegister.wrapperInstance;
         kitRegister.wrapperInstance = nil;
-        
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *stateMachineDirectoryPath = STATE_MACHINE_DIRECTORY_PATH;
-        NSString *kitPath = [stateMachineDirectoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"EmbeddedKit%@.%@", integrationId, kitFileExtension]];
-        
-        if ([fileManager fileExistsAtPath:kitPath]) {
-            [fileManager removeItemAtPath:kitPath error:nil];
-        }
-        
-        NSDictionary *userInfo = @{mParticleKitInstanceKey:integrationId};
-        
-        [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeInactiveNotification
-                                                            object:nil
-                                                          userInfo:userInfo];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if ([wrapperInstance respondsToSelector:@selector(stop)]) {
+                [wrapperInstance stop];
+            }
+
+            NSFileManager *fileManager = [NSFileManager defaultManager];
+            NSString *stateMachineDirectoryPath = STATE_MACHINE_DIRECTORY_PATH;
+            NSString *kitPath = [stateMachineDirectoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"EmbeddedKit%@.%@", integrationId, kitFileExtension]];
+
+            if ([fileManager fileExistsAtPath:kitPath]) {
+                [fileManager removeItemAtPath:kitPath error:nil];
+            }
+
+            NSDictionary *userInfo = @{mParticleKitInstanceKey:integrationId};
+
+            [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeInactiveNotification
+                                                                object:nil
+                                                              userInfo:userInfo];
+        });
     }
 }
 
@@ -661,16 +684,19 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 
 - (void)updateBracketsWithConfiguration:(NSDictionary *)configuration integrationId:(NSNumber *)integrationId {
     NSAssert(integrationId != nil, @"Required parameter. It cannot be nil.");
-    
+
+    dispatch_semaphore_wait(bracketsSemaphore, DISPATCH_TIME_FOREVER);
+
     if (!configuration) {
         [brackets removeObjectForKey:integrationId];
+        dispatch_semaphore_signal(bracketsSemaphore);
         return;
     }
-    
+
     long mpId = [[MPPersistenceController_PRIVATE mpId] longValue];
     short low = (short)[configuration[@"lo"] integerValue];
     short high = (short)[configuration[@"hi"] integerValue];
-    
+
     MPBracket *bracket = brackets[integrationId];
     if (bracket) {
         bracket.mpId = mpId;
@@ -679,6 +705,8 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
     } else {
         brackets[integrationId] = [[MPBracket alloc] initWithMpId:mpId low:low high:high];
     }
+
+    dispatch_semaphore_signal(bracketsSemaphore);
 }
 
 #pragma mark Public class methods

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -215,19 +215,43 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 }
 
 - (void)flushSerializedKits {
+    // kitsRegistry is guarded by kitsSemaphore everywhere else. This path is reached from
+    // the early return in configureKits: - before that lock is taken - so snapshot the set
+    // under the lock rather than enumerating the live one, which raced with the locked
+    // mutation in configureKits: and could crash mid-enumeration.
+    //
+    // The snapshot is taken here and iterated on the main queue without holding the lock:
+    // waiting on kitsSemaphore from the main queue would let a long background critical
+    // section stall the main thread. Iterating the snapshot lets this path call
+    // freeKitRegister: directly, so it never reads kitsRegistry unguarded - freeKit:
+    // itself has to stay lock-free because configureKits: calls it while holding the
+    // semaphore, and dispatch_semaphore is not recursive.
+    dispatch_semaphore_wait(kitsSemaphore, DISPATCH_TIME_FOREVER);
+    NSArray<id<MPExtensionKitProtocol>> *kitsSnapshot = [kitsRegistry allObjects];
+    dispatch_semaphore_signal(kitsSemaphore);
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        for (id<MPExtensionKitProtocol>kitRegister in kitsRegistry) {
-            [self freeKit:kitRegister.code];
+        for (id<MPExtensionKitProtocol>kitRegister in kitsSnapshot) {
+            [self freeKitRegister:kitRegister integrationId:kitRegister.code];
         }
     });
 }
 
+// Resolves the register from kitsRegistry, so callers must already hold kitsSemaphore.
+// Callers that already have the register (see flushSerializedKits) should use
+// freeKitRegister:integrationId: instead of reading the set again.
 - (void)freeKit:(NSNumber *)integrationId {
     NSAssert(integrationId != nil, @"Required parameter. It cannot be nil.");
     
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"code == %@", integrationId];
     id<MPExtensionKitProtocol>kitRegister = [[kitsRegistry filteredSetUsingPredicate:predicate] anyObject];
     
+    [self freeKitRegister:kitRegister integrationId:integrationId];
+}
+
+- (void)freeKitRegister:(id<MPExtensionKitProtocol>)kitRegister integrationId:(NSNumber *)integrationId {
+    NSAssert(integrationId != nil, @"Required parameter. It cannot be nil.");
+
     if (kitRegister.wrapperInstance) {
         if ([kitRegister.wrapperInstance respondsToSelector:@selector(stop)]) {
             [kitRegister.wrapperInstance stop];

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -40,6 +40,16 @@
 
 NSString *const kitFileExtension = @"eks";
 static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
+// Tracks kit teardown work deferred to the main queue by flushSerializedKits and
+// freeKitRegister:integrationId: (stop(), disk cleanup, notification). Workspace-switch
+// callers enter this group before dispatching that work and leave it after, so
+// notifyWhenKitTeardownComplete:block: lets mParticle.m wait for old kits to actually
+// finish stopping before starting the next workspace's kits - deferring the work off
+// kitsSemaphore (to avoid holding that lock across arbitrary kit/observer code) would
+// otherwise leave no guarantee that a kit with process-wide teardown (e.g. one whose
+// stop() shuts down a shared SDK singleton) finishes before the new workspace's identical
+// kit starts back up.
+static dispatch_group_t kitTeardownGroup;
 
 @interface MParticle ()
 @property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
@@ -95,7 +105,16 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 + (void)initialize {
     if (self == [MPKitContainer_PRIVATE class]) {
         kitsRegistry = [[NSMutableSet alloc] initWithCapacity:DEFAULT_ALLOCATION_FOR_KITS];
+        kitTeardownGroup = dispatch_group_create();
     }
+}
+
+// Lets a caller (see resetForSwitchingWorkspaces: and reset: in mParticle.m) wait for every
+// currently in-flight deferred kit teardown - queued by flushSerializedKits or
+// freeKitRegister:integrationId: - to finish before proceeding, e.g. before starting the
+// next workspace's kits.
++ (void)notifyWhenKitTeardownComplete:(dispatch_queue_t)queue block:(void (^)(void))block {
+    dispatch_group_notify(kitTeardownGroup, queue, block);
 }
 
 - (instancetype)init {
@@ -240,10 +259,22 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
     NSArray<id<MPExtensionKitProtocol>> *kitsSnapshot = [kitsRegistry allObjects];
     dispatch_semaphore_signal(kitsSemaphore);
 
+    // Entered synchronously, here, before returning - not inside the dispatched block below.
+    // notifyWhenKitTeardownComplete:block: (see mParticle.m) can be called immediately after
+    // this method returns, and dispatch_group_notify fires as soon as the group's enter count
+    // is back to zero; entering inside the async block would leave a window where the group
+    // still reads as empty because the enter itself hasn't executed yet, letting the next
+    // workspace's kits start before this teardown is even scheduled, let alone done.
+    dispatch_group_enter(kitTeardownGroup);
     dispatch_async(dispatch_get_main_queue(), ^{
         for (id<MPExtensionKitProtocol>kitRegister in kitsSnapshot) {
-            [self freeKitRegister:kitRegister integrationId:kitRegister.code];
+            id<MPKitProtocol> wrapperInstance = kitRegister.wrapperInstance;
+            if (wrapperInstance) {
+                kitRegister.wrapperInstance = nil;
+                [self teardownDetachedWrapperInstance:wrapperInstance forIntegrationId:kitRegister.code];
+            }
         }
+        dispatch_group_leave(kitTeardownGroup);
     });
 }
 
@@ -276,26 +307,40 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         id<MPKitProtocol> wrapperInstance = kitRegister.wrapperInstance;
         kitRegister.wrapperInstance = nil;
 
+        // Entered synchronously here, before dispatch_async - see flushSerializedKits above
+        // for why entering inside the dispatched block itself would be too late.
+        dispatch_group_enter(kitTeardownGroup);
         dispatch_async(dispatch_get_main_queue(), ^{
-            if ([wrapperInstance respondsToSelector:@selector(stop)]) {
-                [wrapperInstance stop];
-            }
-
-            NSFileManager *fileManager = [NSFileManager defaultManager];
-            NSString *stateMachineDirectoryPath = STATE_MACHINE_DIRECTORY_PATH;
-            NSString *kitPath = [stateMachineDirectoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"EmbeddedKit%@.%@", integrationId, kitFileExtension]];
-
-            if ([fileManager fileExistsAtPath:kitPath]) {
-                [fileManager removeItemAtPath:kitPath error:nil];
-            }
-
-            NSDictionary *userInfo = @{mParticleKitInstanceKey:integrationId};
-
-            [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeInactiveNotification
-                                                                object:nil
-                                                              userInfo:userInfo];
+            [self teardownDetachedWrapperInstance:wrapperInstance forIntegrationId:integrationId];
+            dispatch_group_leave(kitTeardownGroup);
         });
     }
+}
+
+// wrapperInstance must already be detached from its kitRegister (kitRegister.wrapperInstance
+// set to nil) before calling this, by a caller synchronized with kitsSemaphore. This method
+// itself touches no container state, so it does not take kitsSemaphore, and every caller
+// runs it off of that lock regardless (see flushSerializedKits and freeKitRegister: above),
+// since stop(), disk cleanup and the notification post here run arbitrary kit/observer code
+// that must not run while the lock is held.
+- (void)teardownDetachedWrapperInstance:(id<MPKitProtocol>)wrapperInstance forIntegrationId:(NSNumber *)integrationId {
+    if ([wrapperInstance respondsToSelector:@selector(stop)]) {
+        [wrapperInstance stop];
+    }
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *stateMachineDirectoryPath = STATE_MACHINE_DIRECTORY_PATH;
+    NSString *kitPath = [stateMachineDirectoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"EmbeddedKit%@.%@", integrationId, kitFileExtension]];
+
+    if ([fileManager fileExistsAtPath:kitPath]) {
+        [fileManager removeItemAtPath:kitPath error:nil];
+    }
+
+    NSDictionary *userInfo = @{mParticleKitInstanceKey:integrationId};
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeInactiveNotification
+                                                        object:nil
+                                                      userInfo:userInfo];
 }
 
 - (void)registerSideloadedKits {

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -616,7 +616,17 @@ MPLog* logger;
         [self.persistenceController resetDatabaseForWorkspaceSwitching];
         
         // Clean up mParticle instance
-        [executor executeOnMain:^{
+        //
+        // flushSerializedKits/removeAllSideloadedKits defer each kit's actual stop() and
+        // teardown to the main queue rather than running it under kitsSemaphore (see
+        // MPKitContainer.m), so by the time this point is reached those calls have only been
+        // *scheduled*, not completed. completion() below starts the next workspace, which can
+        // configure and start a kit with the same integration ID before the old instance has
+        // actually stopped - for a kit whose stop() has process-wide effects (for example one
+        // that shuts down a shared SDK singleton), that can tear down the integration that was
+        // just started. Waiting on notifyWhenKitTeardownComplete: here blocks starting the new
+        // workspace until every kit scheduled for teardown by this reset has actually finished.
+        [MPKitContainer_PRIVATE notifyWhenKitTeardownComplete:dispatch_get_main_queue() block:^{
             [MParticle setSharedInstance:nil];
             if (completion) {
                 completion();
@@ -723,7 +733,12 @@ MPLog* logger;
         [self.kitContainer removeAllSideloadedKits];
         [MPUserDefaultsConnector.userDefaults resetDefaults];
         [self.persistenceController resetDatabase];
-        [executor executeOnMain:^{
+        // See the matching comment in resetForSwitchingWorkspaces: - flushSerializedKits/
+        // removeAllSideloadedKits only schedule each kit's stop() and teardown on the main
+        // queue rather than completing it here, so waiting on notifyWhenKitTeardownComplete:
+        // ensures that work has actually finished before completion() (which per this
+        // method's documented contract is where a caller restarts the SDK) can start new kits.
+        [MPKitContainer_PRIVATE notifyWhenKitTeardownComplete:dispatch_get_main_queue() block:^{
             predicate = 0;
             _sharedInstance = nil;
             if (completion) {


### PR DESCRIPTION
## Summary

`MPKitContainer` had three unsynchronized races around kit teardown and configuration, plus flaky tests hiding them:

- **`kitsRegistry` flush race** — `flushSerializedKits` mutated the registry with no lock, reached via the early return in `configureKits:` before that lock is taken.
- **`brackets` had no lock at all** — `bracketForKit:` read it and `updateBracketsWithConfiguration:` mutated it concurrently with zero synchronization, not even the kit-registry semaphore. Added a dedicated `bracketsSemaphore`.
- **`freeKitRegister:` ran arbitrary code (`stop()`, disk I/O, a notification post) while holding `kitsSemaphore`**, stalling every other thread or risking deadlock. Deferred it off the lock, matching how `flushSerializedKits` already worked — then added a `dispatch_group` so workspace-switch/reset actually wait for that deferred work to finish before starting the next workspace's kits (a real ordering hazard [Cursor Bugbot](https://cursor.com/bugbot) caught: a kit with process-wide teardown could otherwise start its new instance and then have the old one's deferred `stop()` tear it back down).

Also stabilized several flaky/racy tests along the way: fixed-delay `dispatch_after` workspace-switch tests converted to condition waits, `MPRoktTests`' 200ms async budgets raised to realistic timeouts, an OCMock lifetime bug in test teardown, and two of this PR's own new concurrency stress tests hardened (unsynchronized `__block BOOL` + off-main-thread `XCTFail`).

The `brackets` race specifically has been live, unguarded, since an April 2026 merge (the dictionary itself dates to a December 2025 C++ removal) — a new stress test written this week is what finally caught it, in CI, not locally.

## Testing Plan

- Local: `MPKitContainerTests` + `MParticleTests` classes, 100+ combined runs across the fixes in this PR, 0 crashes, 0 failures. Full ObjC suite ×6+, 0 crashes.
- CI (Xcode 16.4 / iOS 18, the environment that originally caught this): all 4 `native-tests` jobs (iOS/tvOS × ObjC/Swift) now pass, including `testActiveKitsRegistryThreadSafety` and `testBracketForKitThreadSafety`, which failed 2/2 runs before this PR's later commits.
- `trunk check` clean.

## Related

Stacked on #870/#867 (CI hang and test-stability fixes, already merged). #916 stacks on top of this with the remaining `kitsRegistry`/`kitsSemaphore` scope mismatch fix.
