### PR TITLE
feat: add typed kit dispatch contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 ### Core
 
+#### Added
+
+- Declare Rokt session lifecycle callbacks in the supported kit protocol.
+
 #### Fixed
 
 - `MPRokt.selectPlacements` and `MPRokt.selectShoppableAds` now deliver a `RoktPlacementFailure` event to the caller's `onEvent` handler when the Rokt kit configuration is unavailable. Previously the call was dropped with only a log message, leaving callers waiting on a callback that never arrived. ([#814](https://github.com/mParticle/mparticle-apple-sdk/pull/814))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 ### Core
 
-#### Added
-
-- Declare Rokt session lifecycle callbacks in the supported kit protocol.
-
 #### Fixed
 
 - `MPRokt.selectPlacements` and `MPRokt.selectShoppableAds` now deliver a `RoktPlacementFailure` event to the caller's `onEvent` handler when the Rokt kit configuration is unavailable. Previously the call was dropped with only a log message, leaving callers waiting on a callback that never arrived. ([#814](https://github.com/mParticle/mparticle-apple-sdk/pull/814))

--- a/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
+++ b/Kits/rokt/rokt/Tests/mParticle-RoktObjCTests/mParticle_RoktTests.m
@@ -7,6 +7,11 @@
 static NSInteger const kMPRoktKitCode = 181;
 static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserIdentityType";
 
+@protocol MPRoktSDKClassMethods
++ (void)close;
++ (void)clearSession;
+@end
+
 @interface MPKitRokt ()
 
 - (MPKitExecStatus *)selectPlacementsWithIdentifier:(NSString * _Nullable)identifier
