### PR TITLE
docs: trim AGENTS.md to the non-derivable core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,11 @@ nothing else discovers it.
   comment, and a `pull_request` event from a fork gets a read-only token whatever the workflow's
   `permissions:` block asks for. Judge a fork PR on the jobs that _can_ run, and on the merge state
   rather than the check list.
+- **Place a red or `cancelled` check before debugging it.** `build-kits / Pod Lint <kit>` resolves
+  third-party pods through the CocoaPods CDN, so those jobs fail as a batch, retries exhausted, when
+  that CDN errors. A `cancelled` job is normally a `timeout-minutes` expiry in `native-tests` or a
+  superseded push, since `pull-request.yml` sets `concurrency: cancel-in-progress` keyed on the PR -
+  neither is a test result. Compare the same job on `main` before reading a red one as yours.
 
 ## Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,9 @@ nothing else discovers it.
   for commits not attributed to a GitHub account, so commit with an email tied to your account. Any
   push dismisses existing approvals, and only squash and merge commits are allowed, never rebase.
 - **A fork PR cannot go green, whatever it changes.** `size-report` finishes by writing a PR
-  comment, which needs the `pull-requests: write` a fork's token is not given, and
-  `cross-platform-tests` checks the head ref out of the base repository, where a fork's branch does
-  not exist. Judge a fork PR on the jobs that _can_ run, and on the merge state rather than the
-  check list.
+  comment, and a `pull_request` event from a fork gets a read-only token whatever the workflow's
+  `permissions:` block asks for. Judge a fork PR on the jobs that _can_ run, and on the merge state
+  rather than the check list.
 
 ## Gotchas
 
@@ -132,6 +131,9 @@ nothing else discovers it.
    break survives every other check.
 5. Integration tests fail on an unmatched request but only _warn_ on a recorded WireMock mapping
    the app never calls (`IntegrationTests/run_integration_tests_ci.sh`).
-6. `RNExample` is not built on PRs - `build-secondary-platforms` is commented out of
-   `.github/workflows/pull-request.yml`.
+6. **Some workflow files never run, and the tree does not show it.** `cross-platform-tests.yml` and
+   `release-ecosystem-from-main.yml` are disabled in repository settings; `RNExample` is not built on
+   PRs because `build-secondary-platforms` is commented out of
+   `.github/workflows/pull-request.yml`. Check `gh workflow list --all` before assuming a workflow
+   file is a live gate.
 7. `ARCHITECTURE.md` is two diagram images and no prose. There is no written architecture document.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,9 +132,10 @@ nothing else discovers it.
    break survives every other check.
 5. Integration tests fail on an unmatched request but only _warn_ on a recorded WireMock mapping
    the app never calls (`IntegrationTests/run_integration_tests_ci.sh`).
-6. **Some workflow files never run, and the tree does not show it.** `cross-platform-tests.yml` and
-   `release-ecosystem-from-main.yml` are disabled in repository settings; `RNExample` is not built on
-   PRs because `build-secondary-platforms` is commented out of
-   `.github/workflows/pull-request.yml`. Check `gh workflow list --all` before assuming a workflow
-   file is a live gate.
+6. **The workflow list and the tree disagree, in both directions.** `cross-platform-tests.yml` is in
+   the tree but `disabled_manually` in repository settings, so it never runs; and
+   `gh workflow list --all` reports a `release-ecosystem-from-main.yml` whose file is not on `main`
+   at all, only on unmerged branches. Separately, `RNExample` is not built on PRs because
+   `build-secondary-platforms` is commented out of `.github/workflows/pull-request.yml`. Neither the
+   tree nor the workflow list is sufficient alone; check the caller too.
 7. `ARCHITECTURE.md` is two diagram images and no prose. There is no written architecture document.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,10 @@ mistake to make.
    workflow invokes it. It prints per-file coverage and nothing more. It also only works with
    `Scripts/` as the working directory, since both the project path and the Python call inside it
    are relative.
-5. **Xcode is pinned to two different versions.** `build-and-lint`, `native-tests` and
-   `size-report` use 16.4; `integration-tests`, `build-kits` and `verify-kit-xcframework-import`
-   use 26.2. Matching only the first still fails the kit and integration jobs.
+5. **Xcode is pinned to two different versions, so "the CI Xcode" is ambiguous.** `build-and-lint`,
+   `native-tests` and `size-report` pin one; `integration-tests`, `build-kits` and
+   `verify-kit-xcframework-import` pin a newer one. Read `XCODE_VERSION` (or `xcode-version`) in the
+   workflow you care about rather than assuming a single toolchain covers the repo.
 6. **`CONTRIBUTING.md`'s test command does not work.** It names an `.xcworkspace` and an
    `mParticle-Apple-SDK-iOS` scheme, neither of which exists. Use the commands above.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,163 +1,137 @@
