### PR TITLE
refactor: evaluate kit filtering policy in Swift

### DIFF
--- a/UnitTests/ObjCTests/MPKitContainerTests.m
+++ b/UnitTests/ObjCTests/MPKitContainerTests.m
@@ -1411,6 +1411,35 @@ static NSDictionary<NSString *, NSString *> *MPOptionalMethodTypes(Protocol *pro
     XCTAssertNil(kitFilter, @"Filter should have been nil.");
 }
 
+- (void)testMissingKitConfigurationStillForwardsEvent {
+    [kitContainer.kitConfigurations removeAllObjects];
+    MPEvent *event = [[MPEvent alloc] initWithName:@"Missing configuration" type:MPEventTypeOther];
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
+    id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
+    id kitRegisterMock = OCMPartialMock(kitRegister);
+    OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
+    [(id<MPKitProtocol>)[kitWrapperMock expect] logBaseEvent:OCMOCK_ANY];
+
+    [kitContainer filter:kitRegisterMock forEvent:event selector:@selector(logEvent:)];
+
+    [kitWrapperMock verifyWithDelay:5.0];
+}
+
+- (void)testMissingKitConfigurationStillForwardsCommerceEvent {
+    [kitContainer.kitConfigurations removeAllObjects];
+    MPProduct *product = [[MPProduct alloc] initWithName:@"Product" sku:@"sku" quantity:@1 price:@1];
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase product:product];
+    MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"AppsFlyer" className:@"MPKitAppsFlyerTest"];
+    id kitWrapperMock = OCMProtocolMock(@protocol(MPKitProtocol));
+    id kitRegisterMock = OCMPartialMock(kitRegister);
+    OCMStub([kitRegisterMock wrapperInstance]).andReturn(kitWrapperMock);
+    [(id<MPKitProtocol>)[kitWrapperMock expect] logBaseEvent:OCMOCK_ANY];
+
+    [kitContainer filter:kitRegisterMock forCommerceEvent:event];
+
+    [kitWrapperMock verifyWithDelay:5.0];
+}
+
 - (void)testFilterCommerceEvent_EventType {
     NSArray *configurations = @[
                                 @{

--- a/mParticle-Apple-SDK-Swift/Sources/Kits/MPKitFilterEngine.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Kits/MPKitFilterEngine.swift
@@ -1,0 +1,504 @@
+import Foundation
+
+/// A Foundation-only view of the filtering fields in a kit configuration.
+@objc(MPKitFilterConfigurationSnapshot)
+public final class MPKitFilterConfigurationSnapshot: NSObject {
+    fileprivate let filters: [String: Any]
+    fileprivate let attributeValueFilteringIsActive: Bool
+    fileprivate let attributeValueFilteringHashedAttribute: String?
+    fileprivate let attributeValueFilteringHashedValue: String?
+    fileprivate let attributeValueFilteringShouldIncludeMatches: Bool
+
+    /// Creates an immutable snapshot from the fields used by kit filtering.
+    @objc public init(filters: [AnyHashable: Any]?,
+                      attributeValueFilteringIsActive: Bool,
+                      attributeValueFilteringHashedAttribute: String?,
+                      attributeValueFilteringHashedValue: String?,
+                      attributeValueFilteringShouldIncludeMatches: Bool) {
+        self.filters = filters?.reduce(into: [:]) { result, element in
+            if let key = element.key as? String {
+                result[key] = element.value
+            }
+        } ?? [:]
+        self.attributeValueFilteringIsActive = attributeValueFilteringIsActive
+        self.attributeValueFilteringHashedAttribute = attributeValueFilteringHashedAttribute
+        self.attributeValueFilteringHashedValue = attributeValueFilteringHashedValue
+        self.attributeValueFilteringShouldIncludeMatches = attributeValueFilteringShouldIncludeMatches
+        super.init()
+    }
+}
+
+/// A Foundation-only view of an event used by the kit filter engine.
+@objc(MPKitEventSnapshot)
+public final class MPKitEventSnapshot: NSObject {
+    fileprivate let type: UInt
+    fileprivate let name: String
+    fileprivate let attributes: [String: Any]?
+    fileprivate let selectorName: String
+
+    /// Creates an immutable event snapshot.
+    @objc public init(type: UInt,
+                      name: String,
+                      attributes: [String: Any]?,
+                      selectorName: String) {
+        self.type = type
+        self.name = name
+        self.attributes = attributes
+        self.selectorName = selectorName
+        super.init()
+    }
+}
+
+/// A Foundation-only view of a user's consent state.
+@objc(MPKitConsentSnapshot)
+public final class MPKitConsentSnapshot: NSObject {
+    fileprivate let gdprConsents: [String: NSNumber]?
+    fileprivate let ccpaConsent: NSNumber?
+
+    /// Creates an immutable consent snapshot. A missing dictionary remains distinct from an empty one.
+    @objc public init(gdprConsents: [String: NSNumber]?, ccpaConsent: NSNumber?) {
+        self.gdprConsents = gdprConsents
+        self.ccpaConsent = ccpaConsent
+        super.init()
+    }
+}
+
+/// A Foundation-only view of a kit's consent matching rule.
+@objc(MPKitConsentFilterSnapshot)
+public final class MPKitConsentFilterSnapshot: NSObject {
+    fileprivate let javascriptHashes: [NSNumber]
+    fileprivate let consentedValues: [NSNumber]
+    fileprivate let shouldIncludeOnMatch: Bool
+
+    /// Creates an immutable consent-filter snapshot.
+    @objc public init(javascriptHashes: [NSNumber],
+                      consentedValues: [NSNumber],
+                      shouldIncludeOnMatch: Bool) {
+        self.javascriptHashes = javascriptHashes
+        self.consentedValues = consentedValues
+        self.shouldIncludeOnMatch = shouldIncludeOnMatch
+        super.init()
+    }
+}
+
+/// The entity-level action ObjC should apply to a commerce event copy.
+@objc public enum MPKitCommerceEntityAction: Int {
+    /// Continue applying commerce filters.
+    case continueFiltering
+    /// Remove product and impression entities and return the event copy.
+    case removeProductsAndImpressions
+    /// Remove promotion entities and return the event copy.
+    case removePromotions
+    /// Return the original event without applying additional filters.
+    case returnOriginalEvent
+}
+
+/// Describes the policy result for an event.
+@objc(MPKitEventFilterDecision)
+public final class MPKitEventFilterDecision: NSObject {
+    /// Whether the entire event should be filtered.
+    @objc public let shouldFilter: Bool
+    /// Attributes that remain after key filtering.
+    @objc public let filteredAttributes: [String: Any]?
+    /// The message type associated with the forwarded selector.
+    @objc public let messageType: String?
+
+    fileprivate init(shouldFilter: Bool,
+                     filteredAttributes: [String: Any]?,
+                     messageType: String?) {
+        self.shouldFilter = shouldFilter
+        self.filteredAttributes = filteredAttributes
+        self.messageType = messageType
+        super.init()
+    }
+}
+
+/// Describes the policy result for a commerce event.
+@objc(MPKitCommerceFilterDecision)
+public final class MPKitCommerceFilterDecision: NSObject {
+    /// Whether the entire commerce event should be filtered.
+    @objc public let shouldFilter: Bool
+    /// The entity-level action ObjC should apply.
+    @objc public let entityAction: MPKitCommerceEntityAction
+    /// The app-family property filter for the event kind.
+    @objc public let appFamilyFilter: [AnyHashable: Any]?
+    /// Expanded attributes that remain after filtering.
+    @objc public let filteredBeautifiedAttributes: [String: Any]?
+    /// Custom attributes that remain after filtering.
+    @objc public let filteredCustomAttributes: [String: Any]?
+    /// Transaction attribute keys that remain after filtering.
+    @objc public let allowedTransactionAttributeKeys: Set<String>?
+    /// Whether commerce attribute filters were configured.
+    @objc public let hasAttributeFilters: Bool
+
+    fileprivate init(shouldFilter: Bool,
+                     entityAction: MPKitCommerceEntityAction = .continueFiltering,
+                     appFamilyFilter: [AnyHashable: Any]? = nil,
+                     filteredBeautifiedAttributes: [String: Any]? = nil,
+                     filteredCustomAttributes: [String: Any]? = nil,
+                     allowedTransactionAttributeKeys: Set<String>? = nil,
+                     hasAttributeFilters: Bool = false) {
+        self.shouldFilter = shouldFilter
+        self.entityAction = entityAction
+        self.appFamilyFilter = appFamilyFilter
+        self.filteredBeautifiedAttributes = filteredBeautifiedAttributes
+        self.filteredCustomAttributes = filteredCustomAttributes
+        self.allowedTransactionAttributeKeys = allowedTransactionAttributeKeys
+        self.hasAttributeFilters = hasAttributeFilters
+        super.init()
+    }
+}
+
+/// The action ObjC should use to materialize a consent-filter decision.
+@objc public enum MPKitConsentAction: Int {
+    /// Preserve the existing nil filter result.
+    case noFilter
+    /// Filter the entire consent state.
+    case filterAll
+    /// Forward only the CCPA consent state.
+    case forwardCCPA
+    /// Forward the allowed GDPR purposes.
+    case forwardGDPR
+}
+
+/// Describes the policy result for a consent state.
+@objc(MPKitConsentDecision)
+public final class MPKitConsentDecision: NSObject {
+    /// The action ObjC should materialize.
+    @objc public let action: MPKitConsentAction
+    /// GDPR purpose names that remain after filtering.
+    @objc public let allowedGDPRPurposes: Set<String>
+
+    fileprivate init(action: MPKitConsentAction, allowedGDPRPurposes: Set<String> = []) {
+        self.action = action
+        self.allowedGDPRPurposes = allowedGDPRPurposes
+        super.init()
+    }
+}
+
+/// Evaluates kit filtering policy using Foundation-only snapshots and decisions.
+@objc(MPKitFilterEngine)
+public final class MPKitFilterEngine: NSObject {
+    private enum FilterKey {
+        static let eventType = "et"
+        static let eventName = "ec"
+        static let eventAttribute = "ea"
+        static let messageType = "mt"
+        static let screenName = "svec"
+        static let screenAttribute = "svea"
+        static let userIdentity = "uid"
+        static let userAttribute = "ua"
+        static let commerceAttribute = "cea"
+        static let commerceEntity = "ent"
+        static let commerceAppFamily = "afa"
+        static let consentRegulation = "reg"
+        static let consentPurpose = "pur"
+    }
+
+    private enum Consent {
+        static let gdprRegulation = "1"
+        static let ccpaRegulation = "2"
+        static let ccpaPurpose = "data_sale_opt_out"
+    }
+
+    private static let messageTypes = [
+        "logBaseEvent:": "e",
+        "logEvent:": "e",
+        "logScreen:": "v",
+        "logScreenEvent:": "v",
+        "beginSession": "ss",
+        "endSession": "se",
+        "logTransaction:": "e",
+        "logLTVIncrease:event:": "e",
+        "logLTVIncrease:eventName:eventInfo:": "e",
+        "leaveBreadcrumb:": "bc",
+        "logError:exception:topmostContext:eventInfo:": "x",
+        "logNetworkPerformanceMeasurement:": "npe",
+        "profileChange:": "pro",
+        "setOptOut:": "o",
+        "logCommerceEvent:": "cm"
+    ]
+
+    private let hasher: MPIHasher
+    private let attributeValueFilter: MPAttributeValueFilter
+
+    /// Creates a filter engine using the SDK's stable hashing implementation.
+    @objc public init(hasher: MPIHasher) {
+        self.hasher = hasher
+        attributeValueFilter = MPAttributeValueFilter(hasher: hasher)
+        super.init()
+    }
+
+    /// Returns the message type associated with a kit selector.
+    @objc public func messageType(forSelectorName selectorName: String) -> String? {
+        Self.messageTypes[selectorName]
+    }
+
+    /// Evaluates event, screen, message, name, attribute, and attribute-value filters.
+    @objc public func filterEvent(_ event: MPKitEventSnapshot,
+                                  configuration: MPKitFilterConfigurationSnapshot) -> MPKitEventFilterDecision {
+        let messageType = messageType(forSelectorName: event.selectorName)
+        guard includesAttributeValues(event.attributes, configuration: configuration) else {
+            return MPKitEventFilterDecision(shouldFilter: true,
+                                            filteredAttributes: nil,
+                                            messageType: messageType)
+        }
+
+        let isScreen = event.selectorName == "logScreen:"
+        if !isScreen,
+           isBlocked(hasher.hashString(String(event.type)),
+                     by: dictionary(configuration, FilterKey.eventType)) {
+            return MPKitEventFilterDecision(shouldFilter: true,
+                                            filteredAttributes: nil,
+                                            messageType: messageType)
+        }
+
+        if let messageType,
+           isBlocked(messageType, by: dictionary(configuration, FilterKey.messageType)) {
+            return MPKitEventFilterDecision(shouldFilter: true,
+                                            filteredAttributes: nil,
+                                            messageType: messageType)
+        }
+
+        let nameFilters = dictionary(configuration, isScreen ? FilterKey.screenName : FilterKey.eventName)
+        let nameHash = hasher.hashString(isScreen ? "0\(event.name)" : "\(event.type)\(event.name)")
+        if isBlocked(nameHash, by: nameFilters) {
+            return MPKitEventFilterDecision(shouldFilter: true,
+                                            filteredAttributes: nil,
+                                            messageType: messageType)
+        }
+
+        let attributeFilters = dictionary(configuration,
+                                          isScreen ? FilterKey.screenAttribute : FilterKey.eventAttribute)
+        let filteredAttributes = event.attributes?.reduce(into: [String: Any]()) { result, element in
+            let value = isScreen
+                ? "0\(event.name)\(element.key)"
+                : "\(event.type)\(event.name)\(element.key)"
+            if !isBlocked(hasher.hashString(value), by: attributeFilters) {
+                result[element.key] = element.value
+            }
+        }
+
+        return MPKitEventFilterDecision(shouldFilter: false,
+                                        filteredAttributes: filteredAttributes?.isEmpty == true ? nil : filteredAttributes,
+                                        messageType: messageType)
+    }
+
+    /// Evaluates message-type filtering for a base event selector.
+    @objc public func shouldFilterBaseEvent(selectorName: String,
+                                            configuration: MPKitFilterConfigurationSnapshot) -> Bool {
+        guard let messageType = messageType(forSelectorName: selectorName) else { return false }
+        return isBlocked(messageType, by: dictionary(configuration, FilterKey.messageType))
+    }
+
+    /// Evaluates commerce event, entity, app-family, attribute, and attribute-value filters.
+    @objc public func filterCommerceEvent(type: UInt,
+                                          kind: Int,
+                                          customAttributes: [String: Any]?,
+                                          beautifiedAttributes: [String: Any]?,
+                                          transactionAttributes: [String: Any]?,
+                                          configuration: MPKitFilterConfigurationSnapshot) -> MPKitCommerceFilterDecision {
+        guard includesAttributeValues(customAttributes, configuration: configuration),
+              !isBlocked(hasher.hashString(String(type)),
+                         by: dictionary(configuration, FilterKey.eventType)) else {
+            return MPKitCommerceFilterDecision(shouldFilter: true)
+        }
+
+        let kindString = String(kind)
+        if isBlocked(kindString, by: dictionary(configuration, FilterKey.commerceEntity)) {
+            switch kind {
+            case 1, 3:
+                return MPKitCommerceFilterDecision(shouldFilter: false,
+                                                   entityAction: .removeProductsAndImpressions)
+            case 2:
+                return MPKitCommerceFilterDecision(shouldFilter: false,
+                                                   entityAction: .removePromotions)
+            default:
+                return MPKitCommerceFilterDecision(shouldFilter: false,
+                                                   entityAction: .returnOriginalEvent)
+            }
+        }
+
+        let appFamilyFilters = dictionary(configuration, FilterKey.commerceAppFamily)?[kindString]
+            as? [AnyHashable: Any]
+        guard let attributeFilters = dictionary(configuration, FilterKey.commerceAttribute) else {
+            return MPKitCommerceFilterDecision(shouldFilter: false,
+                                               appFamilyFilter: appFamilyFilters)
+        }
+
+        func filtered(_ attributes: [String: Any]?) -> [String: Any]? {
+            guard let attributes else { return nil }
+            let result = attributes.reduce(into: [String: Any]()) { result, element in
+                let hash = hasher.hashString("\(type)\(element.key)")
+                if !isBlocked(hash, by: attributeFilters) {
+                    result[element.key] = element.value
+                }
+            }
+            return result.isEmpty ? nil : result
+        }
+
+        let allowedTransactionKeys = Set(transactionAttributes?.keys.filter { key in
+            !isBlocked(hasher.hashString("\(type)\(key)"), by: attributeFilters)
+        } ?? [])
+
+        return MPKitCommerceFilterDecision(
+            shouldFilter: false,
+            appFamilyFilter: appFamilyFilters,
+            filteredBeautifiedAttributes: filtered(beautifiedAttributes),
+            filteredCustomAttributes: filtered(customAttributes),
+            allowedTransactionAttributeKeys: allowedTransactionKeys,
+            hasAttributeFilters: true
+        )
+    }
+
+    /// Returns user attributes that remain after filtering, preserving nil and empty-result behavior.
+    @objc public func filterUserAttributes(_ attributes: [String: Any]?,
+                                           configuration: MPKitFilterConfigurationSnapshot?) -> [String: Any]? {
+        guard let attributes, let configuration else { return nil }
+        let filters = dictionary(configuration, FilterKey.userAttribute)
+        let result = attributes.reduce(into: [String: Any]()) { result, element in
+            if !isBlocked(hasher.hashUserAttributeKey(element.key), by: filters) {
+                result[element.key] = element.value
+            }
+        }
+        return result.isEmpty ? nil : result
+    }
+
+    /// Returns whether a single user attribute should be filtered.
+    @objc public func shouldFilterUserAttribute(key: String,
+                                                configuration: MPKitFilterConfigurationSnapshot?) -> Bool {
+        guard let configuration else { return false }
+        return isBlocked(hasher.hashUserAttributeKey(key),
+                         by: dictionary(configuration, FilterKey.userAttribute))
+    }
+
+    /// Returns whether a user identity type should be filtered.
+    @objc public func shouldFilterUserIdentity(type: UInt,
+                                               configuration: MPKitFilterConfigurationSnapshot?) -> Bool {
+        guard let configuration else { return false }
+        return isBlocked(String(type), by: dictionary(configuration, FilterKey.userIdentity))
+    }
+
+    /// Evaluates consent regulation and purpose filters.
+    @objc public func filterConsent(_ consent: MPKitConsentSnapshot,
+                                    configuration: MPKitFilterConfigurationSnapshot?) -> MPKitConsentDecision {
+        guard let configuration else { return MPKitConsentDecision(action: .noFilter) }
+
+        if consent.ccpaConsent != nil {
+            let hash = hasher.hashConsentPurpose(Consent.ccpaRegulation, purpose: Consent.ccpaPurpose)
+            let action: MPKitConsentAction = isBlocked(
+                hash,
+                by: dictionary(configuration, FilterKey.consentRegulation)
+            ) ? .filterAll : .forwardCCPA
+            return MPKitConsentDecision(action: action)
+        }
+
+        if consent.gdprConsents != nil {
+            let hash = hasher.hashConsentPurpose(Consent.gdprRegulation, purpose: "")
+            if isBlocked(hash, by: dictionary(configuration, FilterKey.consentRegulation)) {
+                return MPKitConsentDecision(action: .filterAll)
+            }
+        }
+
+        guard let gdprConsents = consent.gdprConsents,
+              !gdprConsents.isEmpty,
+              dictionary(configuration, FilterKey.consentPurpose) != nil else {
+            return MPKitConsentDecision(action: .noFilter)
+        }
+
+        let purposeFilters = dictionary(configuration, FilterKey.consentPurpose)
+        let allowedPurposes = Set(gdprConsents.keys.filter { purpose in
+            let hash = hasher.hashConsentPurpose(Consent.gdprRegulation, purpose: purpose)
+            return !isBlocked(hash, by: purposeFilters)
+        })
+        return allowedPurposes.isEmpty
+            ? MPKitConsentDecision(action: .noFilter)
+            : MPKitConsentDecision(action: .forwardGDPR, allowedGDPRPurposes: allowedPurposes)
+    }
+
+    /// Returns whether a kit should be disabled by its consent matching rule.
+    @objc public func isDisabledByConsentFilter(_ filter: MPKitConsentFilterSnapshot?,
+                                                consent: MPKitConsentSnapshot?) -> Bool {
+        var isMatch = false
+        if let filter, let consent {
+            for (index, hashNumber) in filter.javascriptHashes.enumerated() {
+                guard index < filter.consentedValues.count else { continue }
+                let hash = hashNumber.stringValue
+                let consented = filter.consentedValues[index].boolValue
+
+                for (purpose, userConsented) in consent.gdprConsents ?? [:] {
+                    let purposeHash = hasher.hashConsentPurpose(Consent.gdprRegulation, purpose: purpose)
+                    if consented == userConsented.boolValue, purposeHash == hash {
+                        isMatch = true
+                        break
+                    }
+                }
+
+                if let ccpaConsent = consent.ccpaConsent {
+                    let purposeHash = hasher.hashConsentPurpose(Consent.ccpaRegulation,
+                                                                purpose: Consent.ccpaPurpose)
+                    if consented == ccpaConsent.boolValue, purposeHash == hash {
+                        isMatch = true
+                        break
+                    }
+                }
+            }
+        }
+
+        let shouldInclude = filter?.shouldIncludeOnMatch == true ? isMatch : !isMatch
+        return !shouldInclude
+    }
+
+    /// Returns whether an optional bracket excludes the current user.
+    @objc public func isDisabledByBracket(mpId: Int64,
+                                          low: Int16,
+                                          high: Int16,
+                                          hasBracket: Bool) -> Bool {
+        hasBracket && !MPBracket(mpId: mpId, low: low, high: high).shouldForward()
+    }
+
+    /// Combines consent and explicit disabled-kit policy.
+    @objc public func isKitDisabled(isDisabledKit: Bool,
+                                    consentFilter: MPKitConsentFilterSnapshot?,
+                                    consent: MPKitConsentSnapshot?) -> Bool {
+        isDisabledKit || isDisabledByConsentFilter(consentFilter, consent: consent)
+    }
+
+    /// Combines active, bracket, consent, anonymous-user, and disabled-kit decisions.
+    @objc public func isKitActive(active: Bool,
+                                  mpId: Int64,
+                                  bracketLow: Int16,
+                                  bracketHigh: Int16,
+                                  hasBracket: Bool,
+                                  consentFilter: MPKitConsentFilterSnapshot?,
+                                  consent: MPKitConsentSnapshot?,
+                                  excludesAnonymousUsers: Bool,
+                                  isLoggedIn: Bool,
+                                  isDisabledKit: Bool) -> Bool {
+        active &&
+            !isDisabledByBracket(mpId: mpId, low: bracketLow, high: bracketHigh, hasBracket: hasBracket) &&
+            !isKitDisabled(isDisabledKit: isDisabledKit, consentFilter: consentFilter, consent: consent) &&
+            !(excludesAnonymousUsers && !isLoggedIn)
+    }
+
+    private func includesAttributeValues(_ attributes: [String: Any]?,
+                                         configuration: MPKitFilterConfigurationSnapshot) -> Bool {
+        attributeValueFilter.shouldIncludeEvent(
+            withAttributes: attributes,
+            filteringActive: configuration.attributeValueFilteringIsActive,
+            hashedAttribute: configuration.attributeValueFilteringHashedAttribute,
+            hashedValue: configuration.attributeValueFilteringHashedValue,
+            shouldIncludeMatches: configuration.attributeValueFilteringShouldIncludeMatches
+        )
+    }
+
+    private func dictionary(_ configuration: MPKitFilterConfigurationSnapshot,
+                            _ key: String) -> [String: Any]? {
+        configuration.filters[key] as? [String: Any]
+    }
+
+    private func isBlocked(_ key: String, by filters: [String: Any]?) -> Bool {
+        guard let number = filters?[key] as? NSNumber else { return false }
+        return number.compare(0) == .orderedSame
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Kits/MPKitFilterEngineTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Kits/MPKitFilterEngineTests.swift
@@ -1,0 +1,119 @@
+@testable import mParticle_Apple_SDK_Swift
+import XCTest
+
+final class MPKitFilterEngineTests: XCTestCase {
+    private let hasher = MPIHasher(logger: MPLog(logLevel: .none))
+
+    func testEventDecisionAppliesNameAttributeAndMessageFilters() {
+        let engine = MPKitFilterEngine(hasher: hasher)
+        let eventType: UInt = 1
+        let eventName = "Viewed"
+        let blockedAttribute = hasher.hashString("\(eventType)\(eventName)secret")
+        let snapshot = configuration(filters: [
+            "ea": [blockedAttribute: 0],
+            "mt": ["e": 1]
+        ])
+        let event = MPKitEventSnapshot(type: eventType,
+                                       name: eventName,
+                                       attributes: ["keep": NSNull(), "secret": "value"],
+                                       selectorName: "logEvent:")
+
+        let decision = engine.filterEvent(event, configuration: snapshot)
+
+        XCTAssertFalse(decision.shouldFilter)
+        XCTAssertEqual(decision.messageType, "e")
+        XCTAssertEqual(decision.filteredAttributes?.count, 1)
+        XCTAssertTrue(decision.filteredAttributes?["keep"] is NSNull)
+    }
+
+    func testOnlyNumericZeroBlocksAFilterKey() {
+        let engine = MPKitFilterEngine(hasher: hasher)
+        let eventType: UInt = 2
+        let hash = hasher.hashString(String(eventType))
+        let event = MPKitEventSnapshot(type: eventType,
+                                       name: "event",
+                                       attributes: nil,
+                                       selectorName: "logEvent:")
+
+        XCTAssertFalse(engine.filterEvent(event,
+                                          configuration: configuration(filters: ["et": [hash: 0.5]]))
+            .shouldFilter)
+        XCTAssertTrue(engine.filterEvent(event,
+                                         configuration: configuration(filters: ["et": [hash: 0]]))
+            .shouldFilter)
+    }
+
+    func testCommerceDecisionReturnsEntityAndAttributeActions() {
+        let engine = MPKitFilterEngine(hasher: hasher)
+        let eventType: UInt = 16
+        let blockedAttribute = hasher.hashString("\(eventType)coupon")
+
+        let entityDecision = engine.filterCommerceEvent(
+            type: eventType,
+            kind: 1,
+            customAttributes: nil,
+            beautifiedAttributes: nil,
+            transactionAttributes: nil,
+            configuration: configuration(filters: ["ent": ["1": 0]])
+        )
+        XCTAssertEqual(entityDecision.entityAction, .removeProductsAndImpressions)
+
+        let attributeDecision = engine.filterCommerceEvent(
+            type: eventType,
+            kind: 1,
+            customAttributes: ["coupon": "private", "keep": NSNull()],
+            beautifiedAttributes: [:],
+            transactionAttributes: ["coupon": "private", "transaction_id": "id"],
+            configuration: configuration(filters: ["cea": [blockedAttribute: 0]])
+        )
+        XCTAssertTrue(attributeDecision.hasAttributeFilters)
+        XCTAssertTrue(attributeDecision.filteredCustomAttributes?["keep"] is NSNull)
+        XCTAssertNil(attributeDecision.filteredCustomAttributes?["coupon"])
+        XCTAssertFalse(attributeDecision.allowedTransactionAttributeKeys?.contains("coupon") == true)
+        XCTAssertTrue(attributeDecision.allowedTransactionAttributeKeys?.contains("transaction_id") == true)
+    }
+
+    func testCCPAConsentTakesPrecedenceOverGDPR() {
+        let engine = MPKitFilterEngine(hasher: hasher)
+        let gdprRegulation = hasher.hashConsentPurpose("1", purpose: "")
+        let consent = MPKitConsentSnapshot(gdprConsents: ["analytics": true], ccpaConsent: false)
+
+        let decision = engine.filterConsent(
+            consent,
+            configuration: configuration(filters: ["reg": [gdprRegulation: 0]])
+        )
+
+        XCTAssertEqual(decision.action, .forwardCCPA)
+    }
+
+    func testConsentAndAnonymousDecisionsComposeWithActiveState() {
+        let engine = MPKitFilterEngine(hasher: hasher)
+        let hash = Int32(hasher.hashConsentPurpose("1", purpose: "analytics"))!
+        let consent = MPKitConsentSnapshot(gdprConsents: ["analytics": true], ccpaConsent: nil)
+        let filter = MPKitConsentFilterSnapshot(javascriptHashes: [NSNumber(value: hash)],
+                                                consentedValues: [true],
+                                                shouldIncludeOnMatch: true)
+
+        XCTAssertFalse(engine.isDisabledByConsentFilter(filter, consent: consent))
+        XCTAssertFalse(engine.isKitActive(active: true,
+                                          mpId: 256,
+                                          bracketLow: 0,
+                                          bracketHigh: 100,
+                                          hasBracket: true,
+                                          consentFilter: filter,
+                                          consent: consent,
+                                          excludesAnonymousUsers: true,
+                                          isLoggedIn: false,
+                                          isDisabledKit: false))
+    }
+
+    private func configuration(filters: [String: Any]) -> MPKitFilterConfigurationSnapshot {
+        MPKitFilterConfigurationSnapshot(
+            filters: filters,
+            attributeValueFilteringIsActive: false,
+            attributeValueFilteringHashedAttribute: nil,
+            attributeValueFilteringHashedValue: nil,
+            attributeValueFilteringShouldIncludeMatches: false
+        )
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Kits/MPKitFilterEngineTests.swift,
 				Test/Kits/MPKitSelectorInvokerTests.swift,
 				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
@@ -637,6 +638,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Kits/MPKitFilterEngineTests.swift,
 				Test/Kits/MPKitSelectorInvokerTests.swift,
 				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -76,7 +76,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 @property (nonatomic, strong) NSDate *initializedTime;
 @property (nonatomic, strong) MPIHasher *hasher;
 @property (nonatomic, strong) MPKitValueTransformer *valueTransformer;
-@property (nonatomic, strong) MPAttributeValueFilter *attributeValueFilter;
+@property (nonatomic, strong) MPKitFilterEngine *filterEngine;
 @property (nonatomic, strong) MPKitSelectorInvoker *selectorInvoker;
 @end
 
@@ -106,7 +106,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         logger.customLogger = mparticle.customLogger;
         _hasher = [[MPIHasher alloc] initWithLogger:logger];
         _valueTransformer = [[MPKitValueTransformer alloc] initWithLogger:logger];
-        _attributeValueFilter = [[MPAttributeValueFilter alloc] initWithHasher:_hasher];
+        _filterEngine = [[MPKitFilterEngine alloc] initWithHasher:_hasher];
         _selectorInvoker = [[MPKitSelectorInvoker alloc] initWithLogger:logger];
         _attributionCompletionHandler = [^void(MPAttributionResult *_Nullable attributionResult, NSError * _Nullable error) {
             if (attributionResult && attributionResult.kitCode) {
@@ -308,7 +308,9 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
     
     for (NSDictionary *kitConfigurationDictionary in directoryContents) {
         MPKitConfiguration *kitConfiguration = [[MPKitConfiguration alloc] initWithDictionary:kitConfigurationDictionary];
-        BOOL shouldStartKit = !(_disabledKits != nil && [_disabledKits containsObject:kitConfiguration.integrationId]);
+        BOOL shouldStartKit = ![self.filterEngine isKitDisabledWithIsDisabledKit:[_disabledKits containsObject:kitConfiguration.integrationId]
+                                                                consentFilter:nil
+                                                                      consent:nil];
         if (shouldStartKit) {
             self.kitConfigurations[kitConfiguration.integrationId] = kitConfiguration;
             [self startKit:kitConfiguration.integrationId configuration:kitConfiguration];
@@ -340,28 +342,6 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
             MPILogVerbose(@"%@", listOfKits);
         }
     }
-}
-
-- (NSDictionary *)methodMessageTypeMapping {
-    NSString *messageTypeEvent = kMPMessageTypeStringEvent;
-    
-    NSDictionary *methodMessageTypeDictionary = @{@"logBaseEvent:":messageTypeEvent,
-                                                  @"logEvent:":messageTypeEvent,
-                                                  @"logScreen:":kMPMessageTypeStringScreenView,
-                                                  @"logScreenEvent:":kMPMessageTypeStringScreenView,
-                                                  @"beginSession":kMPMessageTypeStringSessionStart,
-                                                  @"endSession":kMPMessageTypeStringSessionEnd,
-                                                  @"logTransaction:":messageTypeEvent,
-                                                  @"logLTVIncrease:eventName:eventInfo:":messageTypeEvent,
-                                                  @"leaveBreadcrumb:":kMPMessageTypeStringBreadcrumb,
-                                                  @"logError:exception:topmostContext:eventInfo:":kMPMessageTypeStringCrashReport,
-                                                  @"logNetworkPerformanceMeasurement:":kMPMessageTypeStringNetworkPerformance,
-                                                  @"profileChange:":kMPMessageTypeStringProfile,
-                                                  @"setOptOut:":kMPMessageTypeStringOptOut,
-                                                  @"logCommerceEvent:":kMPMessageTypeStringCommerceEvent
-                                                  };
-    
-    return methodMessageTypeDictionary;
 }
 
 - (nullable NSString *)nameForKitCode:(nonnull NSNumber *)integrationId {
@@ -406,88 +386,76 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
     }
 }
 
-- (BOOL)shouldIncludeEventWithAttributes:(NSDictionary<NSString *, id> *)attributes afterAttributeValueFilteringWithConfiguration:(MPKitConfiguration *)configuration {
-    return [self.attributeValueFilter shouldIncludeEventWithAttributes:attributes
-                                                      filteringActive:configuration.attributeValueFilteringIsActive
-                                                      hashedAttribute:configuration.attributeValueFilteringHashedAttribute
-                                                          hashedValue:configuration.attributeValueFilteringHashedValue
-                                                 shouldIncludeMatches:configuration.attributeValueFilteringShouldIncludeMatches];
+- (MPKitFilterConfigurationSnapshot *)filterSnapshotForConfiguration:(MPKitConfiguration *)configuration {
+    if (!configuration) {
+        return nil;
+    }
+
+    return [[MPKitFilterConfigurationSnapshot alloc]
+        initWithFilters:configuration.filters
+        attributeValueFilteringIsActive:configuration.attributeValueFilteringIsActive
+        attributeValueFilteringHashedAttribute:configuration.attributeValueFilteringHashedAttribute
+        attributeValueFilteringHashedValue:configuration.attributeValueFilteringHashedValue
+        attributeValueFilteringShouldIncludeMatches:configuration.attributeValueFilteringShouldIncludeMatches];
+}
+
+- (MPKitConsentSnapshot *)consentSnapshotForState:(MPConsentState *)state {
+    if (!state) {
+        return nil;
+    }
+
+    NSMutableDictionary<NSString *, NSNumber *> *gdprConsents;
+    if (state.gdprConsentState) {
+        gdprConsents = [[NSMutableDictionary alloc] initWithCapacity:state.gdprConsentState.count];
+        [state.gdprConsentState enumerateKeysAndObjectsUsingBlock:^(NSString *purpose, MPGDPRConsent *consent, BOOL *stop) {
+            gdprConsents[purpose] = @(consent.consented);
+        }];
+    }
+
+    NSNumber *ccpaConsent = state.ccpaConsentState ? @(state.ccpaConsentState.consented) : nil;
+    return [[MPKitConsentSnapshot alloc] initWithGdprConsents:gdprConsents ccpaConsent:ccpaConsent];
+}
+
+- (MPKitConsentFilterSnapshot *)consentFilterSnapshotForFilter:(MPConsentKitFilter *)filter {
+    if (!filter) {
+        return nil;
+    }
+
+    NSMutableArray<NSNumber *> *hashes = [[NSMutableArray alloc] initWithCapacity:filter.filterItems.count];
+    NSMutableArray<NSNumber *> *consentedValues = [[NSMutableArray alloc] initWithCapacity:filter.filterItems.count];
+    for (MPConsentKitFilterItem *item in filter.filterItems) {
+        [hashes addObject:@(item.javascriptHash)];
+        [consentedValues addObject:@(item.consented)];
+    }
+
+    return [[MPKitConsentFilterSnapshot alloc] initWithJavascriptHashes:hashes
+                                                       consentedValues:consentedValues
+                                                  shouldIncludeOnMatch:filter.shouldIncludeOnMatch];
 }
 
 - (BOOL)isDisabledByBracketConfiguration:(NSDictionary *)bracketConfiguration {
-    if (!bracketConfiguration) {
-        return NO;
-    }
-    NSString *const MPKitBracketLowKey = @"lo";
-    NSString *const MPKitBracketHighKey = @"hi";
-    
-    long mpId = [[MPPersistenceController_PRIVATE mpId] longValue];
-    short low = (short)[bracketConfiguration[MPKitBracketLowKey] integerValue];
-    short high = (short)[bracketConfiguration[MPKitBracketHighKey] integerValue];
-    MPBracket *localBracket = [[MPBracket alloc] initWithMpId:mpId low:low high:high];
-    return ![localBracket shouldForward];
+    int64_t mpId = [[MPPersistenceController_PRIVATE mpId] longLongValue];
+    int16_t low = (int16_t)[bracketConfiguration[@"lo"] integerValue];
+    int16_t high = (int16_t)[bracketConfiguration[@"hi"] integerValue];
+    return [self.filterEngine isDisabledByBracketWithMpId:mpId
+                                                      low:low
+                                                     high:high
+                                               hasBracket:bracketConfiguration != nil];
 }
 
 - (BOOL)isDisabledByConsentKitFilter:(MPConsentKitFilter *)kitFilter {
-    BOOL isMatch = NO;
-
-    if (kitFilter) {
-        NSArray<MPConsentKitFilterItem *> *itemsArray = kitFilter.filterItems;
-        for (MPConsentKitFilterItem *item in itemsArray) {
-            int hash = item.javascriptHash;
-            
-            NSString *hashString = @(hash).stringValue;
-            BOOL consented = item.consented;
-            
-            MPConsentState *state = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:[MParticle sharedInstance].identity.currentUser.userId];
-            
-            if (state != nil) {
-                NSDictionary<NSString *, MPGDPRConsent *> *gdprConsentState = [state.gdprConsentState copy];
-                for (NSString *purpose in gdprConsentState) {
-                    
-                    MPGDPRConsent *gdprConsent = gdprConsentState[purpose];
-                    BOOL userConsented = gdprConsent.consented;
-                    
-                    NSString *purposeHash = [_hasher hashConsentPurpose:kMPConsentGDPRRegulationType purpose:purpose];
-                    
-                    if (consented == userConsented && [purposeHash isEqual:hashString]) {
-                        isMatch = YES;
-                        break;
-                    }
-                }
-                
-                MPCCPAConsent *ccpaConsentState = state.ccpaConsentState;
-                
-                if (ccpaConsentState != nil) {
-                    NSString *purposeHash = [_hasher hashConsentPurpose:kMPConsentCCPARegulationType purpose:kMPConsentCCPAPurposeName];
-                    
-                    if (consented == ccpaConsentState.consented && [purposeHash isEqual:hashString]) {
-                        isMatch = YES;
-                        break;
-                    }
-                }
-            }
-            
-            
-        }
-    }
-    
-    BOOL shouldInclude;
-    if (kitFilter.shouldIncludeOnMatch) {
-        shouldInclude = isMatch;
-    } else {
-        shouldInclude = !isMatch;
-    }
-    
-    BOOL shouldDisable = !shouldInclude;
-    return shouldDisable;
+    MPConsentState *state = [MPPersistenceController_PRIVATE
+        effectiveConsentStateForMpid:[MParticle sharedInstance].identity.currentUser.userId];
+    return [self.filterEngine isDisabledByConsentFilter:[self consentFilterSnapshotForFilter:kitFilter]
+                                                consent:[self consentSnapshotForState:state]];
 }
 
 - (BOOL)isKitDisabled:(NSNumber *)kitCode {
-    BOOL disabledByConsent =  [self isDisabledByConsentKitFilter:self.kitConfigurations[kitCode].consentKitFilter];
-    BOOL disabledKit = [_disabledKits containsObject:kitCode];
-
-    return disabledByConsent || disabledKit;
+    MPConsentState *state = [MPPersistenceController_PRIVATE
+        effectiveConsentStateForMpid:[MParticle sharedInstance].identity.currentUser.userId];
+    return [self.filterEngine isKitDisabledWithIsDisabledKit:[_disabledKits containsObject:kitCode]
+                                               consentFilter:[self consentFilterSnapshotForFilter:self.kitConfigurations[kitCode].consentKitFilter]
+                                                     consent:[self consentSnapshotForState:state]];
 }
 
 - (id<MPKitProtocol>)startKit:(NSNumber *)integrationId configuration:(MPKitConfiguration *)kitConfiguration {
@@ -603,174 +571,121 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 #pragma mark Filtering methods
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forCommerceEvent:(MPCommerceEvent *const)commerceEvent {
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    NSNumber *zero = @0;
     __block MPKitFilter *kitFilter = [[MPKitFilter alloc] initWithCommerceEvent:commerceEvent shouldFilter:NO];
-    
-    // Attribute value filtering
-    if (![self shouldIncludeEventWithAttributes:commerceEvent.customAttributes afterAttributeValueFilteringWithConfiguration:kitConfiguration]) {
-        kitFilter = [[MPKitFilter alloc] initWithCommerceEvent:commerceEvent shouldFilter:YES];
+    MPKitFilterConfigurationSnapshot *configurationSnapshot = [self filterSnapshotForConfiguration:kitConfiguration];
+    if (!configurationSnapshot) {
         return kitFilter;
     }
-    
-    // Event type filter
-    __block NSString *hashValue = [_hasher hashEventType:(MPEventTypeSwift)[commerceEvent type]];
-    
-    __block BOOL shouldFilter = kitConfiguration.eventTypeFilters[hashValue] && [kitConfiguration.eventTypeFilters[hashValue] isEqualToNumber:zero];
-    if (shouldFilter) {
-        kitFilter = [[MPKitFilter alloc] initWithCommerceEvent:commerceEvent shouldFilter:shouldFilter];
-        return kitFilter;
-    }
-    
-    __block MPCommerceEvent *forwardCommerceEvent = [commerceEvent copy];
-    
-    // Entity type filter
-    MPCommerceEventKind commerceEventKind = [commerceEvent kind];
-    NSString *commerceEventKindValue = [@(commerceEventKind) stringValue];
-    shouldFilter = [kitConfiguration.commerceEventEntityTypeFilters[commerceEventKindValue] isEqualToNumber:zero];
-    if (shouldFilter) {
-        switch (commerceEventKind) {
-            case MPCommerceEventKindProduct:
-            case MPCommerceEventKindImpression:
-                [forwardCommerceEvent setProducts:nil];
-                [forwardCommerceEvent setImpressions:nil];
-                break;
-                
-            case MPCommerceEventKindPromotion:
-                [forwardCommerceEvent.promotionContainer setPromotions:nil];
-                break;
-                
-            default:
-                forwardCommerceEvent = nil;
-                break;
-        }
-        
-        if (forwardCommerceEvent) {
-            kitFilter = [[MPKitFilter alloc] initWithCommerceEvent:forwardCommerceEvent shouldFilter:NO];
-        } else {
-            kitFilter = [[MPKitFilter alloc] initWithCommerceEvent:commerceEvent shouldFilter:NO];
-        }
-        
-        return kitFilter;
-    } else { // App family attribute and Commerce event attribute filters
-        // App family attribute filter
-        NSDictionary *appFamilyFilter = kitConfiguration.commerceEventAppFamilyAttributeFilters[commerceEventKindValue];
-        
-        if (appFamilyFilter.count > 0) {
-            switch (commerceEventKind) {
-                case MPCommerceEventKindProduct: {
-                    __block NSMutableArray *products = [[NSMutableArray alloc] init];
-                    
-                    [commerceEvent.products enumerateObjectsUsingBlock:^(MPProduct *product, NSUInteger idx, BOOL *stop) {
-                        MPProduct *filteredProduct = [product copyMatchingHashedProperties:appFamilyFilter];
-                        
-                        if (filteredProduct) {
-                            [products addObject:filteredProduct];
-                        }
-                    }];
-                    
-                    if (products.count > 0) {
-                        [forwardCommerceEvent setProducts:products];
-                    }
-                }
-                    break;
-                    
-                case MPCommerceEventKindImpression:
-                    forwardCommerceEvent.impressions = [commerceEvent copyImpressionsMatchingHashedProperties:appFamilyFilter];
-                    break;
-                    
-                case MPCommerceEventKindPromotion:
-                    forwardCommerceEvent.promotionContainer = [commerceEvent.promotionContainer copyMatchingHashedProperties:appFamilyFilter];
-                    break;
-                    
-                default:
-                    break;
-            }
-        }
-        
-        NSDictionary *commerceEventAttributeFilters = kitConfiguration.commerceEventAttributeFilters;
-        if (commerceEventAttributeFilters) {
-            // Commerce event attribute filter (expanded attributes)
-            __block NSMutableDictionary *filteredAttributes = [[NSMutableDictionary alloc] init];
-            [[forwardCommerceEvent beautifiedAttributes] enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
-                hashValue = [_hasher hashCommerceEventAttribute:(MPEventTypeSwift)[commerceEvent type] key:key];
-                
-                id filterValue = commerceEventAttributeFilters[hashValue];
-                BOOL filterValueIsFalse = [filterValue isEqualToNumber:zero];
-                
-                if (!filterValue || (filterValue && !filterValueIsFalse)) {
-                    filteredAttributes[key] = obj;
-                }
-            }];
-            
-            [forwardCommerceEvent setBeautifiedAttributes:(filteredAttributes.count > 0 ? filteredAttributes : nil)];
-            
-            // Commerce event attribute filter (user defined attributes)
-            filteredAttributes = [[NSMutableDictionary alloc] init];
-            
-            [[forwardCommerceEvent customAttributes] enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
-                hashValue = [_hasher hashCommerceEventAttribute:(MPEventTypeSwift)[commerceEvent type] key:key];
 
-                id filterValue = commerceEventAttributeFilters[hashValue];
-                BOOL filterValueIsFalse = [filterValue isEqualToNumber:zero];
-                
-                if (!filterValue || (filterValue && !filterValueIsFalse)) {
-                    filteredAttributes[key] = obj;
-                }
-            }];
-            
-            [forwardCommerceEvent setCustomAttributes:(filteredAttributes.count > 0 ? filteredAttributes : nil)];
-            
-            // Transaction attributes
-            __block MPTransactionAttributes *filteredTransactionAttributes = [[MPTransactionAttributes alloc] init];
-            
-            [[forwardCommerceEvent.transactionAttributes beautifiedDictionaryRepresentation] enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull obj, BOOL * _Nonnull stop) {
-                hashValue = [_hasher hashCommerceEventAttribute:(MPEventTypeSwift)[commerceEvent type] key:key];
-                
-                id filterValue = commerceEventAttributeFilters[hashValue];
-                BOOL filterValueIsFalse = [filterValue isEqualToNumber:zero];
-                
-                if (!filterValue || (filterValue && !filterValueIsFalse)) {
-                    if ([key isEqualToString:kMPExpTAAffiliation]) {
-                        filteredTransactionAttributes.affiliation = forwardCommerceEvent.transactionAttributes.affiliation;
-                    } else if ([key isEqualToString:kMPExpTAShipping]) {
-                        filteredTransactionAttributes.shipping = forwardCommerceEvent.transactionAttributes.shipping;
-                    } else if ([key isEqualToString:kMPExpTATax]) {
-                        filteredTransactionAttributes.tax = forwardCommerceEvent.transactionAttributes.tax;
-                    } else if ([key isEqualToString:kMPExpTARevenue]) {
-                        filteredTransactionAttributes.revenue = forwardCommerceEvent.transactionAttributes.revenue;
-                    } else if ([key isEqualToString:kMPExpTATransactionId]) {
-                        filteredTransactionAttributes.transactionId = forwardCommerceEvent.transactionAttributes.transactionId;
-                    } else if ([key isEqualToString:kMPExpTACouponCode]) {
-                        filteredTransactionAttributes.couponCode = forwardCommerceEvent.transactionAttributes.couponCode;
+    MPCommerceEventKind commerceEventKind = [commerceEvent kind];
+    MPKitCommerceFilterDecision *decision = [self.filterEngine
+        filterCommerceEventWithType:(NSUInteger)commerceEvent.type
+        kind:(NSInteger)commerceEventKind
+        customAttributes:commerceEvent.customAttributes
+        beautifiedAttributes:commerceEvent.beautifiedAttributes
+        transactionAttributes:commerceEvent.transactionAttributes.beautifiedDictionaryRepresentation
+        configuration:configurationSnapshot];
+    if (decision.shouldFilter) {
+        return [[MPKitFilter alloc] initWithCommerceEvent:commerceEvent shouldFilter:YES];
+    }
+
+    __block MPCommerceEvent *forwardCommerceEvent = [commerceEvent copy];
+    switch (decision.entityAction) {
+        case MPKitCommerceEntityActionRemoveProductsAndImpressions:
+            [forwardCommerceEvent setProducts:nil];
+            [forwardCommerceEvent setImpressions:nil];
+            return [[MPKitFilter alloc] initWithCommerceEvent:forwardCommerceEvent shouldFilter:NO];
+
+        case MPKitCommerceEntityActionRemovePromotions:
+            [forwardCommerceEvent.promotionContainer setPromotions:nil];
+            return [[MPKitFilter alloc] initWithCommerceEvent:forwardCommerceEvent shouldFilter:NO];
+
+        case MPKitCommerceEntityActionReturnOriginalEvent:
+            return [[MPKitFilter alloc] initWithCommerceEvent:commerceEvent shouldFilter:NO];
+
+        case MPKitCommerceEntityActionContinueFiltering:
+            break;
+    }
+
+    NSDictionary *appFamilyFilter = decision.appFamilyFilter;
+    if (appFamilyFilter.count > 0) {
+        switch (commerceEventKind) {
+            case MPCommerceEventKindProduct: {
+                NSMutableArray *products = [[NSMutableArray alloc] init];
+                [commerceEvent.products enumerateObjectsUsingBlock:^(MPProduct *product, NSUInteger idx, BOOL *stop) {
+                    MPProduct *filteredProduct = [product copyMatchingHashedProperties:appFamilyFilter];
+                    if (filteredProduct) {
+                        [products addObject:filteredProduct];
                     }
+                }];
+                if (products.count > 0) {
+                    [forwardCommerceEvent setProducts:products];
                 }
-            }];
-            
-            forwardCommerceEvent.transactionAttributes = filteredTransactionAttributes;
+                break;
+            }
+
+            case MPCommerceEventKindImpression:
+                forwardCommerceEvent.impressions = [commerceEvent copyImpressionsMatchingHashedProperties:appFamilyFilter];
+                break;
+
+            case MPCommerceEventKindPromotion:
+                forwardCommerceEvent.promotionContainer = [commerceEvent.promotionContainer copyMatchingHashedProperties:appFamilyFilter];
+                break;
+
+            default:
+                break;
         }
     }
-    
+
+    if (decision.hasAttributeFilters) {
+        [forwardCommerceEvent setBeautifiedAttributes:[decision.filteredBeautifiedAttributes mutableCopy]];
+        [forwardCommerceEvent setCustomAttributes:decision.filteredCustomAttributes];
+
+        MPTransactionAttributes *source = forwardCommerceEvent.transactionAttributes;
+        MPTransactionAttributes *filtered = [[MPTransactionAttributes alloc] init];
+        NSSet<NSString *> *allowedKeys = decision.allowedTransactionAttributeKeys;
+        if ([allowedKeys containsObject:kMPExpTAAffiliation]) {
+            filtered.affiliation = source.affiliation;
+        }
+        if ([allowedKeys containsObject:kMPExpTAShipping]) {
+            filtered.shipping = source.shipping;
+        }
+        if ([allowedKeys containsObject:kMPExpTATax]) {
+            filtered.tax = source.tax;
+        }
+        if ([allowedKeys containsObject:kMPExpTARevenue]) {
+            filtered.revenue = source.revenue;
+        }
+        if ([allowedKeys containsObject:kMPExpTATransactionId]) {
+            filtered.transactionId = source.transactionId;
+        }
+        if ([allowedKeys containsObject:kMPExpTACouponCode]) {
+            filtered.couponCode = source.couponCode;
+        }
+        forwardCommerceEvent.transactionAttributes = filtered;
+    }
+
     [self project:kitRegister commerceEvent:forwardCommerceEvent completionHandler:^(NSArray<MPCommerceEvent *> *projectedCommerceEvents,
                                                                                      NSArray<MPEvent *> *projectedEvents,
                                                                                      NSArray<MPEventProjection *> *appliedProjections) {
         NSArray<MPEventProjection *> *appliedProjectionsArray = appliedProjections.count ? appliedProjections : nil;
-        
+
         if (projectedEvents.count != 0) {
             for (MPEvent *projectedEvent in projectedEvents) {
                 kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:NO appliedProjections:appliedProjectionsArray eventCopy:nil commerceEventCopy:commerceEvent];
                 [self attemptToLogEventToKit:kitRegister kitFilter:kitFilter selector:@selector(logEvent:) parameters:nil messageType:MPMessageTypeEvent userInfo:[[NSDictionary alloc] init]];
             }
         }
-        
+
         if (projectedCommerceEvents.count != 0) {
             for (MPCommerceEvent *projectedCommerceEvent in projectedCommerceEvents) {
                 kitFilter = [[MPKitFilter alloc] initWithCommerceEvent:projectedCommerceEvent shouldFilter:NO appliedProjections:appliedProjectionsArray];
                 [self attemptToLogCommerceEventToKit:kitRegister kitFilter:kitFilter];
             }
         }
-        
+
     }];
-    
+
     return kitFilter;
 }
 
@@ -783,92 +698,36 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
                 selector:(SEL)selector
               parameters:(MPForwardQueueParameters *)parameters {
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    NSNumber *zero = @0;
     __block MPKitFilter *kitFilter = [[MPKitFilter alloc] initWithEvent:event shouldFilter:NO];
-    __block NSString *hashValue = nil;
-    __block BOOL shouldFilter = NO;
-    
-    // Attribute value filtering
-    shouldFilter = ![self shouldIncludeEventWithAttributes:event.customAttributes afterAttributeValueFilteringWithConfiguration:kitConfiguration];
-    if (shouldFilter) {
-        kitFilter = [[MPKitFilter alloc] initWithFilter:shouldFilter];
+    NSString *selectorString = NSStringFromSelector(selector);
+    MPKitFilterConfigurationSnapshot *configurationSnapshot = [self filterSnapshotForConfiguration:kitConfiguration];
+    if (!configurationSnapshot) {
         return kitFilter;
     }
-    
-    // Event type filter
-    if (selector != @selector(logScreen:)) {
-        hashValue = [_hasher hashEventType:(MPEventTypeSwift)event.type];
-        
-        shouldFilter = kitConfiguration.eventTypeFilters[hashValue] && [kitConfiguration.eventTypeFilters[hashValue] isEqualToNumber:zero];
-        if (shouldFilter) {
-            kitFilter = [[MPKitFilter alloc] initWithFilter:shouldFilter];
-            return kitFilter;
-        }
-        
-    }
-    
-    // Message type filter
-    NSString *selectorString = NSStringFromSelector(selector);
-    NSString *messageType = [self methodMessageTypeMapping][selectorString];
-    if (messageType) {
-        shouldFilter = kitConfiguration.messageTypeFilters[messageType] && [kitConfiguration.messageTypeFilters[messageType] isEqualToNumber:zero];
-        
-        if (shouldFilter) {
-            kitFilter = [[MPKitFilter alloc] initWithFilter:shouldFilter];
-            return kitFilter;
-        }
-    }
-    
-    NSDictionary *attributeFilters;
-    NSDictionary *nameFilters;
-    
-    if ([selectorString isEqualToString:@"logScreen:"]) { // Screen name and screen attribute filters
-        nameFilters = kitConfiguration.screenNameFilters;
-        attributeFilters = kitConfiguration.screenAttributeFilters;
-    } else { // Event name and event attribute filters
-        nameFilters = kitConfiguration.eventNameFilters;
-        attributeFilters = kitConfiguration.eventAttributeFilters;
-    }
-    
-    MPEvent *forwardEvent = [event copy];
-    // Attributes
-    MPMessageType messageTypeCode = [MPEnum messageTypeFromNSString:messageType];
-    if (messageTypeCode != MPMessageTypeEvent && messageTypeCode != MPMessageTypeScreenView && messageTypeCode != MPMessageTypeMedia) {
-        messageTypeCode = MPMessageTypeUnknown;
+
+    MPKitEventSnapshot *eventSnapshot = [[MPKitEventSnapshot alloc]
+        initWithType:(NSUInteger)event.type
+        name:event.name
+        attributes:event.customAttributes
+        selectorName:selectorString];
+    MPKitEventFilterDecision *decision = [self.filterEngine filterEvent:eventSnapshot
+                                                          configuration:configurationSnapshot];
+    if (decision.shouldFilter) {
+        return [[MPKitFilter alloc] initWithFilter:YES];
     }
 
-    if ([event isKindOfClass:[MPEvent class]]) {
-        hashValue = [_hasher hashEventType:(MPEventTypeSwift)event.type eventName:event.name isLogScreen:[selectorString isEqualToString:@"logScreen:"]];
-        
-        shouldFilter = nameFilters[hashValue] && [nameFilters[hashValue] isEqualToNumber:zero];
-        if (shouldFilter) {
-            kitFilter = [[MPKitFilter alloc] initWithFilter:shouldFilter];
-            return kitFilter;
-        }
-        
-        if (event.customAttributes) {
-            __block NSMutableDictionary *filteredAttributes = [[NSMutableDictionary alloc] initWithCapacity:forwardEvent.customAttributes.count];
-            
-            [forwardEvent.customAttributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
-                hashValue = [_hasher hashEventAttributeKey:(MPEventTypeSwift)event.type eventName:event.name customAttributeName:key isLogScreen:[selectorString isEqualToString:@"logScreen:"]];
-                
-                id attributeFilterValue = attributeFilters[hashValue];
-                BOOL attributeFilterIsFalse = [attributeFilterValue isEqualToNumber:zero];
-                
-                if (!attributeFilterValue || (attributeFilterValue && !attributeFilterIsFalse)) {
-                    filteredAttributes[key] = obj;
-                }
-            }];
-            
-            forwardEvent.customAttributes = filteredAttributes.count > 0 ? filteredAttributes : nil;
-        }
+    MPEvent *forwardEvent = [event copy];
+    forwardEvent.customAttributes = decision.filteredAttributes;
+    MPMessageType messageTypeCode = [MPEnum messageTypeFromNSString:decision.messageType];
+    if (messageTypeCode != MPMessageTypeEvent && messageTypeCode != MPMessageTypeScreenView && messageTypeCode != MPMessageTypeMedia) {
+        messageTypeCode = MPMessageTypeUnknown;
     }
     
     [self project:kitRegister event:forwardEvent messageType:messageTypeCode completionHandler:^(NSArray<MPEvent *> *projectedEvents, NSArray<MPEventProjection *> *appliedProjections) {
         NSArray<MPEventProjection *> *appliedProjectionsArray = appliedProjections.count > 0 ? appliedProjections : nil;
         
         for (MPEvent *projectedEvent in projectedEvents) {
-            kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:shouldFilter appliedProjections:appliedProjectionsArray eventCopy:event commerceEventCopy:nil];
+            kitFilter = [[MPKitFilter alloc] initWithEvent:projectedEvent shouldFilter:NO appliedProjections:appliedProjectionsArray eventCopy:event commerceEventCopy:nil];
             SEL mutableSelector = selector;
             if (selector == @selector(logScreen:)) {
                 for (NSUInteger i = 0; i < appliedProjectionsArray.count; i++) {
@@ -894,17 +753,11 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         kitFilter = [[MPKitFilter alloc] initWithFilter:NO];
     }
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    
-    if (kitConfiguration) {
-        NSString *selectorString = NSStringFromSelector(selector);
-        NSString *messageType = [self methodMessageTypeMapping][selectorString];
-        
-        if (messageType) {
-            BOOL shouldFilter = kitConfiguration.messageTypeFilters[messageType] && [kitConfiguration.messageTypeFilters[messageType] isEqualToNumber:@0];
-            if (shouldFilter) {
-                return [[MPKitFilter alloc] initWithFilter:shouldFilter];
-            }
-        }
+    MPKitFilterConfigurationSnapshot *configurationSnapshot = [self filterSnapshotForConfiguration:kitConfiguration];
+    if (configurationSnapshot &&
+        [self.filterEngine shouldFilterBaseEventWithSelectorName:NSStringFromSelector(selector)
+                                                  configuration:configurationSnapshot]) {
+        return [[MPKitFilter alloc] initWithFilter:YES];
     }
     
     return kitFilter;
@@ -915,26 +768,19 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         return nil;
     }
     
-    MPKitFilter *kitFilter = nil;
-    __block NSMutableDictionary *filteredAttributes = [[NSMutableDictionary alloc] initWithCapacity:userAttributes.count];
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    
-    if (kitConfiguration) {
-        [userAttributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-            NSString *hashValue = [_hasher hashUserAttributeKey:key];
-            
-            BOOL shouldFilter = kitConfiguration.userAttributeFilters[hashValue] && [kitConfiguration.userAttributeFilters[hashValue] isEqualToNumber:@0];
-            if (!shouldFilter) {
-                filteredAttributes[key] = [value copy];
-            }
-        }];
+    NSDictionary *decisionAttributes = [self.filterEngine
+        filterUserAttributes:userAttributes
+        configuration:[self filterSnapshotForConfiguration:kitConfiguration]];
+    if (decisionAttributes.count == 0) {
+        return nil;
     }
-    
-    if (filteredAttributes.count > 0) {
-        kitFilter = [[MPKitFilter alloc] initWithFilter:YES filteredAttributes:filteredAttributes];
-    }
-    
-    return kitFilter;
+
+    NSMutableDictionary *forwardAttributes = [[NSMutableDictionary alloc] initWithCapacity:decisionAttributes.count];
+    [decisionAttributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
+        forwardAttributes[key] = [value copy];
+    }];
+    return [[MPKitFilter alloc] initWithFilter:YES filteredAttributes:forwardAttributes];
 }
 
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forUserAttributeKey:(NSString *)key value:(id)value {
@@ -942,36 +788,19 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         return nil;
     }
     
-    NSString *hashValue = [_hasher hashUserAttributeKey:key];
-    
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    
-    MPKitFilter *kitFilter = nil;
-    BOOL shouldFilter = NO;
-    
-    if (kitConfiguration) {
-        shouldFilter = kitConfiguration.userAttributeFilters[hashValue] && [kitConfiguration.userAttributeFilters[hashValue] isEqualToNumber:@0];
-        
-        kitFilter = shouldFilter ? [[MPKitFilter alloc] initWithFilter:shouldFilter] : nil;
-    }
-    
-    return kitFilter;
+    BOOL shouldFilter = [self.filterEngine
+        shouldFilterUserAttributeWithKey:key
+        configuration:[self filterSnapshotForConfiguration:kitConfiguration]];
+    return shouldFilter ? [[MPKitFilter alloc] initWithFilter:YES] : nil;
 }
 
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forUserIdentityKey:(NSString *)key identityType:(MPUserIdentity)identityType {
-    NSString *identityTypeString = [[NSString alloc] initWithFormat:@"%lu", (unsigned long)identityType];
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    
-    MPKitFilter *kitFilter = nil;
-    BOOL shouldFilter = NO;
-    
-    if (kitConfiguration) {
-        shouldFilter = kitConfiguration.userIdentityFilters[identityTypeString] && [kitConfiguration.userIdentityFilters[identityTypeString] isEqualToNumber:@0];
-        
-        kitFilter = shouldFilter ? [[MPKitFilter alloc] initWithFilter:shouldFilter] : nil;
-    }
-    
-    return kitFilter;
+    BOOL shouldFilter = [self.filterEngine
+        shouldFilterUserIdentityWithType:(NSUInteger)identityType
+        configuration:[self filterSnapshotForConfiguration:kitConfiguration]];
+    return shouldFilter ? [[MPKitFilter alloc] initWithFilter:YES] : nil;
 }
 
 - (MPKitFilter *)filter:(id<MPExtensionKitProtocol>)kitRegister forConsentState:(MPConsentState *)state {
@@ -979,71 +808,33 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         return nil;
     }
     
-    MPKitFilter *kitFilter = nil;
-    
     MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-    
-    if (kitConfiguration) {
-        
-        MPCCPAConsent *ccpaConsentState = state.ccpaConsentState;
+    MPKitConsentDecision *decision = [self.filterEngine
+        filterConsent:[self consentSnapshotForState:state]
+        configuration:[self filterSnapshotForConfiguration:kitConfiguration]];
+    switch (decision.action) {
+        case MPKitConsentActionFilterAll:
+            return [[MPKitFilter alloc] initWithFilter:YES];
 
-        NSDictionary<NSString *, MPGDPRConsent *> *gdprState = state.gdprConsentState;
-                
-        if (ccpaConsentState != nil) {
-            NSString *regulationHash = [_hasher hashConsentPurpose:kMPConsentCCPARegulationType purpose:kMPConsentCCPAPurposeName];
-            
-            if (kitConfiguration.consentRegulationFilters[regulationHash] && [kitConfiguration.consentRegulationFilters[regulationHash] isEqual:@0]) {
-                kitFilter = [[MPKitFilter alloc] initWithFilter:YES];
-                return kitFilter;
-            } else {
-                MPConsentState *filteredState = [[MPConsentState alloc] init];
-                [filteredState setCCPAConsentState:ccpaConsentState];
-                
-                kitFilter = [[MPKitFilter alloc] initWithConsentState:filteredState shouldFilter:NO];
-                return kitFilter;
-            }
+        case MPKitConsentActionForwardCCPA: {
+            MPConsentState *filteredState = [[MPConsentState alloc] init];
+            [filteredState setCCPAConsentState:state.ccpaConsentState];
+            return [[MPKitFilter alloc] initWithConsentState:filteredState shouldFilter:NO];
         }
 
-        if (gdprState) {
-            NSString *regulationHash = [_hasher hashConsentPurpose:kMPConsentGDPRRegulationType purpose:@""];
-            
-            if (kitConfiguration.consentRegulationFilters[regulationHash] && [kitConfiguration.consentRegulationFilters[regulationHash] isEqual:@0]) {
-                kitFilter = [[MPKitFilter alloc] initWithFilter:YES];
-                return kitFilter;
+        case MPKitConsentActionForwardGDPR: {
+            NSMutableDictionary<NSString *, MPGDPRConsent *> *filteredGDPRState = [NSMutableDictionary dictionary];
+            for (NSString *purpose in decision.allowedGDPRPurposes) {
+                filteredGDPRState[purpose] = state.gdprConsentState[purpose];
             }
+            MPConsentState *filteredState = [[MPConsentState alloc] init];
+            [filteredState setGDPRConsentState:filteredGDPRState];
+            return [[MPKitFilter alloc] initWithConsentState:filteredState shouldFilter:NO];
         }
-        
-        if (gdprState && gdprState.count > 0) {
-            
-            if (kitConfiguration.consentPurposeFilters) {
-                
-                NSMutableDictionary<NSString *, MPGDPRConsent *> *filteredGDPRState = [NSMutableDictionary dictionary];
-                
-                for (NSString *purpose in gdprState) {
-                    NSString *purposeHash = [_hasher hashConsentPurpose:kMPConsentGDPRRegulationType purpose:purpose];
-                    
-                    BOOL shouldFilterPurpose = kitConfiguration.consentPurposeFilters[purposeHash] && [kitConfiguration.consentPurposeFilters[purposeHash] isEqual:@0];
-                    
-                    if (!shouldFilterPurpose) {
-                        MPGDPRConsent *consent = gdprState[purpose];
-                        [filteredGDPRState setObject:consent forKey:purpose];
-                    }
-                }
-                
-                if (filteredGDPRState.count > 0) {
-                    MPConsentState *filteredState = [[MPConsentState alloc] init];
-                    [filteredState setGDPRConsentState:filteredGDPRState];
-                    
-                    kitFilter = [[MPKitFilter alloc] initWithConsentState:filteredState shouldFilter:NO];
-                }
-                
-            }
-            
-        }
-        
+
+        case MPKitConsentActionNoFilter:
+            return nil;
     }
-    
-    return kitFilter;
 }
 
 #pragma mark Projection methods
@@ -1936,14 +1727,19 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
     BOOL active = kitRegister.wrapperInstance ? [kitRegister.wrapperInstance started] : NO;
     MPBracket *bracket = [self bracketForKit:kitRegister.code];
     MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
+    MPKitConfiguration *configuration = self.kitConfigurations[kitRegister.code];
+    MPConsentState *state = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:currentUser.userId];
 
-    BOOL disabledByConsent =  [self isDisabledByConsentKitFilter:self.kitConfigurations[kitRegister.code].consentKitFilter];
-    BOOL disabledByExcludingAnonymousUsers =  (self.kitConfigurations[kitRegister.code].excludeAnonymousUsers && !currentUser.isLoggedIn);
-    // May be able to remove this entirely and not require CPP
-    BOOL disabledByRamping =  !(bracket == nil || (bracket != nil && [bracket shouldForward]));
-    BOOL disabledKit = [_disabledKits containsObject:kitRegister.code];
-
-    return (active && !disabledByRamping && !disabledByConsent && !disabledByExcludingAnonymousUsers && !disabledKit);
+    return [self.filterEngine isKitActiveWithActive:active
+                                              mpId:bracket.mpId
+                                         bracketLow:bracket.low
+                                        bracketHigh:bracket.high
+                                         hasBracket:bracket != nil
+                                       consentFilter:[self consentFilterSnapshotForFilter:configuration.consentKitFilter]
+                                             consent:[self consentSnapshotForState:state]
+                              excludesAnonymousUsers:configuration.excludeAnonymousUsers
+                                         isLoggedIn:currentUser.isLoggedIn
+                                      isDisabledKit:[_disabledKits containsObject:kitRegister.code]];
 }
 
 - (void)configureKits:(NSArray<NSDictionary *> *)kitConfigurations {

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.m
@@ -387,10 +387,6 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 }
 
 - (MPKitFilterConfigurationSnapshot *)filterSnapshotForConfiguration:(MPKitConfiguration *)configuration {
-    if (!configuration) {
-        return nil;
-    }
-
     return [[MPKitFilterConfigurationSnapshot alloc]
         initWithFilters:configuration.filters
         attributeValueFilteringIsActive:configuration.attributeValueFilteringIsActive


### PR DESCRIPTION
## Background

Kit filtering policy is independent decision logic that can move to Swift while Objective-C continues constructing existing SDK model objects.

## What Has Changed

- Add Foundation-only snapshots for configuration, events, users, and consent.
- Evaluate event, commerce, identity, consent, bracket, anonymous-user, and disabled-kit filtering in Swift.
- Preserve consent precedence, hashing, `NSNull`, and data-plan behavior.
- Keep existing Objective-C filter and filtered-user materialization.
- Add direct Swift policy coverage and Objective-C behavior regressions.

## Screenshots/Video

N/A — no visual changes.

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [x] Tested locally

## Testing

- Trunk checks and ABI guard
- Swift filter-engine tests
- Objective-C container and filtering tests
- Swift and Objective-C unit suites
- Core CocoaPods lint
