### PR TITLE
fix: use supplied Rokt kit configuration

### DIFF
--- a/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
+++ b/Kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m
@@ -5,9 +5,6 @@
 // Kit version
 static NSString * const kMPRoktKitVersion = @"9.4.1";
 
-// Constants for kit configuration keys
-static NSString * const kMPKitConfigurationIdKey = @"id";
-static NSString * const kMPRemoteConfigKitConfigurationKey = @"as";
 static NSString * const kMPAttributeMappingSourceKey = @"map";
 static NSString * const kMPAttributeMappingDestinationKey = @"value";
 
@@ -343,11 +340,10 @@ static __weak MPKitRokt *roktKit = nil;
 + (NSDictionary<NSString *, NSString *> *)mapAttributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes filteredUser:(FilteredMParticleUser * _Nonnull)filteredUser {
     NSArray<NSDictionary<NSString *, NSString *> *> *attributeMap = nil;
     
-    // Get the kit configuration
-    NSDictionary *roktKitConfig = [MPKitRokt getKitConfig];
+    NSDictionary *configuration = roktKit.configuration;
     
     // Return original attributes if no Rokt Kit configuration found
-    if (!roktKitConfig) {
+    if (!configuration) {
         return attributes;
     }
     
@@ -356,7 +352,7 @@ static __weak MPKitRokt *roktKit = nil;
     NSData *dataAttributeMap;
     // Rokt Kit is available though there may not be an attribute map
     attributeMap = @[];
-    id configJSONString = roktKitConfig[kMPRemoteConfigKitConfigurationKey][kMPPlacementAttributesMapping];
+    id configJSONString = configuration[kMPPlacementAttributesMapping];
     if (configJSONString != nil && configJSONString != [NSNull null]) {
         strAttributeMap = [configJSONString stringByRemovingPercentEncoding];
         dataAttributeMap = [strAttributeMap dataUsingEncoding:NSUTF8StringEncoding];
@@ -513,27 +509,12 @@ static __weak MPKitRokt *roktKit = nil;
 
 #pragma mark - Private Helper Methods
 
-/// Retrieves the Rokt Kit configuration from the kit container.
-/// @return The Rokt Kit configuration dictionary, or nil if Rokt Kit is not configured.
-+ (NSDictionary * _Nullable)getKitConfig {
-    NSArray<NSDictionary *> *kitConfigs = [MParticle sharedInstance].kitContainer_PRIVATE.originalConfig.copy;
-    for (NSDictionary *kitConfig in kitConfigs) {
-        if ([kitConfig[kMPKitConfigurationIdKey] integerValue] == kMPRoktKitCode) {
-            return kitConfig;
-        }
-    }
-   [MPKitRokt MPLog:@"Rokt Kit is not configured in kit container"];
-    return nil;
-}
-
 /// Retrieves the configured identity type to use for hashed email from the Rokt Kit configuration.
 /// The hashed email identity type is determined by dashboard settings and may vary (e.g., CustomerId, Other, etc.).
 /// @return The NSNumber representing the MPIdentity type for hashed email, or nil if not configured.
 + (NSNumber * _Nullable)getRoktHashedEmailUserIdentityType {
-    NSDictionary *roktKitConfig = [MPKitRokt getKitConfig];
-    
     // Get the string representing which identity to use and convert it to the key (NSNumber)
-    NSString *hashedIdentityTypeString = roktKitConfig[kMPRemoteConfigKitConfigurationKey][kMPHashedEmailUserIdentityType];
+    NSString *hashedIdentityTypeString = roktKit.configuration[kMPHashedEmailUserIdentityType];
     NSNumber *hashedIdentityTypeNumber = [MPKitRokt identityTypeForString:hashedIdentityTypeString.lowercaseString];
     
     return hashedIdentityTypeNumber;

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -31,8 +31,6 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 + (void)handleHashedEmail:(NSMutableDictionary<NSString *, NSString *> * _Nullable)attributes;
 
-+ (NSDictionary *)getKitConfig;
-
 + (NSNumber *)getRoktHashedEmailUserIdentityType;
 
 + (NSString *)stringForIdentityType:(MPIdentity)identityType;
@@ -908,53 +906,67 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 }
 
 - (void)testGetRoktHashedEmailUserIdentityTypeOther4 {
-    // Test case 1: When kit configuration exists with hashed email identity type
-    NSDictionary *roktKitConfig = @{
-        @"id": @(kMPRoktKitCode),
-        @"as": @{
-            kMPRoktHashedEmailUserIdentityType: @"other4"
-        }
+    NSDictionary *configuration = @{
+        @"accountId": @"test_account_id",
+        kMPRoktHashedEmailUserIdentityType: @"other4"
     };
-    
-    // Mock the MParticle shared instance and kit container
-    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
-    [[[mockMPKitRoktClass stub] andReturn:roktKitConfig] getKitConfig];
-    
-    // Call the method and verify result
+
+    [self.kitInstance didFinishLaunchingWithConfiguration:configuration];
+
     NSNumber *result = [MPKitRokt getRoktHashedEmailUserIdentityType];
     XCTAssertEqualObjects(result, @(MPIdentityOther4), @"Should return MPIdentityOther4 when configured with 'other4'");
-    
-    [mockMPKitRoktClass stopMocking];
 }
 
 - (void)testGetRoktHashedEmailUserIdentityTypeConfigNil {
-    // Test case 2: When kit config nil
-    // Mock the MParticle shared instance and kit container
-    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
-    [[[mockMPKitRoktClass stub] andReturn:nil] getKitConfig];
-    
     NSNumber *defaultResult = [MPKitRokt getRoktHashedEmailUserIdentityType];
     XCTAssertNil(defaultResult, @"Should return nil when when no configuration exists");
-    
-    [mockMPKitRoktClass stopMocking];
 }
 
 - (void)testGetRoktHashedEmailUserIdentityTypeNil {
-    // Mock the MParticle shared instance and kit container
-    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
-    // Test case 3: When kit config exists but no hashed email identity type specified
-    NSDictionary *roktKitConfigNoHash = @{
-        @"id": @(kMPRoktKitCode),
-        @"as": @{
-            // No kMPRoktHashedEmailUserIdentityType specified
-        }
-    };
-    [[[mockMPKitRoktClass stub] andReturn:roktKitConfigNoHash] getKitConfig];
-    
+    [self.kitInstance didFinishLaunchingWithConfiguration:self.configuration];
+
     NSNumber *noHashResult = [MPKitRokt getRoktHashedEmailUserIdentityType];
     XCTAssertNil(noHashResult, @"Should return nil when hashed email identity type not specified");
-    
-    [mockMPKitRoktClass stopMocking];
+}
+
+- (void)testConfigurationUpdateChangesHashedEmailUserIdentityType {
+    NSDictionary *launchConfiguration = @{
+        @"accountId": @"test_account_id",
+        kMPRoktHashedEmailUserIdentityType: @"other4"
+    };
+    [self.kitInstance didFinishLaunchingWithConfiguration:launchConfiguration];
+    XCTAssertEqualObjects([MPKitRokt getRoktHashedEmailUserIdentityType], @(MPIdentityOther4));
+
+    self.kitInstance.configuration = @{
+        @"accountId": @"test_account_id",
+        kMPRoktHashedEmailUserIdentityType: @"other7"
+    };
+
+    XCTAssertEqualObjects([MPKitRokt getRoktHashedEmailUserIdentityType], @(MPIdentityOther7));
+}
+
+- (void)testStopAndRelaunchReplaceHashedEmailUserIdentityType {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+    OCMStub([mockRoktSDK close]);
+
+    NSDictionary *launchConfiguration = @{
+        @"accountId": @"test_account_id",
+        kMPRoktHashedEmailUserIdentityType: @"other4"
+    };
+    [self.kitInstance didFinishLaunchingWithConfiguration:launchConfiguration];
+    XCTAssertEqualObjects([MPKitRokt getRoktHashedEmailUserIdentityType], @(MPIdentityOther4));
+
+    [self.kitInstance stop];
+    XCTAssertNil([MPKitRokt getRoktHashedEmailUserIdentityType]);
+
+    NSDictionary *relaunchConfiguration = @{
+        @"accountId": @"test_account_id",
+        kMPRoktHashedEmailUserIdentityType: @"other9"
+    };
+    [self.kitInstance didFinishLaunchingWithConfiguration:relaunchConfiguration];
+
+    XCTAssertEqualObjects([MPKitRokt getRoktHashedEmailUserIdentityType], @(MPIdentityOther9));
+    [mockRoktSDK stopMocking];
 }
 
 #pragma mark - logSelectPlacementEvent tests
@@ -1135,17 +1147,12 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 }
 
 - (void)testMapAttributesWithNewConfigurationStructure {
-    // Test the mapAttributes method with the new nested configuration structure
-    NSDictionary *roktKitConfig = @{
-        @"id": @(kMPRoktKitCode),
-        @"as": @{
-            @"placementAttributesMapping": @"[{\"jsmap\":null,\"map\":\"f.name\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"firstname\"},{\"jsmap\":null,\"map\":\"zip\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"billingzipcode\"},{\"jsmap\":null,\"map\":\"l.name\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"lastname\"}]"
-        }
+    NSDictionary *configuration = @{
+        @"accountId": @"test_account_id",
+        @"placementAttributesMapping": @"[{\"jsmap\":null,\"map\":\"f.name\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"firstname\"},{\"jsmap\":null,\"map\":\"zip\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"billingzipcode\"},{\"jsmap\":null,\"map\":\"l.name\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"lastname\"}]"
     };
-    
-    // Mock the kit configuration
-    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
-    [[[mockMPKitRoktClass stub] andReturn:roktKitConfig] getKitConfig];
+
+    [self.kitInstance didFinishLaunchingWithConfiguration:configuration];
     
     // Create test input attributes
     NSDictionary<NSString *, NSString *> *inputAttributes = @{
@@ -1174,14 +1181,9 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     XCTAssertNil(result[@"zip"], @"Original zip key should be removed");
     XCTAssertNil(result[@"l.name"], @"Original l.name key should be removed");
     
-    [mockMPKitRoktClass stopMocking];
 }
 
 - (void)testMapAttributesWithNoConfiguration {
-    // Test mapAttributes when no kit configuration exists
-    id mockMPKitRoktClass = OCMClassMock([MPKitRokt class]);
-    [[[mockMPKitRoktClass stub] andReturn:nil] getKitConfig];
-    
     NSDictionary<NSString *, NSString *> *inputAttributes = @{
         @"email": @"test@example.com",
         @"name": @"Test User"
@@ -1195,7 +1197,6 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
     // Should return original attributes unchanged
     XCTAssertEqualObjects(result, inputAttributes, @"Should return original attributes when no configuration exists");
     
-    [mockMPKitRoktClass stopMocking];
 }
 
 - (void)testAddIdentityAttributesMpidWithNilUserId {


### PR DESCRIPTION
## Background

Rokt already receives its configuration through the kit lifecycle. Reading the same data back through the core kit container creates an unnecessary dependency and can leave refreshed or switched workspace configuration out of sync.

## What Has Changed

- Use the configuration supplied to the Rokt kit as its source of truth.
- Read placement mappings and hashed-email settings directly from that configuration.
- Preserve later configuration updates through `setConfiguration:`.
- Clear stored configuration when the kit stops.
- Replace mocked-container coverage with launch, refresh, missing-configuration, and stop/relaunch tests.

## Screenshots/Video

N/A — no visual changes.

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [x] Tested locally

## Testing

- Trunk checks
- Rokt unit tests against the local core SDK
- Core and Rokt CocoaPods lint
- iOS SDK build and unit tests