@@ -116,7 +121,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 - (void)testStopResetsKitState {
     id mockRoktSDK = OCMClassMock([Rokt class]);
-    OCMExpect([mockRoktSDK close]);
+    OCMExpect([(Class<MPRoktSDKClassMethods>)mockRoktSDK close]);
 
     [self.kitInstance didFinishLaunchingWithConfiguration:self.configuration];
     [self.kitInstance start];
@@ -144,7 +149,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 - (void)testStartCanBeCalledAgainAfterStop {
     id mockRoktSDK = OCMClassMock([Rokt class]);
-    OCMStub([mockRoktSDK close]);
+    OCMStub([(Class<MPRoktSDKClassMethods>)mockRoktSDK close]);
 
     [self.kitInstance didFinishLaunchingWithConfiguration:self.configuration];
     [self.kitInstance start];
@@ -947,7 +952,7 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 
 - (void)testStopAndRelaunchReplaceHashedEmailUserIdentityType {
     id mockRoktSDK = OCMClassMock([Rokt class]);
-    OCMStub([mockRoktSDK close]);
+    OCMStub([(Class<MPRoktSDKClassMethods>)mockRoktSDK close]);
 
     NSDictionary *launchConfiguration = @{
         @"accountId": @"test_account_id",
@@ -1059,14 +1064,9 @@ static NSString * const kMPRoktHashedEmailUserIdentityType = @"hashedEmailUserId
 - (void)testClearSessionForwardsToRoktSDK {
     id mockRoktSDK = OCMClassMock([Rokt class]);
 
-    OCMExpect([mockRoktSDK clearSession]);
+    OCMExpect([(Class<MPRoktSDKClassMethods>)mockRoktSDK clearSession]);
 
-    // Invoked dynamically on purpose. Declaring -clearSession on MPKitRokt here would put a
-    // second `clearSession` with a different return type in this translation unit, alongside
-    // Rokt's +clearSession, and sending it to OCMock's id receiver above then fails to compile
-    // with "multiple methods named 'clearSession' ... mismatched result". A selector carries no
-    // return type, so this stays unambiguous.
-    MPKitExecStatus *status = [self.kitInstance performSelector:@selector(clearSession)];
+    MPKitExecStatus *status = [(id<MPKitProtocol>)self.kitInstance clearSession];
 
     XCTAssertNotNil(status);
     XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);

--- a/Tools/abi-baseline.txt
+++ b/Tools/abi-baseline.txt
@@ -369,6 +369,8 @@ METHOD|- (instancetype)initWithKitInstance:(id<MPKitProtocol>)kitInstance;
 METHOD|- (nonnull MPKitExecStatus *)beginLocationTracking:(MPLocationAccuracy)accuracy minDistance:(MPLocationDistance)distanceFilter;
 METHOD|- (nonnull MPKitExecStatus *)beginSession;
 METHOD|- (nonnull MPKitExecStatus *)beginTimedEvent:(nonnull MPEvent *)event;
+METHOD|- (nonnull MPKitExecStatus *)clearSession;
+METHOD|- (nonnull MPKitExecStatus *)close;
 METHOD|- (nonnull MPKitExecStatus *)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler;
 METHOD|- (nonnull MPKitExecStatus *)didBecomeActive;
 METHOD|- (nonnull MPKitExecStatus *)didFinishLaunchingWithConfiguration:(nonnull NSDictionary *)configuration;
@@ -415,6 +417,7 @@ METHOD|- (nonnull MPKitExecStatus *)setDeviceToken:(nonnull NSData *)deviceToken
 METHOD|- (nonnull MPKitExecStatus *)setKitAttribute:(nonnull NSString *)key value:(nullable id)value;
 METHOD|- (nonnull MPKitExecStatus *)setLocation:(nonnull MPLocation *)location;
 METHOD|- (nonnull MPKitExecStatus *)setOptOut:(BOOL)optOut;
+METHOD|- (nonnull MPKitExecStatus *)setSessionId:(nonnull NSString *)sessionId;
 METHOD|- (nonnull MPKitExecStatus *)setUserAttribute:(nonnull NSString *)key value:(nonnull id)value;
 METHOD|- (nonnull MPKitExecStatus *)setUserAttribute:(nonnull NSString *)key values:(nonnull NSArray *)values;
 METHOD|- (nonnull MPKitExecStatus *)setUserIdentity:(nullable NSString *)identityString identityType:(MPUserIdentity)identityType;

--- a/UnitTests/ObjCTests/MPKitContainerTests.m
+++ b/UnitTests/ObjCTests/MPKitContainerTests.m
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
+#import <objc/runtime.h>
 #import "mParticle.h"
 #import "MPKitContainer.h"
 #import "MPIConstants.h"
@@ -29,6 +30,25 @@
 #import "MPGDPRConsent.h"
 #import "MPUserDefaultsConnector.h"
 @import mParticle_Apple_SDK_Swift;
+
+static NSString *MPNormalizedMethodTypes(const char *types) {
+    NSString *methodTypes = [NSString stringWithUTF8String:types ?: ""];
+    return [[methodTypes componentsSeparatedByCharactersInSet:NSCharacterSet.decimalDigitCharacterSet]
+            componentsJoinedByString:@""];
+}
+
+static NSDictionary<NSString *, NSString *> *MPOptionalMethodTypes(Protocol *protocol) {
+    unsigned int count = 0;
+    struct objc_method_description *methods = protocol_copyMethodDescriptionList(protocol, NO, YES, &count);
+    NSMutableDictionary<NSString *, NSString *> *methodTypes = [NSMutableDictionary dictionaryWithCapacity:count];
+
+    for (unsigned int index = 0; index < count; index++) {
+        methodTypes[NSStringFromSelector(methods[index].name)] = MPNormalizedMethodTypes(methods[index].types);
+    }
+
+    free(methods);
+    return methodTypes;
+}
 
 @interface MParticle ()
 
@@ -2810,21 +2830,71 @@
     MPKitContainer_PRIVATE *localKitContainer = [[MPKitContainer_PRIVATE alloc] init];
     
     MPForwardQueueParameters *queueParameters = [[MPForwardQueueParameters alloc] init];
-    NSURL *url = [NSURL URLWithString:@"mparticle://baseurl?query"];
-    [queueParameters addParameter:url];
-    NSDictionary *options = @{@"key":@"val"};
-    [queueParameters addParameter:options];
+    NSDictionary *userAttributes = @{@"membership":@"gold"};
+    [queueParameters addParameter:userAttributes];
     
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
     id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
     id kitRegisterMock = OCMPartialMock(kitRegister);
     OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
     
-    [(id <MPKitProtocol>)[kitWrapperMock expect] surveyURLWithUserAttributes:OCMOCK_ANY];
+    [(id <MPKitProtocol>)[kitWrapperMock expect] surveyURLWithUserAttributes:userAttributes];
     
     [localKitContainer attemptToLogEventToKit:kitRegister kitFilter:nil selector:@selector(surveyURLWithUserAttributes:) parameters:queueParameters messageType:MPMessageTypeUnknown userInfo:[[NSDictionary alloc] init]];
     
     [kitWrapperMock verifyWithDelay:5.0];
+}
+
+- (void)testKitDispatchTargetMatchesSupportedSelectorsAndTypeEncodings {
+    NSArray<NSString *> *expectedSelectors = @[
+        @"beginSession",
+        @"beginTimedEvent:",
+        @"clearSession",
+        @"close",
+        @"continueUserActivity:restorationHandler:",
+        @"didUpdateUserActivity:",
+        @"endSession",
+        @"endTimedEvent:",
+        @"events:onEvent:",
+        @"failedToRegisterForUserNotifications:",
+        @"globalEvents:",
+        @"handleActionWithIdentifier:forRemoteNotification:",
+        @"handleActionWithIdentifier:forRemoteNotification:withResponseInfo:",
+        @"leaveBreadcrumb:",
+        @"logBaseEvent:",
+        @"logCommerceEvent:",
+        @"logError:eventInfo:",
+        @"logEvent:",
+        @"logException:",
+        @"logLTVIncrease:event:",
+        @"logScreen:",
+        @"openURL:options:",
+        @"openURL:sourceApplication:annotation:",
+        @"purchaseFinalized:catalogItemId:success:",
+        @"receivedUserNotification:",
+        @"registerPaymentExtension:",
+        @"selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:",
+        @"selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:",
+        @"setATTStatus:withATTStatusTimestampMillis:",
+        @"setDeviceToken:",
+        @"setOptOut:",
+        @"setSessionId:",
+        @"setWrapperSdk:version:",
+        @"shouldDelayMParticleUpload",
+        @"surveyURLWithUserAttributes:"
+    ];
+    NSDictionary<NSString *, NSString *> *dispatchMethods = MPOptionalMethodTypes(@protocol(MPKitDispatchTarget));
+    NSDictionary<NSString *, NSString *> *kitMethods = MPOptionalMethodTypes(@protocol(MPKitProtocol));
+    NSSet<NSString *> *expectedSelectorSet = [NSSet setWithArray:expectedSelectors];
+    NSSet<NSString *> *dispatchSelectorSet = [NSSet setWithArray:dispatchMethods.allKeys];
+
+    XCTAssertEqualObjects(dispatchSelectorSet, expectedSelectorSet);
+
+    for (NSString *selectorName in expectedSelectors) {
+        XCTAssertNotNil(kitMethods[selectorName], @"%@ is missing from MPKitProtocol", selectorName);
+        XCTAssertEqualObjects(dispatchMethods[selectorName], kitMethods[selectorName],
+                              @"%@ has mismatched type encodings", selectorName);
+    }
 }
 
 - (void)testAttemptToShouldDelayEventToKit {

--- a/mParticle-Apple-SDK-Swift/Sources/Kits/MPKitDispatchTarget.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Kits/MPKitDispatchTarget.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Mirrors the optional `MPKitProtocol` selectors handled by the kit dispatch boundary.
+///
+/// The Foundation-only Swift module cannot import `MPKitProtocol` because the Objective-C module
+/// depends on this module. Object parameters that use SDK-specific types are represented by
+/// `AnyObject` or `Any`; scalar parameters retain their exact Objective-C representation.
+@objc public protocol MPKitDispatchTarget {
+    @objc(logBaseEvent:) optional func logBaseEvent(_ event: Any) -> AnyObject?
+    @objc(logEvent:) optional func logEvent(_ event: Any) -> AnyObject?
+    @objc(logScreen:) optional func logScreen(_ event: Any) -> AnyObject?
+    @objc(leaveBreadcrumb:) optional func leaveBreadcrumb(_ event: Any) -> AnyObject?
+    @objc(beginTimedEvent:) optional func beginTimedEvent(_ event: Any) -> AnyObject?
+    @objc(endTimedEvent:) optional func endTimedEvent(_ event: Any) -> AnyObject?
+    @objc(logCommerceEvent:) optional func logCommerceEvent(_ commerceEvent: Any) -> AnyObject?
+    @objc(logLTVIncrease:event:) optional func logLTVIncrease(_ increaseAmount: Double, event: Any) -> AnyObject?
+
+    @objc(beginSession) optional func beginSession() -> AnyObject?
+    @objc(endSession) optional func endSession() -> AnyObject?
+
+    @objc(logError:eventInfo:) optional func logError(_ message: String?, eventInfo: [AnyHashable: Any]?) -> AnyObject?
+    @objc(logException:) optional func logException(_ exception: NSException) -> AnyObject?
+
+    @objc(setOptOut:) optional func setOptOut(_ optOut: Bool) -> AnyObject?
+    @objc(setATTStatus:withATTStatusTimestampMillis:)
+    optional func setATTStatus(_ status: UInt, withATTStatusTimestampMillis timestampMillis: NSNumber?) -> AnyObject?
+    @objc(setWrapperSdk:version:) optional func setWrapperSdk(_ wrapperSdk: UInt, version: String) -> AnyObject?
+    @objc(surveyURLWithUserAttributes:)
+    optional func surveyURL(withUserAttributes userAttributes: [AnyHashable: Any]) -> String?
+    @objc(shouldDelayMParticleUpload) optional func shouldDelayMParticleUpload() -> Bool
+
+    @objc(failedToRegisterForUserNotifications:)
+    optional func failedToRegisterForUserNotifications(_ error: NSError?) -> AnyObject?
+    @objc(setDeviceToken:) optional func setDeviceToken(_ deviceToken: Data) -> AnyObject?
+    @objc(receivedUserNotification:)
+    optional func receivedUserNotification(_ userInfo: [AnyHashable: Any]) -> AnyObject?
+    @objc(handleActionWithIdentifier:forRemoteNotification:)
+    optional func handleAction(withIdentifier identifier: String?,
+                               forRemoteNotification userInfo: [AnyHashable: Any]) -> AnyObject?
+    @objc(handleActionWithIdentifier:forRemoteNotification:withResponseInfo:)
+    optional func handleAction(withIdentifier identifier: String?,
+                               forRemoteNotification userInfo: [AnyHashable: Any],
+                               withResponseInfo responseInfo: [AnyHashable: Any]) -> AnyObject?
+    @objc(openURL:options:) optional func open(_ url: URL, options: [AnyHashable: Any]?) -> AnyObject?
+    @objc(openURL:sourceApplication:annotation:)
+    optional func open(_ url: URL, sourceApplication: String?, annotation: Any?) -> AnyObject?
+    @objc(didUpdateUserActivity:) optional func didUpdateUserActivity(_ userActivity: NSUserActivity) -> AnyObject?
+    @objc(continueUserActivity:restorationHandler:)
+    optional func continueUserActivity(_ userActivity: NSUserActivity,
+                                       restorationHandler: @escaping ([Any]?) -> Void) -> AnyObject?
+
+    @objc(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:)
+    optional func selectPlacements(withIdentifier identifier: String?,
+                                   attributes: [String: String],
+                                   embeddedViews: [String: AnyObject]?,
+                                   config: AnyObject?,
+                                   onEvent: ((AnyObject) -> Void)?,
+                                   filteredUser: AnyObject,
+                                   options: AnyObject?) -> AnyObject?
+    @objc(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:)
+    optional func selectShoppableAds(withIdentifier identifier: String,
+                                     attributes: [String: String],
+                                     config: AnyObject?,
+                                     onEvent: ((AnyObject) -> Void)?,
+                                     filteredUser: AnyObject) -> AnyObject?
+    @objc(events:onEvent:) optional func events(_ identifier: String,
+                                                onEvent: ((AnyObject) -> Void)?) -> AnyObject?
+    @objc(globalEvents:) optional func globalEvents(_ onEvent: @escaping (AnyObject) -> Void) -> AnyObject?
+    @objc(registerPaymentExtension:)
+    optional func registerPaymentExtension(_ paymentExtension: AnyObject) -> AnyObject?
+    @objc(purchaseFinalized:catalogItemId:success:)
+    optional func purchaseFinalized(_ identifier: String,
+                                    catalogItemId: String,
+                                    success: NSNumber) -> AnyObject?
+
+    @objc(close) optional func close() -> AnyObject?
+    @objc(setSessionId:) optional func setSessionId(_ sessionId: String) -> AnyObject?
+    @objc(clearSession) optional func clearSession() -> AnyObject?
+}

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -92,7 +92,13 @@
  */
 - (nonnull MPKitExecStatus *)setSessionId:(nonnull NSString *)sessionId;
 
-/** Clears the current kit session. */
+/**
+ Clears session state maintained by the kit without ending the mParticle SDK session.
+
+ The Rokt kit uses this callback to flush and end the current Rokt session at a shared-device
+ transaction boundary. The next placement request starts a new Rokt session; login, logout, and
+ identity changes do not invoke this callback automatically.
+ */
 - (nonnull MPKitExecStatus *)clearSession;
 
 #pragma mark User attributes and identities

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -93,11 +93,12 @@
 - (nonnull MPKitExecStatus *)setSessionId:(nonnull NSString *)sessionId;
 
 /**
- Clears session state maintained by the kit without ending the mParticle SDK session.
+ Clears session state maintained by the kit without ending the mParticle SDK session. This method
+ is dispatched only in response to an explicit clearSession call; session, login, logout, and
+ identity callbacks do not clear the kit session.
 
- The Rokt kit uses this callback to flush and end the current Rokt session at a shared-device
- transaction boundary. The next placement request starts a new Rokt session; login, logout, and
- identity changes do not invoke this callback automatically.
+ For Rokt, the host app calls MPRokt.clearSession at a shared-device transaction boundary to flush
+ and end the current Rokt session. The next placement request starts a new Rokt session.
  */
 - (nonnull MPKitExecStatus *)clearSession;
 

--- a/mParticle-Apple-SDK/Include/MPKitProtocol.h
+++ b/mParticle-Apple-SDK/Include/MPKitProtocol.h
@@ -82,6 +82,19 @@
 - (nonnull MPKitExecStatus *)beginSession;
 - (nonnull MPKitExecStatus *)endSession;
 
+/** Closes any active experience presented by the kit. */
+- (nonnull MPKitExecStatus *)close;
+
+/**
+ Sets the session identifier used by the kit.
+
+ @param sessionId A non-empty session identifier.
+ */
+- (nonnull MPKitExecStatus *)setSessionId:(nonnull NSString *)sessionId;
+
+/** Clears the current kit session. */
+- (nonnull MPKitExecStatus *)clearSession;
+
 #pragma mark User attributes and identities
 - (nonnull MPKitExecStatus *)incrementUserAttribute:(nonnull NSString *)key byValue:(nonnull NSNumber *)value;
 - (nonnull MPKitExecStatus *)removeUserAttribute:(nonnull NSString *)key;

--- a/mParticle-Apple-SDK/Kits/MPForwardQueueItem.h
+++ b/mParticle-Apple-SDK/Kits/MPForwardQueueItem.h
@@ -1,5 +1,5 @@
-// Intentionally kept in Objective-C: stores SDK event types (MPBaseEvent/MPCommerceEvent)
-// and a SEL, which the Foundation-only Swift migration module cannot import.
+// Intentionally kept in Objective-C because it stores SDK event types
+// (MPBaseEvent/MPCommerceEvent) and MPMessageType, which the Foundation-only Swift module cannot import.
 #import <Foundation/Foundation.h>
 #import "MPEnums.h"
 #import "MPKitProtocol.h"


### PR DESCRIPTION
## Background

Kit selector dispatch needs a machine-checkable contract before its dynamic Objective-C invocation can move to Swift safely.

## What Has Changed

- Add optional `close`, `setSessionId:`, and `clearSession` kit methods.
- Mirror the supported dispatch surface in `MPKitDispatchTarget`.
- Add selector and Objective-C type-encoding parity tests.
- Correct the survey-dispatch regression test and queue-item migration documentation.
- Record the additive protocol declarations in the ABI baseline.

## Screenshots/Video

N/A — no visual changes.

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Testing

- Trunk checks and ABI guard
- Objective-C and Swift unit tests
- Typed-dispatch parity tests
- Address Sanitizer validation
- Core CocoaPods lint