-# AGENTS.md
+# mParticle Apple SDK - Agent Instructions
 
-## About mParticle SDKs
+Loaded into every agent session, so it holds only what you cannot get by reading the repository.
+Anything a config file already states is deliberately absent: read the config, which cannot go
+stale, rather than this file, which can. For the rest see `README.md` (install and public API),
+`CONTRIBUTING.md` (commit and PR conventions), `RELEASE.md`, `Kits/README.md`,
+`IntegrationTests/README.md`, and the
+[public SDK docs](https://docs.mparticle.com/developers/sdk/ios/).
 
-mParticle is a Customer Data Platform that collects, validates, and forwards event data to analytics and marketing integrations. The SDK is responsible for:
+## Working rules
 
-- **Event Collection**: Capturing user interactions, commerce events, and custom events
-- **Identity Management**: Managing user identity across sessions and platforms
-- **Event Forwarding**: Routing events to configured integrations (kits/forwarders)
-- **Data Validation**: Enforcing data quality through data plans
-- **Consent Management**: Handling user consent preferences (GDPR, CCPA)
-- **Session Management**: Tracking user sessions and engagement
-- **Batch Upload**: Efficiently uploading events to mParticle servers
+Objective-C and Swift customer-data-platform SDK for iOS and tvOS. Treat it as a public framework,
+not an app: keep the public API additive, deprecate rather than remove, never break the kit
+interface, never block the main thread, never crash on bad input or a failed request, and prefer
+additive changes to refactors unless a refactor was asked for. Do not raise the deployment-target
+floor - it is pinned in `Package.swift` and all three podspecs. Do not edit `.github/`, `Scripts/`
+or `.trunk/` unless the task is about them. Update `PrivacyInfo.xcprivacy` if data-collection
+behaviour changes; the single root copy is what both SwiftPM and CocoaPods ship. Ask first before
+adding a dependency, dropping an OS version, making a breaking API change, or touching the kit
+interface.
 
-### Glossary of Terms
+## Names that collide
 
-- **MPID (mParticle ID)**: Unique identifier for a user across sessions and devices
-- **Kit/Forwarder**: Third-party integration (e.g., Google Analytics, Braze) that receives events from the SDK
-- **Data Plan**: Validation schema that defines expected events and their attributes
-- **Workspace**: A customer's mParticle environment (identified by API key)
-- **Batch**: Collection of events grouped together for efficient server upload
-- **Identity Request**: API call to identify, login, logout, or modify a user's identity
-- **Session**: Period of user activity with automatic timeout (typically 30 minutes)
-- **Consent State**: User's privacy preferences (GDPR, CCPA) that control data collection and forwarding
-- **User Attributes**: Key-value pairs describing user properties (e.g., email, age, preferences)
-- **Custom Events**: Application-specific events defined by the developer
-- **Commerce Events**: Predefined events for e-commerce tracking (purchases, product views, etc.)
-- **Event Type**: Category of event (Navigation, Location, Transaction, UserContent, UserPreference, Social, Other)
+Several unrelated things here answer to "mParticle-Apple-SDK", and confusing them is the easiest
+mistake to make.
 
-## Role for agents
+- `mParticle-Apple-SDK/` (the directory) is the Objective-C core: SwiftPM target
+  `mParticle_Apple_SDK_ObjC`, pod `mParticle-Apple-SDK-ObjC`.
+- `MParticle/Sources/` is the small Swift umbrella that _is_ the consumer-facing SwiftPM product and
+  the pod named `mParticle-Apple-SDK`.
+- `mParticle-Apple-SDK-Swift/Sources/` is internal Swift components: pod
+  `mParticle-Apple-SDK-Swift`, which release does not publish automatically (see `RELEASE.md`).
+- `mParticle-Apple-SDK.xcodeproj` is the Xcode framework build, and the one CI compiles in the
+  build, analyze and unit-test jobs.
 
-You are a senior iOS SDK engineer specializing in customer data platform (CDP) SDK development.
+## Commands
 
-- Treat this as a **public SDK / framework** (distributed via SPM, and CocoaPods), not a full consumer app.
-- Prioritize: API stability, minimal footprint, backward compatibility (iOS 15.0+, tvOS 15.0+), thread-safety, privacy compliance.
-- The SDK handles event tracking, identity management, consent, commerce events, push notifications, and integration kits.
-- Avoid proposing big refactors unless explicitly asked; prefer additive changes + deprecations.
+- Lint and format: `trunk check`
+- Build for iOS:
+  `xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle-Apple-SDK -destination 'generic/platform=iOS' build`
+- Objective-C unit tests:
+  `xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle-Apple-SDK -destination 'platform=iOS Simulator,name=iPhone 16 Pro' test`
+- Swift unit tests: the same, with `-scheme mParticle-Apple-SDK-Swift`
+- Podspec lint:
+  `pod lib lint mParticle-Apple-SDK.podspec --include-podspecs="{mParticle-Apple-SDK-Swift.podspec,mParticle-Apple-SDK-ObjC.podspec,mParticle-Apple-SDK.podspec}"`
+- Integration tests: see `IntegrationTests/README.md` - needs Tuist, Java and WireMock
 
-## Quick Start for Agents
+### Command traps
 
-- Open the Xcode project/workspace with Xcode 16.4+.
-- Primary actions:
-  - Build: via Xcode scheme or `xcodebuild`.
-  - Run unit tests: `Rokt_WidgetTests/` or via Xcode (Command + U).
-  - Lint: `trunk check` (primary enforcement tool).
-  - Pod lint: `pod lib lint mParticle-Apple-SDK.podspec --include-podspecs="{mParticle-Apple-SDK-Swift.podspec,mParticle-Apple-SDK-ObjC.podspec,mParticle-Apple-SDK.podspec}"` (same as CI).
-  - Size report: Check binary size impact via CI workflow.
-- Always validate changes with the full sequence in "Code style, quality, and validation" below before proposing or committing.
+1. **There are two test schemes, and each has exactly one testable.** `-scheme mParticle-Apple-SDK`
+   runs only `mParticle-Apple-SDKTests` (`UnitTests/ObjCTests`); the Swift suite is reachable only
+   through `-scheme mParticle-Apple-SDK-Swift`. Run one and you have tested half the SDK. CI runs
+   both schemes against both iOS and tvOS (`.github/workflows/native-tests.yml`).
+2. **The lint configs are not at the repo root.** `.swiftlint.yml` and `.swiftformat` live in
+   `.trunk/configs/`, where a bare `swiftlint` or `swiftformat .` invoked from the root will not
+   find them - those runs silently apply the tools' own defaults instead of this repo's rules. Use
+   `trunk check`; there is no fallback that reproduces it.
+3. **`pod lib lint` needs all three podspecs.** They depend on each other by exact version
+   (`s.dependency 'mParticle-Apple-SDK-ObjC', s.version.to_s`), so the umbrella cannot resolve
+   without `--include-podspecs`.
+4. **`Scripts/check_coverage.sh` cannot fail.** `Scripts/check_coverage.py` appends to
+   `failed_files` and then never exits non-zero, and the shell wrapper ends on `rm -rf venv`. No
+   workflow invokes it. It prints per-file coverage and nothing more. It also only works with
+   `Scripts/` as the working directory, since both the project path and the Python call inside it
+   are relative.
+5. **Xcode is pinned to two different versions.** `build-and-lint`, `native-tests` and
+   `size-report` use 16.4; `integration-tests`, `build-kits` and `verify-kit-xcframework-import`
+   use 26.2. Matching only the first still fails the kit and integration jobs.
+6. **`CONTRIBUTING.md`'s test command does not work.** It names an `.xcworkspace` and an
+   `mParticle-Apple-SDK-iOS` scheme, neither of which exists. Use the commands above.
 
-## Strict Do's and Don'ts
+## Conventions that no config enforces
 
-### Always Do
+- **Three consumers decide header publicness separately, and it takes two actions.** Moving a header
+  into `mParticle-Apple-SDK/Include/` covers SwiftPM (`publicHeadersPath`) and CocoaPods (the
+  podspec's `public_header_files` glob); the Xcode framework target keeps its own list, so the file
+  also needs `ATTRIBUTES = (Public, )` there. Skip the second action and the header is public to
+  SwiftPM and CocoaPods consumers but missing from the built framework.
+- **SwiftLint never sees test code** - `.trunk/configs/.swiftlint.yml` excludes `UnitTests`.
+- **Never hand-edit a version string.** The Release - Draft workflow rewrites `VERSION`,
+  `Framework/Info.plist`, every core and kit podspec, `MPIConstants.m` and a handful of kit sources
+  in one pass. Introducing a new place a version lives means teaching
+  `.github/workflows/release-draft.yml` about it, or it goes stale silently.
+- **Never hand-write `CHANGELOG.md`.** Release sections are generated from conventional-commit PR
+  titles at release time (same workflow, `exclude-types: chore,ci,test,build`) and inserted below
+  the `## [Unreleased]` heading, which is not itself consumed - so a hand-written entry there is
+  never folded into a release. Your PR title is the changelog entry.
+- Objective-C follows Apple's Cocoa coding guidelines. Swift prefers `let` and value types and
+  avoids force-unwraps. Public API needs HeaderDoc (Objective-C) or `///` (Swift). Add a comment
+  only where the code cannot be made clear instead.
 
-- Maintain compatibility with mParticle's kit/integration ecosystem.
-- Keep public API surface additive; deprecate instead of remove.
-- Mark public APIs with thorough documentation (HeaderDoc for Obj-C, `///` for Swift).
-- Ensure changes work on both iOS and tvOS targets.
-- Run `trunk check` and unit tests before any commit.
-- Measure & report size impact before proposing dependency or asset changes.
-- Update `PrivacyInfo.xcprivacy` if data collection practices change.
+## Kits
 
-### Never
+`Kits/<vendor>/<vendor>-<major>/` is a self-contained package: its own `Package.swift`, podspec,
+`.xcodeproj`, `CHANGELOG.md` and example apps. `Kits/matrix.json` is the registry, mapping each kit
+to its `local_path`, `podspec`, build `schemes` and the `dest_repo` it is mirrored out to on
+release. **A kit missing from `matrix.json` is not built, not pod-linted and not released** -
+nothing else discovers it.
 
-- Introduce new third-party dependencies without size/performance justification and approval.
-- Block the main thread (no synchronous network, heavy computation, etc.).
-- Crash on bad input/network — always provide fallback / error callback.
-- Touch CI configs (`.github/`), `Scripts/` utilities, or CI YAML without explicit request.
-- Propose dropping iOS 15.0 / tvOS 15.0 support or raising min deployment target.
-- Break kit/integration compatibility without explicit coordination.
-- Modify vendored libraries in `Libraries/` without explicit request.
+## Pull requests
 
-## When to Ask for Clarification
+- Base off `main`. `workstation/*` are long-lived integration branches covered by the same ruleset,
+  and stacks of migration PRs often target one of them instead - check what the work you are
+  following up on is based on rather than assuming `main`.
+- Branch name _and_ PR title are both checked against the semantic-commit convention by
+  `.github/workflows/reusable-workflows.yml`; the allowed types are listed in `CONTRIBUTING.md`.
+- **CI is not the merge gate.** The ruleset covering `main` and `workstation/*` requires no status
+  checks at all - re-check that before treating a green run as a gate. What it does require: one
+  CODEOWNERS approval (`* @mParticle/sdk-team`), every review thread resolved, and an extra approval
+  for commits not attributed to a GitHub account, so commit with an email tied to your account. Any
+  push dismisses existing approvals, and only squash and merge commits are allowed, never rebase.
+- **A fork PR cannot go green, whatever it changes.** `size-report` finishes by writing a PR
+  comment, which needs the `pull-requests: write` a fork's token is not given, and
+  `cross-platform-tests` checks the head ref out of the base repository, where a fork's branch does
+  not exist. Judge a fork PR on the jobs that _can_ run, and on the merge state rather than the
+  check list.
 
-- Before adding any new dependency.
-- Before dropping support for OS versions.
-- Before making breaking API changes.
-- When changes affect the kit/integration interface.
-- When test failures suggest the original code may have had bugs.
+## Gotchas
 
-## Project overview
-
-- mParticle Apple SDK (Rokt fork): a comprehensive customer data platform SDK for iOS and tvOS written in Objective-C and Swift.
-- Handles event tracking, user identity management, consent management, commerce events, push notification handling, and integration kit orchestration.
-- Distributed via Swift Package Manager and CocoaPods.
-- Integration kits (like the Rokt kit) plug into this SDK to forward events to third-party services.
-
-## Key paths
-
-- `mParticle-Apple-SDK/` — Main SDK source (40+ subdirectories).
-  - `Include/` — Public headers (46 files).
-  - `AppNotifications/` — Push notification handling.
-  - `Consent/` — Consent management.
-  - `Data Model/` — Core data structures.
-  - `Ecommerce/` — Commerce event handling.
-  - `Event/` — Event processing.
-  - `Identity/` — User identity management.
-  - `Kits/` — Integration kit infrastructure.
-  - `Network/` — Network communication.
-  - `Persistence/` — Data storage.
-- `mParticle-Apple-SDK-Swift/` — Swift-only components.
-- `UnitTests/` — Unit tests (ObjCTests, SwiftTests, Mocks).
-- `IntegrationTests/` — Integration tests (Tuist + WireMock).
-- `Example/` — Sample app (11 subdirectories).
-- `Scripts/` — Build and utility scripts (`xcframework.sh`, `check_coverage.sh`, etc.).
-- `VERSION` — Ecosystem version advanced by the Release – Draft workflow; consumed by publish/mirror workflows.
-- `Package.swift` — SPM manifest (swift-tools-version 5.5).
-- `mParticle-Apple-SDK.podspec` — CocoaPods umbrella (Swift sources; consumer-facing pod name `mParticle-Apple-SDK`).
-- `mParticle-Apple-SDK-ObjC.podspec` — CocoaPods ObjC core (`mParticle-Apple-SDK-ObjC`).
-- `PrivacyInfo.xcprivacy` — iOS privacy manifest.
-- `ARCHITECTURE.md` — Architecture documentation with sequence diagrams.
-- `CHANGELOG.md` — Release notes (extensive).
-- `MIGRATING.md` — Migration guides for older versions.
-- `RELEASE.md` — Release process (GitHub Actions and root `VERSION` file).
-- `CONTRIBUTING.md` — Contribution guidelines.
-
-## Code style, quality, and validation
-
-- **Lint & format tools**:
-  - SwiftFormat: configured in project.
-  - SwiftLint: configured in project.
-  - **Primary enforcement tool**: `trunk check` (via Trunk.io). If Trunk unavailable, fall back to `swiftformat .` && `swiftlint`.
-  - Important: Only add comments if absolutely necessary. If you're adding comments, review why the code is hard to reason with and rewrite that first.
-
-- **Strict post-change validation rule (always follow this)**:
-  After **any** code change, refactor, or addition — even small ones — you **must** run the full validation sequence:
-  1. `trunk check` — to lint, format-check, and catch style/quality issues.
-  2. Build the SDK: via Xcode or `xcodebuild` for both iOS and tvOS.
-  3. Run unit tests: both Objective-C and Swift test suites in `UnitTests/`.
-  4. `pod lib lint` with `--include-podspecs` for Swift + ObjC + umbrella (see Quick Start) — verify CocoaPods specs.
-  5. If change affects code, assets, or dependencies: check coverage via `Scripts/check_coverage.sh`.
-  - Only propose / commit changes if all steps pass cleanly.
-  - If `trunk check` suggests auto-fixes, apply them first and re-validate.
-  - Never bypass this — it's required to maintain SDK stability, footprint, and public API quality.
-
-- **Style preferences**:
-  - Objective-C: follow Apple's Coding Guidelines for Cocoa.
-  - Swift: prefer `let` over `var`; use value types where possible.
-  - Write thorough documentation for all public APIs.
-  - Avoid force-unwraps in Swift; use proper error handling in Objective-C.
-
-- **Testing expectations**:
-  - Unit tests in `UnitTests/ObjCTests/` and `UnitTests/SwiftTests/`.
-  - Mocks in `UnitTests/Mocks/`.
-  - Integration tests in `IntegrationTests/`.
-  - Code coverage tracked via `Scripts/check_coverage.sh`.
-  - After changes, always re-run affected tests + full suite if core/shared code is touched.
-
-- **CHANGELOG.md maintenance**:
-  - For **substantial changes**, **always add a clear entry** to `CHANGELOG.md`.
-  - Use standard categories: `Added`, `Changed`, `Deprecated`, `Fixed`, `Removed`, `Security`.
-  - Keep entries concise and written in imperative mood.
-  - Update `CHANGELOG.md` **before** finalizing a change.
-  - Never auto-generate or hallucinate changelog entries — flag for human review.
-
-## Pull request and branching
-
-- Follow mParticle's standard PR and branching conventions.
-
-## External Resources
-
-- [mParticle Apple SDK Documentation](https://docs.mparticle.com/developers/sdk/ios/)
-- [Rokt mParticle Integration Docs](https://docs.rokt.com/developers/integration-guides/rokt-ads/customer-data-platforms/mparticle/)
-- [ARCHITECTURE.md](./ARCHITECTURE.md) — SDK architecture and sequence diagrams.
+1. **The analyzer job fails on any new clang warning.** `run-analyzer` filters four known warning
+   strings out of the `xcodebuild analyze` log and fails if any `: warning:` line survives
+   (`.github/workflows/build-and-lint.yml`). A warning you would normally ignore breaks the build.
+2. **The custom `mparticle-api-key-check` trunk linter over-matches.** Its pattern
+   `[a-z]{2}[0-9]*-[0-9a-f]{32}` runs against every file and also matches `md5-…` and `sha256-…`
+   digests, so a lockfile integrity hash or a hex test fixture fails `trunk check` as a suspected
+   API key.
+3. **A clean `size-report` is not proof of no size change.** The base-branch measurement is
+   `continue-on-error`, and a base build that fails is reported as `N/A (new baseline)` rather than
+   failing the job.
+4. **The root `Package.swift` is compiled by exactly one PR job.** `integration-tests` pulls it in
+   through Tuist (`.package(path: "../")`); nothing else builds the SwiftPM graph, so an SPM-only
+   break survives every other check.
+5. Integration tests fail on an unmatched request but only _warn_ on a recorded WireMock mapping
+   the app never calls (`IntegrationTests/run_integration_tests_ci.sh`).
+6. `RNExample` is not built on PRs - `build-secondary-platforms` is commented out of
+   `.github/workflows/pull-request.yml`.
+7. `ARCHITECTURE.md` is two diagram images and no prose. There is no written architecture document.


### PR DESCRIPTION
`AGENTS.md` is loaded into every agent session (and, via the one-line `CLAUDE.md` import, into
every Claude Code session too). It competes for context with the task, so it should hold only what
an agent cannot get by reading the repository. This rewrites it on that principle: derivable
material out, verified traps in.

Only `AGENTS.md` changes. No code, config, CI or docs elsewhere.

## Size against the three budgets

| | Lines | Size |
| --- | --- | --- |
| Before | 163 | 9.00 KiB |
| After | 146 | 9.98 KiB |

- **Claude Code** (target under 200 lines): 163 → 146.
- **Codex** (`project_doc_max_bytes` 32 KiB for the whole merged root→cwd chain): the chain here is
  `CLAUDE.md` (48 B) + `AGENTS.md`, so ~10 KiB either way - a rounding error against the limit.
- **Copilot** ("no longer than 2 pages"): closer, not yet there.

Lines came down; bytes went up by about 1 KiB. Much of the old file was content an agent can derive
for itself, and the space that freed went back into traps it cannot, which are denser per line. The
win is signal per line, not file size - and against the Codex budget 9 KiB and 10 KiB are the same
number.

## `CLAUDE.md`

Already correct — 48 bytes, a `markdownlint-disable` comment plus a bare `@AGENTS.md` import.
Untouched. Worth saying out loud so nobody "helpfully" replaces it with a duplicated copy later:
a second copy of the guidance is the failure mode, because the two then drift.

## What was deleted, and why

**Config already states it, so the config is the better source**

- The Xcode/iOS/tvOS deployment-target numbers. `Package.swift` and all three podspecs pin them.
  The *policy* ("do not raise the floor") is kept; the numbers are not, because a number in prose
  can disagree with the pin and a pointer cannot.
- SwiftFormat/SwiftLint "configured in project". `.trunk/trunk.yaml` enables and pins them. Replaced
  by the non-obvious half: **where** those configs live, which is not the repo root.
- The mandatory 5-step post-change validation ritual. Superseded by a commands list plus the traps
  that actually make those commands lie.

**Derivable by reading the repo or running `ls`**

- The `Key paths` directory tree, the glossary of mParticle terms, and the "About mParticle SDKs" /
  "Project overview" sections (which restated each other and `README.md`).

**Counts and drift-prone numbers**

- "40+ subdirectories", "`Include/` — 46 files", "`Example/` (11 subdirectories)". `Include/` has 44
  files today, so one of those was already wrong. No count is load-bearing enough to maintain.

**Generic advice**

- "Ensure changes work on both iOS and tvOS", "always re-run affected tests", "run lint before
  commit", "prioritize thread-safety". Models do these anyway; they dilute the rules that matter.

## Stale claims corrected

1. **`Rokt_WidgetTests/` does not exist in this repo.** The old Quick Start told agents to run unit
   tests there — it looks like it arrived from a different SDK. The real targets are
   `mParticle-Apple-SDKTests` and `mParticle-Apple-SDK-SwiftTests`.
2. **`Libraries/` is not at the repo root.** "Never modify vendored libraries in `Libraries/`"
   pointed at a path that does not exist; the vendored code is `mParticle-Apple-SDK/Libraries/`.
3. **"Always add a `CHANGELOG.md` entry" is the wrong instruction.** `.github/workflows/release-draft.yml`
   generates release sections from conventional-commit PR titles at release time
   (`exclude-types: chore,ci,test,build`) and inserts them *below* the `## [Unreleased]` heading
   without consuming it — so a hand-written entry there is never folded into a release. The new file
   says the PR title is the changelog entry.
4. **`Kits/` was missing entirely.** The old `Key paths` listed `mParticle-Apple-SDK/Kits/` (the kit
   *infrastructure*) but not the root `Kits/` monorepo, or `Kits/matrix.json`, or `Tests/`.
5. **"mParticle Apple SDK (Rokt fork)"** — this repo is not a fork of anything; dropped.
6. **`ARCHITECTURE.md` was described as "Architecture documentation with sequence diagrams".** It is
   272 bytes: two image embeds, no prose. Now stated as such so nobody spends a read on it.

## Traps added, with evidence

1. **Two test schemes, one testable each.** `-scheme mParticle-Apple-SDK` runs only
   `mParticle-Apple-SDKTests`; the Swift suite is reachable only via `-scheme mParticle-Apple-SDK-Swift`.
   Evidence: the `<Testables>` block of each of `mParticle-Apple-SDK.xcodeproj/xcshareddata/xcschemes/*.xcscheme`,
   and the `scheme: [mParticle-Apple-SDK, mParticle-Apple-SDK-Swift]` matrix in
   `.github/workflows/native-tests.yml:18`.
2. **Lint configs are not at the repo root.** `.trunk/configs/.swiftlint.yml` and
   `.trunk/configs/.swiftformat`; no root copies exist. A bare `swiftlint` / `swiftformat .` from the
   root cannot find them and silently applies tool defaults — which is what the old file recommended
   as a fallback. `trunk check` is the only faithful path.
3. **`pod lib lint` needs `--include-podspecs`** because the three podspecs depend on each other by
   exact version: `mParticle-Apple-SDK.podspec:24`, `mParticle-Apple-SDK-ObjC.podspec:37`.
4. **`Scripts/check_coverage.sh` cannot fail.** `Scripts/check_coverage.py` appends to `failed_files`
   and never calls `sys.exit`, and the wrapper's last statement is `rm -rf venv`
   (`Scripts/check_coverage.sh:23`). Nothing in `.github/` invokes it. The old file listed it as a
   required validation step, so an agent could "pass coverage" without a coverage gate existing. It
   also only runs with `Scripts/` as cwd (`-project ../mParticle-Apple-SDK.xcodeproj`,
   `python check_coverage.py`).
5. **Two Xcode pins, not one.** `build-and-lint.yml:14`, `native-tests.yml:8` and
   `size-report.yml:12` pin one version; `integration-tests.yml:11` and `build-kits.yml:36`/`:58`
   (including the `verify-kit-xcframework-import` job at `build-kits.yml:195`) pin a newer one. The
   old file said "Xcode 16.4+", which is not sufficient for the kit or integration jobs. The new file
   names the jobs and the env var rather than the numbers, so a pin bump cannot make it wrong.
6. **`CONTRIBUTING.md`'s test command does not work** — it names an `.xcworkspace` (none exists in
   the repo) and a scheme `mParticle-Apple-SDK-iOS` (`xcodebuild -list` reports only
   `mParticle-Apple-SDK` and `mParticle-Apple-SDK-Swift`). See "for the team to decide" below.
7. **Three consumers decide header publicness separately.**
   `mParticle-Apple-SDK/Include/` covers SwiftPM (`Package.swift:38`, `publicHeadersPath: "Include"`)
   and CocoaPods (`mParticle-Apple-SDK-ObjC.podspec:33`, a glob over `Include/*.h`), but the Xcode
   framework target keeps its own list: `project.pbxproj` carries `ATTRIBUTES = (Public, )` per file.
   The two lists agree today, which is exactly why a miss is easy to ship.
8. **`Kits/matrix.json` is the only registry.** A kit absent from it is not built, not pod-linted and
   not mirrored — `build-kits.yml:21-22` derives both matrices from that file, and
   `release-draft.yml:79` reads it to bump kit podspec versions.
9. **The analyzer job fails on any surviving clang warning** after four hardcoded filters
   (the `run-analyzer` job, `build-and-lint.yml:64`).
10. **`mparticle-api-key-check` over-matches.** `.trunk/trunk.yaml:55` greps every file for
    `[a-z]{2}[0-9]*-[0-9a-f]{32}`. Verified locally that this also matches
    `md5-<32 hex>` and `sha256-<32 hex>`, so a lockfile integrity hash or a hex fixture trips it as a
    suspected API key.
11. **A clean `size-report` is not proof of no size change** — the base-branch measurement is
    `continue-on-error: true` (`size-report.yml:37`) and a failed base build is reported as
    `N/A (new baseline)`.
12. **The root `Package.swift` is compiled by exactly one PR job.** `IntegrationTests/Project.swift:6`
    declares `.package(path: "../")`, so `integration-tests` is the only job that builds the SwiftPM
    graph; every other job builds the `.xcodeproj`. An SPM-only break passes the rest of CI.
13. **CI is not the merge gate.** The ruleset covering `main` and `workstation/**` has no
    `required_status_checks` rule at all; it requires one CODEOWNERS approval, resolution of every
    review thread, and `require_extra_approval_for_unattributed_changes` — the last of which is worth
    writing down in a repo where agents commit, since a commit email not tied to a GitHub account
    silently raises the bar to two approvals. `dismiss_stale_reviews_on_push` is on and rebase merges
    are not allowed.
14. **Fork PRs cannot go green.** `size-report` ends by writing a PR comment
    (`size-report.yml:263`), and a `pull_request` event from a fork gets a read-only token whatever
    the workflow's `permissions:` block asks for (`size-report.yml:9`). Flagged so nobody debugs it
    as a regression.
15. **`workstation/*` are long-lived integration branches**, covered by the same ruleset and by the
    `push` trigger in `pull-request.yml:9`; a stack of migration PRs may be based on one rather than
    on `main`.
16. Integration tests fail on an unmatched request but only *warn* on a recorded mapping the app
    never calls (`IntegrationTests/run_integration_tests_ci.sh`, `verify_wiremock_results`).
17. **The workflow list and the tree disagree, in both directions.** `cross-platform-tests.yml` is
    in the tree but `disabled_manually` in repository settings, so reading it as a live gate is
    wrong; and `gh workflow list --all` reports a `release-ecosystem-from-main.yml` that
    `git ls-tree -r origin/main .github/workflows/` does not contain — the file exists only on
    unmerged branches, so its Actions entry is a stale registration. `RNExample` is separately not
    built on PRs, because `build-secondary-platforms` is commented out in `pull-request.yml:32-33`.
    (Corrected in a follow-up commit: an earlier revision of this file described both as workflow
    files in the tree that never run, which is true of the first and not the second.)
18. **A red or `cancelled` check often is not a test result.** `build-kits / Pod Lint <kit>` resolves
    third-party pods through the CocoaPods CDN and fails as a batch when that CDN errors; and a
    `cancelled` job is normally a per-leg `timeout-minutes` expiry in `native-tests.yml:12`, or a run
    superseded by a later push (`pull-request.yml:18-20` sets `concurrency: cancel-in-progress: true`
    keyed on the PR number). Note `native-tests.yml:14` sets `fail-fast: false`, so a failing leg does
    *not* cancel its siblings - I assumed it did until I read it. All three observed on this branch.

## What was verified how

- `xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme mParticle-Apple-SDK -destination 'generic/platform=iOS' build`
  run locally on Xcode 16.4: **BUILD SUCCEEDED**, one warning, and it is one of the four the
  analyzer job already filters.
- `xcodebuild -list` for the scheme and target names.
- `trunk fmt` and `trunk check` clean on `AGENTS.md` and `CLAUDE.md` (this repo lints Markdown with
  `markdownlint` + `prettier`).
- Every backticked path in the new file asserted to exist, except the four named as *not* existing.
- The API-key false positive reproduced end to end: a scratch file containing
  `md5-<32 hex>` makes `trunk check --filter=mparticle-api-key-check` report a high-severity
  `mparticle-api-key-check/error`.
- The unit-test suites and `pod lib lint` were **not** run locally (no CocoaPods on the machine, and
  the test matrix needs simulators this box cannot host for tvOS). Those claims come from the scheme
  definitions and workflow files, cited above.

## CI on this PR

The diff is Markdown-only, so it cannot change a build, and every job has been green on at least one
run of this branch - `trunk-check`, `xcode-build`, `run-analyzer`, `pod-lint`, the iOS integration
tests, all four `native-tests` legs and every `build-kits` job. Which ones are red varies run to run,
for three reasons, none of them this diff:

- `size-report / measure-size` fails at exactly the `Create or update PR comment` step, on every run.
  That is trap 14 above, observed rather than predicted; nothing a fork PR can do will change it.
- `build-kits / Pod Lint <kit>` fails as a batch for the kits with third-party CocoaPods
  dependencies when the CocoaPods CDN errors, all three built-in retries exhausted:
  `CDN: trunk URL couldn't be downloaded: .../BrazeUI/15.0.0/BrazeUI.podspec.json Response: 400`.
  The same jobs were green on the previous commit of this branch.
- `native-tests / native-unit-tests (*, mParticle-Apple-SDK)` - the ObjC suite - is flaky on both
  platforms, most recently on
  `-[MPRoktTests testSelectPlacementsWithNilMappingAndNilOnEventDoesNotCrash]`, having passed on both
  platforms on an earlier commit of this branch. Recent `Pull request` runs include failures on
  `main` itself, and there are open PRs about flaky concurrency tests and simulator hangs.

Not chased, per the above. `mergeStateStatus` is `BLOCKED` on the review requirement, not on checks -
the ruleset requires none.

## For the team to decide — deliberately not fixed here

1. **`Scripts/check_coverage.py` never fails.** It computes `failed_files` against a 90% threshold
   and then discards it. Either add the `sys.exit(1)` and wire the script into a workflow, or delete
   the script — right now it is a coverage gate in name only. (There is also a latent
   `full_path.endwith` typo on the `files_to_check` path, unreachable today because that set is
   always empty.) That is a CI change, not a docs change.
2. **`CONTRIBUTING.md`'s testing section is wrong** for the current project layout, and it is the
   document outside contributors are pointed at. Worth a one-line fix by someone who owns it.
3. **`ARCHITECTURE.md`** is two images. If prose is wanted, that is a separate PR; if not, consider
   folding the diagrams into `README.md`.
4. **`.trunk/trunk.yaml:75`** ignores `kits/**/CHANGELOG.md` in lowercase while the directory is
   `Kits/`. It works on the case-insensitive macOS runners in use today; it would stop working on a
   case-sensitive filesystem.
5. **Sibling SDK repos.** I can only see this one. If `mparticle-android-sdk` or the kit repos carry
   a copy of this `AGENTS.md`, the same deletions and traps need mirroring by hand — nothing syncs
   them. This file has no `<!-- COMMON SECTION -->` markers, so nothing was trimmed inside a shared
   block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


