### PR TITLE
fix: forward kit calls through typed Swift dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 #### Fixed
 
+- Forward wrapper SDK enum values to kits without pointer reinterpretation.
+- Forward LTV increases to kits with both the original amount and transformed event.
 - `MPRokt.selectPlacements` and `MPRokt.selectShoppableAds` now deliver a `RoktPlacementFailure` event to the caller's `onEvent` handler when the Rokt kit configuration is unavailable. Previously the call was dropped with only a log message, leaving callers waiting on a callback that never arrived. ([#814](https://github.com/mParticle/mparticle-apple-sdk/pull/814))
 
 ### Kits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ For each release, **Core** (main SDK) changes are listed first, followed by **Ki
 
 #### Fixed
 
-- Forward wrapper SDK enum values to kits without pointer reinterpretation.
-- Forward LTV increases to kits with both the original amount and transformed event.
 - `MPRokt.selectPlacements` and `MPRokt.selectShoppableAds` now deliver a `RoktPlacementFailure` event to the caller's `onEvent` handler when the Rokt kit configuration is unavailable. Previously the call was dropped with only a log message, leaving callers waiting on a callback that never arrived. ([#814](https://github.com/mParticle/mparticle-apple-sdk/pull/814))
 
 ### Kits

--- a/UnitTests/MParticle+PrivateMethods.h
+++ b/UnitTests/MParticle+PrivateMethods.h
@@ -28,7 +28,7 @@
 - (void)logCrashCallback:(MPExecStatus)execStatus message:(NSString * _Nullable)message;
 - (void)logCommerceEventCallback:(MPCommerceEvent *)commerceEvent execStatus:(MPExecStatus)execStatus;
 - (void)logCommerceEvent:(MPCommerceEvent *)commerceEvent;
-- (void)logLTVIncreaseCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus;
+- (void)logLTVIncreaseCallback:(MPEvent *)event increaseAmount:(double)increaseAmount execStatus:(MPExecStatus)execStatus;
 - (void)logNetworkPerformanceCallback:(MPExecStatus)execStatus;
 + (void)setSharedInstance:(MParticle *)instance;
 - (void)executeKitsInitializedBlocks;

--- a/UnitTests/ObjCTests/MPKitContainerTests.m
+++ b/UnitTests/ObjCTests/MPKitContainerTests.m
@@ -2752,6 +2752,59 @@ static NSDictionary<NSString *, NSString *> *MPOptionalMethodTypes(Protocol *pro
     [kitWrapperMock verifyWithDelay:5.0];
 }
 
