### PR TITLE
chore: add CODEOWNERS to mirrored kit subtrees

### DIFF
--- a/Kits/adjust/adjust-5/.github/CODEOWNERS
+++ b/Kits/adjust/adjust-5/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/adobe/adobe-5/.github/CODEOWNERS
+++ b/Kits/adobe/adobe-5/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/appsflyer/appsflyer-6/.github/CODEOWNERS
+++ b/Kits/appsflyer/appsflyer-6/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/apptentive/apptentive-6/.github/CODEOWNERS
+++ b/Kits/apptentive/apptentive-6/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/apptentive/apptentive-7/.github/CODEOWNERS
+++ b/Kits/apptentive/apptentive-7/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/apptimize/apptimize-3/.github/CODEOWNERS
+++ b/Kits/apptimize/apptimize-3/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/branchmetrics/branchmetrics-3/.github/CODEOWNERS
+++ b/Kits/branchmetrics/branchmetrics-3/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/braze/braze-12/.github/CODEOWNERS
+++ b/Kits/braze/braze-12/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/braze/braze-13/.github/CODEOWNERS
+++ b/Kits/braze/braze-13/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/braze/braze-14/.github/CODEOWNERS
+++ b/Kits/braze/braze-14/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/braze/braze-17/.github/CODEOWNERS
+++ b/Kits/braze/braze-17/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/clevertap/clevertap-7/.github/CODEOWNERS
+++ b/Kits/clevertap/clevertap-7/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/comscore/comscore-6/.github/CODEOWNERS
+++ b/Kits/comscore/comscore-6/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-11/.github/CODEOWNERS
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-11/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/google-analytics-firebase-ga4/firebase-ga4-12/.github/CODEOWNERS
+++ b/Kits/google-analytics-firebase-ga4/firebase-ga4-12/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/google-analytics-firebase/firebase-11/.github/CODEOWNERS
+++ b/Kits/google-analytics-firebase/firebase-11/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/google-analytics-firebase/firebase-12/.github/CODEOWNERS
+++ b/Kits/google-analytics-firebase/firebase-12/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/iterable/iterable-6/.github/CODEOWNERS
+++ b/Kits/iterable/iterable-6/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/kochava/kochava-9/.github/CODEOWNERS
+++ b/Kits/kochava/kochava-9/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/kochava/kochava-no-tracking-9/.github/CODEOWNERS
+++ b/Kits/kochava/kochava-no-tracking-9/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/leanplum/leanplum-6/.github/CODEOWNERS
+++ b/Kits/leanplum/leanplum-6/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/localytics/localytics-6/.github/CODEOWNERS
+++ b/Kits/localytics/localytics-6/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/localytics/localytics-7/.github/CODEOWNERS
+++ b/Kits/localytics/localytics-7/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/onetrust/onetrust/.github/CODEOWNERS
+++ b/Kits/onetrust/onetrust/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/optimizely/optimizely-4/.github/CODEOWNERS
+++ b/Kits/optimizely/optimizely-4/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/optimizely/optimizely-5/.github/CODEOWNERS
+++ b/Kits/optimizely/optimizely-5/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/radar/radar-3/.github/CODEOWNERS
+++ b/Kits/radar/radar-3/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/rokt-sdk-plus/rokt-sdk-plus-ios/.github/CODEOWNERS
+++ b/Kits/rokt-sdk-plus/rokt-sdk-plus-ios/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ROKT/sdk-engineering

--- a/Kits/rokt/rokt/.github/CODEOWNERS
+++ b/Kits/rokt/rokt/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/singular/singular-12/.github/CODEOWNERS
+++ b/Kits/singular/singular-12/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/urbanairship/urbanairship-19/.github/CODEOWNERS
+++ b/Kits/urbanairship/urbanairship-19/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team

--- a/Kits/urbanairship/urbanairship-20/.github/CODEOWNERS
+++ b/Kits/urbanairship/urbanairship-20/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mparticle-integrations/sdk-team


### PR DESCRIPTION
## Background
- The versioned kit subtrees under `Kits/` are published to standalone mirror repos by the `mirror-and-release-kits` job in `release-publish.yml`, which runs `git subtree split` and pushes the subtree as the mirror's root.
- None of those 32 mirror repos currently has a `CODEOWNERS` file, so review is unassigned on every one of them. Because the mirror is overwritten on each release, the file has to originate here rather than be added to the mirror directly.

## What Has Changed
- Added `.github/CODEOWNERS` to each of the 32 kit subtrees listed in `Kits/matrix.json`. After the next release each lands at the mirror's root and takes effect there.
- The owning team matches each kit's destination org, since GitHub ignores a `CODEOWNERS` entry naming a team outside the repo's own org:
  - 31 kits → `@mparticle-integrations/sdk-team`
  - `rokt-sdk-plus-ios` → `@ROKT/sdk-engineering` (the one entry with `dest_org: ROKT`)
- No effect on this repo's own review routing — GitHub only reads `CODEOWNERS` from the root, `.github/`, or `docs/`, so these nested files are inert here.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- `trunk check` passes on all 32 files. No podspec picks them up (`source_files` globs `Sources/**`), and no workflow path filters are affected.
- Follow-up, not fixable here: `@mparticle-integrations/sdk-team` has no access to `mparticle-apple-integration-apptentive-7`, so its `CODEOWNERS` will be ignored until the team is granted write on that repo.