+- (void)testAttemptToSetWrapperSdkPreservesScalarValue {
+    MPKitContainer_PRIVATE *localKitContainer = [[MPKitContainer_PRIVATE alloc] init];
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"Rokt" className:@"MPKitRokt"];
+    id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
+    id kitRegisterMock = OCMPartialMock(kitRegister);
+    OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
+    MPKitFilter *kitFilter = [kitContainer filter:kitRegisterMock forEvent:nil selector:@selector(setWrapperSdk:version:)];
+    NSString *version = @"2.4.1";
+    __block MPWrapperSdk receivedWrapperSdk = MPWrapperSdkNone;
+
+    id wrapperRecorder = [[kitWrapperMock expect] ignoringNonObjectArgs];
+    id<MPKitProtocol> wrapperExpectation = [wrapperRecorder andDo:^(NSInvocation *invocation) {
+        [invocation getArgument:&receivedWrapperSdk atIndex:2];
+    }];
+    [wrapperExpectation setWrapperSdk:MPWrapperSdkNone version:version];
+
+    MPForwardQueueParameters *parameters = [[MPForwardQueueParameters alloc]
+        initWithParameters:@[@(MPWrapperSdkXamarin), version]];
+    [localKitContainer attemptToLogEventToKit:kitRegisterMock
+                                    kitFilter:kitFilter
+                                     selector:@selector(setWrapperSdk:version:)
+                                   parameters:parameters
+                                  messageType:MPMessageTypeUnknown
+                                     userInfo:nil];
+
+    [kitWrapperMock verifyWithDelay:5.0];
+    XCTAssertEqual(receivedWrapperSdk, MPWrapperSdkXamarin);
+}
+
+- (void)testAttemptToLogEventContainsKitExceptions {
+    MPKitContainer_PRIVATE *localKitContainer = [[MPKitContainer_PRIVATE alloc] init];
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"Throwing Kit" className:@"ThrowingKit"];
+    id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
+    id kitRegisterMock = OCMPartialMock(kitRegister);
+    OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
+    XCTestExpectation *invoked = [self expectationWithDescription:@"Kit method invoked"];
+
+    id<MPKitProtocol> exceptionStub = [[kitWrapperMock stub] andDo:^(NSInvocation *invocation) {
+        [invoked fulfill];
+        @throw [NSException exceptionWithName:@"KitException" reason:@"Test exception" userInfo:nil];
+    }];
+    [exceptionStub beginSession];
+
+    [localKitContainer attemptToLogEventToKit:kitRegisterMock
+                                    kitFilter:nil
+                                     selector:@selector(beginSession)
+                                   parameters:nil
+                                  messageType:MPMessageTypeUnknown
+                                     userInfo:nil];
+
+    [self waitForExpectations:@[invoked] timeout:5.0];
+}
+
 - (void)testAttemptToLegacyOpenURLToKit {
     MPKitContainer_PRIVATE *localKitContainer = [[MPKitContainer_PRIVATE alloc] init];
     SEL selector = @selector(openURL:sourceApplication:annotation:);

--- a/UnitTests/SwiftTests/MParticle/MParticleLTVTests.swift
+++ b/UnitTests/SwiftTests/MParticle/MParticleLTVTests.swift
@@ -61,7 +61,7 @@ final class MParticleLTVTests: MParticleTestBase {
     func test_logLTVIncreaseCallback_blocksEvent_whenFilterReturnsNil() {
         dataPlanFilter.transformEventReturnValue = nil
         
-        mparticle.logLTVIncreaseCallback(event, execStatus: .success)
+        mparticle.logLTVIncreaseCallback(event, increaseAmount: 12.5, execStatus: .success)
         
         XCTAssertTrue(dataPlanFilter.transformEventCalled)
         XCTAssertTrue(dataPlanFilter.transformEventEventParam === event)
@@ -72,7 +72,7 @@ final class MParticleLTVTests: MParticleTestBase {
     func test_logLTVIncreaseCallback_forwardsTransformedEvent_whenFilterReturnsEvent() {
         dataPlanFilter.transformEventReturnValue = transformedEvent
         
-        mparticle.logLTVIncreaseCallback(event, execStatus: .success)
+        mparticle.logLTVIncreaseCallback(event, increaseAmount: 12.5, execStatus: .success)
         
         // Verify filter transformed event
         XCTAssertTrue(dataPlanFilter.transformEventCalled)
@@ -85,6 +85,7 @@ final class MParticleLTVTests: MParticleTestBase {
         XCTAssertTrue(kitContainer.forwardSDKCallCalled)
         XCTAssertEqual(kitContainer.forwardSDKCallSelectorParam?.description, "logLTVIncrease:event:")
         XCTAssertEqual(kitContainer.forwardSDKCallMessageTypeParam, .unknown)
-        XCTAssertNil(kitContainer.forwardSDKCallEventParam)
+        XCTAssertTrue(kitContainer.forwardSDKCallEventParam === transformedEvent)
+        XCTAssertEqual(kitContainer.forwardSDKCallParametersParam?[0] as? Double, 12.5)
     }
 }

--- a/mParticle-Apple-SDK-Swift/Sources/Kits/MPKitSelectorInvoker.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Kits/MPKitSelectorInvoker.swift
@@ -1,0 +1,317 @@
+import Foundation
+
+/// Describes the result of forwarding a selector to a kit.
+@objc public enum MPKitInvocationOutcome: Int {
+    /// The kit returned a value for the selector.
+    case returnedStatus
+    /// The selector completed and does not return a kit status.
+    case completedWithoutStatus
+    /// The kit does not implement the selector.
+    case notImplemented
+    /// The selector is outside the supported dispatch contract.
+    case unknownSelector
+    /// A required selector argument was unavailable or invalid.
+    case missingArguments
+}
+
+/// Contains the outcome and optional return value from a forwarded kit call.
+@objc(MPKitInvocationResult) public final class MPKitInvocationResult: NSObject {
+    /// The result category for the invocation.
+    @objc public let outcome: MPKitInvocationOutcome
+    /// The object returned by the kit, when the selector returns one.
+    @objc public let returnedObject: AnyObject?
+
+    fileprivate init(_ outcome: MPKitInvocationOutcome, returnedObject: AnyObject? = nil) {
+        self.outcome = outcome
+        self.returnedObject = returnedObject
+        super.init()
+    }
+}
+
+/// Forwards supported selectors through the typed `MPKitDispatchTarget` contract.
+@objc(MPKitSelectorInvoker) public final class MPKitSelectorInvoker: NSObject {
+    private typealias RestorationBlock = @convention(block) (NSArray?) -> Void
+    private typealias RoktEventBlock = @convention(block) (AnyObject) -> Void
+
+    private static let blockClass: AnyClass? = NSClassFromString("NSBlock")
+
+    private let logger: MPLog
+
+    /// Creates an invoker that reports unsupported selectors through the supplied logger.
+    @objc public init(logger: MPLog) {
+        self.logger = logger
+        super.init()
+    }
+
+    private func isBlock(_ value: Any?) -> Bool {
+        guard let value, let blockClass = Self.blockClass else { return false }
+        return (value as AnyObject).isKind(of: blockClass)
+    }
+
+    private func restorationHandler(_ value: Any?) -> (([Any]?) -> Void)? {
+        guard isBlock(value), let value else { return nil }
+        let block = unsafeBitCast(value as AnyObject, to: RestorationBlock.self)
+        return { objects in block(objects as NSArray?) }
+    }
+
+    private func roktEventHandler(_ value: Any?) -> ((AnyObject) -> Void)? {
+        guard isBlock(value), let value else { return nil }
+        let block = unsafeBitCast(value as AnyObject, to: RoktEventBlock.self)
+        return { event in block(event) }
+    }
+
+    /// Invokes a supported selector when the kit implements it and its required arguments exist.
+    @objc public func invoke(_ kit: MPKitDispatchTarget?,
+                             selectorName: String,
+                             event: Any?,
+                             filteredUser: AnyObject?,
+                             parameters: MPForwardQueueParameters?) -> MPKitInvocationResult {
+        guard let kit else { return MPKitInvocationResult(.notImplemented) }
+
+        func argument(_ index: Int) -> Any? { parameters?[index] }
+        func returned(_ value: AnyObject?) -> MPKitInvocationResult {
+            MPKitInvocationResult(.returnedStatus, returnedObject: value)
+        }
+
+        switch selectorName {
+        case "logBaseEvent:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.logBaseEvent else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "logEvent:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.logEvent else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "logScreen:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.logScreen else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "leaveBreadcrumb:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.leaveBreadcrumb else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "beginTimedEvent:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.beginTimedEvent else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "endTimedEvent:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.endTimedEvent else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "logCommerceEvent:":
+            guard let event else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.logCommerceEvent else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(event))
+
+        case "logLTVIncrease:event:":
+            guard let amount = argument(0) as? NSNumber, let event else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.logLTVIncrease else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(amount.doubleValue, event))
+
+        case "beginSession":
+            guard let call = kit.beginSession else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call())
+
+        case "endSession":
+            guard let call = kit.endSession else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call())
+
+        case "logError:eventInfo:":
+            guard let call = kit.logError else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(argument(0) as? String, argument(1) as? [AnyHashable: Any]))
+
+        case "logException:":
+            guard let exception = argument(0) as? NSException else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.logException else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(exception))
+
+        case "setOptOut:":
+            guard let call = kit.setOptOut else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call((argument(0) as? NSNumber)?.boolValue ?? false))
+
+        case "setATTStatus:withATTStatusTimestampMillis:":
+            guard let statusValue = argument(0) as? NSNumber else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.setATTStatus else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(statusValue.uintValue, argument(1) as? NSNumber))
+
+        case "setWrapperSdk:version:":
+            guard let wrapperSdk = argument(0) as? NSNumber,
+                  let version = argument(1) as? String else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.setWrapperSdk else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(wrapperSdk.uintValue, version))
+
+        case "surveyURLWithUserAttributes:":
+            guard let attributes = argument(0) as? [AnyHashable: Any] else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.surveyURL else { return MPKitInvocationResult(.notImplemented) }
+            _ = call(attributes)
+            return MPKitInvocationResult(.completedWithoutStatus)
+
+        case "shouldDelayMParticleUpload":
+            guard let call = kit.shouldDelayMParticleUpload else { return MPKitInvocationResult(.notImplemented) }
+            _ = call()
+            return MPKitInvocationResult(.completedWithoutStatus)
+
+        case "failedToRegisterForUserNotifications:":
+            guard let call = kit.failedToRegisterForUserNotifications else {
+                return MPKitInvocationResult(.notImplemented)
+            }
+            return returned(call(argument(0) as? NSError))
+
+        case "setDeviceToken:":
+            guard let token = argument(0) as? Data else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.setDeviceToken else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(token))
+
+        case "receivedUserNotification:":
+            guard let userInfo = argument(0) as? [AnyHashable: Any] else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.receivedUserNotification else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(userInfo))
+
+        case "handleActionWithIdentifier:forRemoteNotification:":
+            guard let userInfo = argument(1) as? [AnyHashable: Any] else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.handleAction(withIdentifier:forRemoteNotification:) else {
+                return MPKitInvocationResult(.notImplemented)
+            }
+            return returned(call(argument(0) as? String, userInfo))
+
+        case "handleActionWithIdentifier:forRemoteNotification:withResponseInfo:":
+            guard let userInfo = argument(1) as? [AnyHashable: Any],
+                  let responseInfo = argument(2) as? [AnyHashable: Any] else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.handleAction(withIdentifier:forRemoteNotification:withResponseInfo:) else {
+                return MPKitInvocationResult(.notImplemented)
+            }
+            return returned(call(argument(0) as? String, userInfo, responseInfo))
+
+        case "openURL:options:":
+            guard let url = argument(0) as? URL else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.open(_:options:) else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(url, argument(1) as? [AnyHashable: Any]))
+
+        case "openURL:sourceApplication:annotation:":
+            guard let url = argument(0) as? URL else { return MPKitInvocationResult(.missingArguments) }
+            guard let call = kit.open(_:sourceApplication:annotation:) else {
+                return MPKitInvocationResult(.notImplemented)
+            }
+            return returned(call(url, argument(1) as? String, argument(2)))
+
+        case "didUpdateUserActivity:":
+            guard let activity = argument(0) as? NSUserActivity else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.didUpdateUserActivity else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(activity))
+
+        case "continueUserActivity:restorationHandler:":
+            guard let activity = argument(0) as? NSUserActivity,
+                  let handler = restorationHandler(argument(1)) else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.continueUserActivity else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(activity, handler))
+
+        case "selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:":
+            let rawHandler = argument(4)
+            guard let attributes = argument(1) as? [String: String],
+                  let filteredUser,
+                  rawHandler == nil || isBlock(rawHandler) else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.selectPlacements else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(argument(0) as? String,
+                                 attributes,
+                                 argument(2) as? [String: AnyObject],
+                                 argument(3) as AnyObject?,
+                                 roktEventHandler(rawHandler),
+                                 filteredUser,
+                                 argument(5) as AnyObject?))
+
+        case "selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:":
+            let rawHandler = argument(3)
+            guard let identifier = argument(0) as? String,
+                  let attributes = argument(1) as? [String: String],
+                  let filteredUser,
+                  rawHandler == nil || isBlock(rawHandler) else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.selectShoppableAds else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(identifier,
+                                 attributes,
+                                 argument(2) as AnyObject?,
+                                 roktEventHandler(rawHandler),
+                                 filteredUser))
+
+        case "events:onEvent:":
+            let rawHandler = argument(1)
+            guard let identifier = argument(0) as? String,
+                  rawHandler == nil || isBlock(rawHandler) else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.events else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(identifier, roktEventHandler(rawHandler)))
+
+        case "globalEvents:":
+            guard let handler = roktEventHandler(argument(0)) else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.globalEvents else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(handler))
+
+        case "registerPaymentExtension:":
+            guard let paymentExtension = argument(0) as AnyObject? else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.registerPaymentExtension else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(paymentExtension))
+
+        case "purchaseFinalized:catalogItemId:success:":
+            guard let identifier = argument(0) as? String,
+                  let catalogItemId = argument(1) as? String,
+                  let success = argument(2) as? NSNumber else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.purchaseFinalized else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(identifier, catalogItemId, success))
+
+        case "close":
+            guard let call = kit.close else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call())
+
+        case "setSessionId:":
+            guard let sessionId = argument(0) as? String else {
+                return MPKitInvocationResult(.missingArguments)
+            }
+            guard let call = kit.setSessionId else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call(sessionId))
+
+        case "clearSession":
+            guard let call = kit.clearSession else { return MPKitInvocationResult(.notImplemented) }
+            return returned(call())
+
+        default:
+            logger.error("Forwarded selector \(selectorName) is not supported by the typed dispatcher.")
+            return MPKitInvocationResult(.unknownSelector)
+        }
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Kits/MPKitSelectorInvokerTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Kits/MPKitSelectorInvokerTests.swift
@@ -1,0 +1,190 @@
+@testable import mParticle_Apple_SDK_Swift
+import XCTest
+
+private final class KitDispatchTargetStub: NSObject, MPKitDispatchTarget {
+    var attStatus: UInt?
+    var ltvAmount: Double?
+    var optOut: Bool?
+    var sessionId: String?
+    var wrapperSDK: UInt?
+
+    @objc func logLTVIncrease(_ increaseAmount: Double, event: Any) -> AnyObject? {
+        ltvAmount = increaseAmount
+        return NSObject()
+    }
+
+    @objc func setOptOut(_ optOut: Bool) -> AnyObject? {
+        self.optOut = optOut
+        return NSObject()
+    }
+
+    @objc func setATTStatus(_ status: UInt,
+                            withATTStatusTimestampMillis _: NSNumber?) -> AnyObject? {
+        attStatus = status
+        return NSObject()
+    }
+
+    @objc func setWrapperSdk(_ wrapperSdk: UInt, version _: String) -> AnyObject? {
+        wrapperSDK = wrapperSdk
+        return NSObject()
+    }
+
+    @objc func setSessionId(_ sessionId: String) -> AnyObject? {
+        self.sessionId = sessionId
+        return NSObject()
+    }
+
+    @objc func continueUserActivity(_: NSUserActivity,
+                                    restorationHandler: @escaping ([Any]?) -> Void) -> AnyObject? {
+        restorationHandler(["restored"])
+        return NSObject()
+    }
+
+    @objc func selectPlacements(withIdentifier _: String?,
+                                attributes _: [String: String],
+                                embeddedViews _: [String: AnyObject]?,
+                                config _: AnyObject?,
+                                onEvent: ((AnyObject) -> Void)?,
+                                filteredUser _: AnyObject,
+                                options _: AnyObject?) -> AnyObject? {
+        onEvent?(NSObject())
+        return NSObject()
+    }
+
+    @objc func selectShoppableAds(withIdentifier _: String,
+                                  attributes _: [String: String],
+                                  config _: AnyObject?,
+                                  onEvent: ((AnyObject) -> Void)?,
+                                  filteredUser _: AnyObject) -> AnyObject? {
+        onEvent?(NSObject())
+        return NSObject()
+    }
+
+    @objc func events(_: String, onEvent: ((AnyObject) -> Void)?) -> AnyObject? {
+        onEvent?(NSObject())
+        return NSObject()
+    }
+
+    @objc func globalEvents(_ onEvent: @escaping (AnyObject) -> Void) -> AnyObject? {
+        onEvent(NSObject())
+        return NSObject()
+    }
+}
+
+private final class EmptyKitDispatchTarget: NSObject, MPKitDispatchTarget {}
+
+final class MPKitSelectorInvokerTests: XCTestCase {
+    private typealias RestorationBlock = @convention(block) (NSArray?) -> Void
+    private typealias RoktEventBlock = @convention(block) (AnyObject) -> Void
+
+    private let invoker = MPKitSelectorInvoker(logger: MPLog(logLevel: .none))
+
+    func testScalarArgumentsAreUnboxed() {
+        let kit = KitDispatchTargetStub()
+        let event = NSObject()
+
+        let wrapperParameters = MPForwardQueueParameters(parameters: [NSNumber(value: 4), "2.4.1"])
+        XCTAssertEqual(invoke(kit, "setWrapperSdk:version:", parameters: wrapperParameters).outcome,
+                       .returnedStatus)
+        XCTAssertEqual(kit.wrapperSDK, 4)
+
+        let ltvParameters = MPForwardQueueParameters(parameters: [NSNumber(value: 12.5)])
+        XCTAssertEqual(invoke(kit, "logLTVIncrease:event:", event: event, parameters: ltvParameters).outcome,
+                       .returnedStatus)
+        XCTAssertEqual(kit.ltvAmount, 12.5)
+
+        let optOutParameters = MPForwardQueueParameters(parameters: [NSNumber(value: true)])
+        XCTAssertEqual(invoke(kit, "setOptOut:", parameters: optOutParameters).outcome, .returnedStatus)
+        XCTAssertEqual(kit.optOut, true)
+
+        let attParameters = MPForwardQueueParameters(parameters: [NSNumber(value: 3), NSNumber(value: 42)])
+        XCTAssertEqual(invoke(kit,
+                              "setATTStatus:withATTStatusTimestampMillis:",
+                              parameters: attParameters).outcome,
+                       .returnedStatus)
+        XCTAssertEqual(kit.attStatus, 3)
+    }
+
+    func testBlockArgumentsAreGuardedAndRemainCallable() {
+        let kit = KitDispatchTargetStub()
+        let filteredUser = NSObject()
+        var callbacks = Set<String>()
+
+        let restorationHandler: RestorationBlock = { objects in
+            if objects?.firstObject as? String == "restored" {
+                callbacks.insert("restoration")
+            }
+        }
+        let activityParameters = MPForwardQueueParameters(parameters: [
+            NSUserActivity(activityType: "test"),
+            restorationHandler
+        ])
+        XCTAssertEqual(invoke(kit,
+                              "continueUserActivity:restorationHandler:",
+                              parameters: activityParameters).outcome,
+                       .returnedStatus)
+
+        func eventHandler(_ name: String) -> RoktEventBlock {
+            { _ in callbacks.insert(name) }
+        }
+
+        let placementParameters = MPForwardQueueParameters(parameters: [
+            "placement",
+            ["key": "value"],
+            [String: AnyObject](),
+            NSObject(),
+            eventHandler("placements"),
+            NSObject()
+        ])
+        XCTAssertEqual(invoke(kit,
+                              "selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:",
+                              filteredUser: filteredUser,
+                              parameters: placementParameters).outcome,
+                       .returnedStatus)
+
+        let shoppableParameters = MPForwardQueueParameters(parameters: [
+            "placement",
+            ["key": "value"],
+            NSObject(),
+            eventHandler("shoppable")
+        ])
+        XCTAssertEqual(invoke(kit,
+                              "selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:",
+                              filteredUser: filteredUser,
+                              parameters: shoppableParameters).outcome,
+                       .returnedStatus)
+
+        let eventsParameters = MPForwardQueueParameters(parameters: ["placement", eventHandler("events")])
+        XCTAssertEqual(invoke(kit, "events:onEvent:", parameters: eventsParameters).outcome, .returnedStatus)
+
+        let globalParameters = MPForwardQueueParameters(parameters: [eventHandler("global")])
+        XCTAssertEqual(invoke(kit, "globalEvents:", parameters: globalParameters).outcome, .returnedStatus)
+
+        XCTAssertEqual(callbacks, ["restoration", "placements", "shoppable", "events", "global"])
+    }
+
+    func testExplicitFailureOutcomes() {
+        XCTAssertEqual(invoke(nil, "beginSession").outcome, .notImplemented)
+        XCTAssertEqual(invoke(EmptyKitDispatchTarget(), "beginSession").outcome, .notImplemented)
+        XCTAssertEqual(invoke(KitDispatchTargetStub(), "setSessionId:").outcome, .missingArguments)
+        XCTAssertEqual(invoke(KitDispatchTargetStub(), "unknownSelector:").outcome, .unknownSelector)
+
+        let invalidBlockParameters = MPForwardQueueParameters(parameters: ["placement", "not a block"])
+        XCTAssertEqual(invoke(KitDispatchTargetStub(),
+                              "events:onEvent:",
+                              parameters: invalidBlockParameters).outcome,
+                       .missingArguments)
+    }
+
+    private func invoke(_ kit: MPKitDispatchTarget?,
+                        _ selectorName: String,
+                        event: Any? = nil,
+                        filteredUser: AnyObject? = nil,
+                        parameters: MPForwardQueueParameters? = nil) -> MPKitInvocationResult {
+        invoker.invoke(kit,
+                       selectorName: selectorName,
+                       event: event,
+                       filteredUser: filteredUser,
+                       parameters: parameters)
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Kits/MPKitSelectorInvokerTests.swift,
 				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
 				Test/Network/MPEndpointPathStyleTests.swift,
@@ -636,6 +637,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Kits/MPKitSelectorInvokerTests.swift,
 				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
 				Test/Network/MPEndpointPathStyleTests.swift,

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -26,7 +26,6 @@
 #import "mParticle.h"
 #import "MPIConstants.h"
 #import "MPDataPlanFilter.h"
-#import <objc/message.h>
 #import "MPCCPAConsent.h"
 #import "MPGDPRConsent.h"
 #import "MPUserDefaultsConnector.h"
@@ -78,6 +77,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 @property (nonatomic, strong) MPIHasher *hasher;
 @property (nonatomic, strong) MPKitValueTransformer *valueTransformer;
 @property (nonatomic, strong) MPAttributeValueFilter *attributeValueFilter;
+@property (nonatomic, strong) MPKitSelectorInvoker *selectorInvoker;
 @end
 
 
@@ -107,6 +107,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         _hasher = [[MPIHasher alloc] initWithLogger:logger];
         _valueTransformer = [[MPKitValueTransformer alloc] initWithLogger:logger];
         _attributeValueFilter = [[MPAttributeValueFilter alloc] initWithHasher:_hasher];
+        _selectorInvoker = [[MPKitSelectorInvoker alloc] initWithLogger:logger];
         _attributionCompletionHandler = [^void(MPAttributionResult *_Nullable attributionResult, NSError * _Nullable error) {
             if (attributionResult && attributionResult.kitCode) {
                 linkInfo[attributionResult.kitCode] = attributionResult;
@@ -774,6 +775,13 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 }
 
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forEvent:(MPEvent *const)event selector:(SEL)selector {
+    return [self filter:kitRegister forEvent:event selector:selector parameters:nil];
+}
+
+- (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister
+                forEvent:(MPEvent *const)event
+                selector:(SEL)selector
+              parameters:(MPForwardQueueParameters *)parameters {
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
     NSNumber *zero = @0;
     __block MPKitFilter *kitFilter = [[MPKitFilter alloc] initWithEvent:event shouldFilter:NO];
@@ -871,7 +879,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                     }
                 }
             }
-            [self attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:mutableSelector parameters:nil messageType:messageTypeCode userInfo:[[NSDictionary alloc] init]];
+            [self attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:mutableSelector parameters:parameters messageType:messageTypeCode userInfo:[[NSDictionary alloc] init]];
         }
     }];
     
@@ -2020,7 +2028,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
             if (kitInstance) {
                 if (![kitInstance started] && !disabled) {
                     if ([kitInstance respondsToSelector:@selector(setLaunchOptions:)]) {
-                        [kitInstance performSelector:@selector(setLaunchOptions:) withObject:stateMachine.launchOptions];
+                        [kitInstance setLaunchOptions:stateMachine.launchOptions];
                     }
                     
                     if ([kitInstance respondsToSelector:@selector(start)]) {
@@ -2230,7 +2238,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
     
     for (id<MPExtensionKitProtocol>kitRegister in activeKitsRegistry) {
         if (event && [event isMemberOfClass:[MPEvent class]]) {
-            [self filter:kitRegister forEvent:(MPEvent *)event selector:selector];
+            [self filter:kitRegister forEvent:(MPEvent *)event selector:selector parameters:parameters];
         } else {
             MPKitFilter *kitFilter = [self filter:kitRegister forBaseEvent:event forSelector:selector];
             [self attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:selector parameters:parameters messageType:messageType userInfo:userInfo];
@@ -2253,93 +2261,77 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
             MPILogDebug(@"Forwarding %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
         }
         
-        MPKitExecStatus *execStatus;
+        MPKitExecStatus *execStatus = nil;
         
         @try {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            if ([kitRegister.wrapperInstance respondsToSelector:@selector(logBaseEvent:)] && ((selector == @selector(logEvent:)) || (selector == @selector(logBaseEvent:)))) {
-                if (!kitFilter.forwardEvent) {
-                    return;
-                }
-                execStatus = [kitRegister.wrapperInstance logBaseEvent:kitFilter.forwardEvent];
-            } else if (selector == @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:)) {
-                if (kitFilter.shouldFilter) {
-                    MPILogDebug(@"selectPlacementsWithIdentifier filtered out for kit: %@ - shouldFilter: YES", kitRegister.name);
-                    return;
-                }
-                MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
-                MPILogVerbose(@"selectPlacementsWithIdentifier - kit: %@, currentUser: %@", kitRegister.name, currentUser ? currentUser.userId : @"nil");
-                FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:currentUser kitConfiguration:self.kitConfigurations[kitRegister.code]];
+            id<MPKitProtocol> kit = kitRegister.wrapperInstance;
+            SEL effectiveSelector = selector;
 
-                if ([kitRegister.wrapperInstance respondsToSelector:@selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:)]) {
-                    execStatus = [kitRegister.wrapperInstance selectPlacementsWithIdentifier:parameters[0]
-                                                                         attributes:parameters[1]
-                                                                      embeddedViews:parameters[2]
-                                                                             config:parameters[3]
-                                                                            onEvent:parameters[4]
-                                                                       filteredUser:filteredUser
-                                                                            options:parameters[5]];
-                }
-            } else if (selector == @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:)) {
+            if ([kit respondsToSelector:@selector(logBaseEvent:)] &&
+                (selector == @selector(logEvent:) || selector == @selector(logBaseEvent:))) {
+                effectiveSelector = @selector(logBaseEvent:);
+            }
+
+            id filteredUser = nil;
+            if (effectiveSelector == @selector(selectPlacementsWithIdentifier:attributes:embeddedViews:config:onEvent:filteredUser:options:) ||
+                effectiveSelector == @selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:)) {
                 if (kitFilter.shouldFilter) {
-                    MPILogDebug(@"selectShoppableAdsWithIdentifier filtered out for kit: %@ - shouldFilter: YES", kitRegister.name);
+                    MPILogDebug(@"%@ filtered out for kit: %@ - shouldFilter: YES",
+                                NSStringFromSelector(effectiveSelector), kitRegister.name);
                     return;
                 }
-                MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
-                MPILogVerbose(@"selectShoppableAdsWithIdentifier - kit: %@, currentUser: %@", kitRegister.name, currentUser ? currentUser.userId : @"nil");
-                FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:currentUser kitConfiguration:self.kitConfigurations[kitRegister.code]];
 
-                if ([kitRegister.wrapperInstance respondsToSelector:@selector(selectShoppableAdsWithIdentifier:attributes:config:onEvent:filteredUser:)]) {
-                    execStatus = [kitRegister.wrapperInstance selectShoppableAdsWithIdentifier:parameters[0]
-                                                                         attributes:parameters[1]
-                                                                             config:parameters[2]
-                                                                            onEvent:parameters[3]
-                                                                       filteredUser:filteredUser];
-                }
-            } else if ([kitRegister.wrapperInstance respondsToSelector:selector]) {
-                if (selector == @selector(logEvent:)) {
-                    if (!kitFilter.forwardEvent || ![kitFilter.forwardEvent isKindOfClass:[MPEvent class]]) {
-                        return;
+                MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
+                MPILogVerbose(@"%@ - kit: %@, currentUser: %@", NSStringFromSelector(effectiveSelector),
+                              kitRegister.name, currentUser ? currentUser.userId : @"nil");
+                filteredUser = [[FilteredMParticleUser alloc]
+                    initWithMParticleUser:currentUser
+                         kitConfiguration:self.kitConfigurations[kitRegister.code]];
+            }
+
+            if ((effectiveSelector == @selector(logEvent:) || effectiveSelector == @selector(logScreen:)) &&
+                ![kitFilter.forwardEvent isKindOfClass:[MPEvent class]]) {
+                return;
+            }
+            if (effectiveSelector == @selector(logBaseEvent:) && !kitFilter.forwardEvent) {
+                return;
+            }
+
+            MPKitInvocationResult *result = [self.selectorInvoker invoke:(id<MPKitDispatchTarget>)kit
+                                                           selectorName:NSStringFromSelector(effectiveSelector)
+                                                                  event:kitFilter.forwardEvent
+                                                           filteredUser:filteredUser
+                                                             parameters:parameters];
+
+            switch (result.outcome) {
+                case MPKitInvocationOutcomeReturnedStatus:
+                    if ([result.returnedObject isKindOfClass:[MPKitExecStatus class]]) {
+                        execStatus = (MPKitExecStatus *)result.returnedObject;
+                    } else {
+                        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code
+                                                                  returnCode:MPKitReturnCodeFail];
                     }
-                    execStatus = [kitRegister.wrapperInstance logEvent:((MPEvent *)kitFilter.forwardEvent)];
-                } else if (selector == @selector(logScreen:)) {
-                    if (!kitFilter.forwardEvent || ![kitFilter.forwardEvent isKindOfClass:[MPEvent class]]) {
-                        return;
-                    }
-                    execStatus = [kitRegister.wrapperInstance logScreen:((MPEvent *)kitFilter.forwardEvent)];
-                } else if (selector == @selector(surveyURLWithUserAttributes:)) {
-                    [kitRegister.wrapperInstance surveyURLWithUserAttributes:parameters[0]];
-                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code returnCode:MPKitReturnCodeSuccess];
-                } else if (selector == @selector(shouldDelayMParticleUpload)) {
-                    [kitRegister.wrapperInstance shouldDelayMParticleUpload];
-                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code returnCode:MPKitReturnCodeSuccess];
-                } else if (selector == @selector(setATTStatus:withATTStatusTimestampMillis:)) {
-                    MPATTAuthorizationStatus status = (MPATTAuthorizationStatus)[parameters[0] unsignedIntValue];
-                    NSNumber *timestamp = [parameters[1] isKindOfClass:[NSNumber class]] ? (NSNumber*)parameters[1] : nil;
-                    execStatus = [kitRegister.wrapperInstance setATTStatus:status withATTStatusTimestampMillis:timestamp];
-                } else if (selector == @selector(setOptOut:)) {
-                    BOOL isOptOut = (parameters.count >= 1 && [parameters[0] boolValue]);
-                    execStatus = [kitRegister.wrapperInstance setOptOut:isOptOut];
-                } else if (parameters.count == 3) {
-                    typedef MPKitExecStatus *(*send_type)(id, SEL, id, id, id);
-                    send_type func = (send_type)objc_msgSend;
-                    execStatus = func(kitRegister.wrapperInstance, selector, parameters[0], parameters[1], parameters[2]);
-                } else if (parameters.count == 2) {
-                    execStatus = [kitRegister.wrapperInstance performSelector:selector withObject:parameters[0] withObject:parameters[1]];
-                } else if (parameters.count == 1) {
-                    execStatus = [kitRegister.wrapperInstance performSelector:selector withObject:parameters[0]];
-                } else if (parameters.count == 0) {
-                    execStatus = [kitRegister.wrapperInstance performSelector:selector];
-#pragma clang diagnostic pop
-                } else {
-                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code returnCode:MPKitReturnCodeFail];
-                    MPILogError(@"Forwarded selector: %@ has illegal number of parameters: %@",  NSStringFromSelector(selector), [NSNumber numberWithUnsignedInteger:parameters.count]);
-                }
-            } else {
-                execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code returnCode:MPKitReturnCodeFail];
-                MPILogError(@"Forwarded selector: %@ is not supported by this kit",  NSStringFromSelector(selector));
+                    break;
+                case MPKitInvocationOutcomeCompletedWithoutStatus:
+                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code
+                                                              returnCode:MPKitReturnCodeSuccess];
+                    break;
+                case MPKitInvocationOutcomeNotImplemented:
+                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code
+                                                              returnCode:MPKitReturnCodeFail];
+                    MPILogError(@"Forwarded selector: %@ is not supported by this kit",
+                                NSStringFromSelector(effectiveSelector));
+                    break;
+                case MPKitInvocationOutcomeMissingArguments:
+                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code
+                                                              returnCode:MPKitReturnCodeFail];
+                    MPILogError(@"Forwarded selector: %@ is missing required arguments",
+                                NSStringFromSelector(effectiveSelector));
+                    break;
+                case MPKitInvocationOutcomeUnknownSelector:
+                    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code
+                                                              returnCode:MPKitReturnCodeFail];
+                    break;
             }
             
             if (execStatus.success) {
@@ -2348,6 +2340,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
                 MPILogError(@"Failed to forward SDK call to kit: %@ (code: %@)", kitRegister.name, kitRegister.code);
             }
         } @catch (NSException *e) {
+            execStatus = [[MPKitExecStatus alloc] initWithSDKCode:kitRegister.code returnCode:MPKitReturnCodeFail];
             MPILogError(@"Kit handler threw an exception: %@", e);
         }
         

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -1222,15 +1222,17 @@ MPLog* logger;
     [self logLTVIncrease:increaseAmount eventName:eventName eventInfo:nil];
 }
 
-- (void)logLTVIncreaseCallback:(MPEvent *)event execStatus:(MPExecStatus)execStatus {
+- (void)logLTVIncreaseCallback:(MPEvent *)event increaseAmount:(double)increaseAmount execStatus:(MPExecStatus)execStatus {
     if (execStatus == MPExecStatusSuccess) {
         MPEvent *kitEvent = self.dataPlanFilter != nil ? [self.dataPlanFilter transformEventForEvent:event] : event;
         if (kitEvent) {
             [executor executeOnMain: ^{
                 // Forwarding calls to kits
+                MPForwardQueueParameters *parameters = [[MPForwardQueueParameters alloc] init];
+                [parameters addParameter:@(increaseAmount)];
                 [self.kitContainer forwardSDKCall:@selector(logLTVIncrease:event:)
-                                                                     event:nil
-                                                                parameters:nil
+                                                                     event:kitEvent
+                                                                parameters:parameters
                                                                messageType:MPMessageTypeUnknown
                                                                   userInfo:nil
                 ];
@@ -1257,7 +1259,7 @@ MPLog* logger;
     
     [self.backendController logEvent:event
                    completionHandler:^(MPEvent *event, MPExecStatus execStatus) {
-        [self logLTVIncreaseCallback:event execStatus:execStatus];
+        [self logLTVIncreaseCallback:event increaseAmount:increaseAmount execStatus:execStatus];
     }];
 }
 


### PR DESCRIPTION
## Background

The container currently relies on dynamic selector invocation and manually cast message sends, which makes argument handling difficult to verify and caused incorrect scalar and LTV forwarding.

## What Has Changed

- Route supported kit selectors through a typed Swift invoker.
- Preserve optional-kit handling and block-based callbacks.
- Return explicit missing-argument and unknown-selector outcomes.
- Unbox wrapper SDK enum values before delivery.
- Forward both the amount and transformed event for LTV increases.
- Keep Objective-C exception containment at the SDK boundary.

## Screenshots/Video

N/A — no visual changes.

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally

## Testing

- Trunk checks and ABI guard
- Direct Swift selector-invoker tests
- Objective-C container regression tests
- Swift and Objective-C unit suites
- Core CocoaPods lint
