### PR TITLE
refactor: move event projection parsing to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Kits/MPEventProjectionParser.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Kits/MPEventProjectionParser.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+@objc(MPProjectionMatchFields)
+public final class MPProjectionMatchFields: NSObject {
+    @objc public let attributeKey: String
+    @objc public let attributeValues: [Any]
+
+    init(attributeKey: String, attributeValues: [Any]) {
+        self.attributeKey = attributeKey
+        self.attributeValues = attributeValues
+        super.init()
+    }
+}
+
+@objc(MPEventProjectionBehavior)
+public final class MPEventProjectionBehavior: NSObject {
+    @objc public let appendAsIs: Bool
+    @objc public let isDefault: Bool
+    @objc public let maxCustomParameters: UInt
+    @objc public let selectsLast: Bool
+
+    init(appendAsIs: Bool, isDefault: Bool, maxCustomParameters: UInt, selectsLast: Bool) {
+        self.appendAsIs = appendAsIs
+        self.isDefault = isDefault
+        self.maxCustomParameters = maxCustomParameters
+        self.selectsLast = selectsLast
+        super.init()
+    }
+}
+
+@objc(MPEventProjectionParser)
+public final class MPEventProjectionParser: NSObject {
+    /// `max_custom_params` defaults to INT_MAX, not NSUIntegerMax.
+    private static let unlimitedCustomParameters = UInt(Int32.max)
+
+    @objc(matchesFromConfiguration:isCommerceEvent:)
+    public static func matches(
+        from configuration: [AnyHashable: Any]?,
+        isCommerceEvent: Bool
+    ) -> [MPProjectionMatchFields]? {
+        guard let matches = configuration?["matches"] as? [Any], !matches.isEmpty else {
+            return nil
+        }
+
+        let keyName = isCommerceEvent ? "property_name" : "attribute_key"
+        let valuesName = isCommerceEvent ? "property_value" : "attribute_values"
+
+        let fields = matches.compactMap { match -> MPProjectionMatchFields? in
+            guard let match = match as? [AnyHashable: Any],
+                  let key = MPJSONCoercion.nonEmptyString(match[keyName]),
+                  let values = match[valuesName] as? [Any],
+                  !values.isEmpty
+            else {
+                return nil
+            }
+            return MPProjectionMatchFields(attributeKey: key, attributeValues: values)
+        }
+
+        return fields.isEmpty ? nil : fields
+    }
+
+    @objc(behaviorFromConfiguration:)
+    public static func behavior(from configuration: [AnyHashable: Any]?) -> MPEventProjectionBehavior {
+        guard let behavior = configuration?["behavior"] as? [AnyHashable: Any] else {
+            return MPEventProjectionBehavior(
+                appendAsIs: true,
+                isDefault: false,
+                maxCustomParameters: unlimitedCustomParameters,
+                selectsLast: false
+            )
+        }
+
+        return MPEventProjectionBehavior(
+            appendAsIs: MPJSONCoercion.boolValue(behavior["append_unmapped_as_is"]) ?? true,
+            isDefault: MPJSONCoercion.boolValue(behavior["is_default"]) ?? false,
+            maxCustomParameters: MPJSONCoercion.integerValue(behavior["max_custom_params"])
+                .map { UInt(bitPattern: $0) } ?? unlimitedCustomParameters,
+            selectsLast: MPJSONCoercion.nonEmptyString(behavior["selector"]) == "last"
+        )
+    }
+
+    @objc(messageTypeFromMatchesInConfiguration:defaultValue:)
+    public static func messageType(
+        fromMatchesIn configuration: [AnyHashable: Any]?,
+        defaultValue: UInt
+    ) -> UInt {
+        guard let matches = configuration?["matches"] as? [Any],
+              let first = matches.first as? [AnyHashable: Any],
+              let messageType = MPJSONCoercion.integerValue(first["message_type"])
+        else {
+            return defaultValue
+        }
+        return UInt(bitPattern: messageType)
+    }
+
+    @objc(outboundMessageTypeFromAction:defaultValue:)
+    public static func outboundMessageType(
+        from action: [AnyHashable: Any]?,
+        defaultValue: UInt
+    ) -> UInt {
+        guard let outbound = MPJSONCoercion.integerValue(action?["outbound_message_type"]) else {
+            return defaultValue
+        }
+        return UInt(bitPattern: outbound)
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Kits/MPJSONCoercion.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Kits/MPJSONCoercion.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Mirrors the Objective-C accessors kit configurations relied on. `-boolValue`
+/// and `-integerValue` are defined on both NSString and NSNumber, and remote
+/// configuration uses either interchangeably; Swift's NSNumber bridge accepts
+/// only the latter.
+enum MPJSONCoercion {
+    static func isNull(_ value: Any?) -> Bool {
+        value == nil || value is NSNull
+    }
+
+    static func nonEmptyString(_ value: Any?) -> String? {
+        guard let string = value as? String, !string.isEmpty else {
+            return nil
+        }
+        return string
+    }
+
+    static func integerValue(_ value: Any?) -> Int? {
+        switch value {
+        case let number as NSNumber: Int(truncating: number)
+        case let string as NSString: string.integerValue
+        default: nil
+        }
+    }
+
+    static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let number as NSNumber: number.boolValue
+        case let string as NSString: string.boolValue
+        default: nil
+        }
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Kits/MPEventProjectionParserTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Kits/MPEventProjectionParserTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPEventProjectionParserTests: XCTestCase {
+    private let unlimited = UInt(Int32.max)
+
+    // MARK: - matches
+
+    func testMatchesReadsAttributeKeysForNonCommerceEvents() {
+        let configuration: [AnyHashable: Any] = ["matches": [
+            ["attribute_key": "k", "attribute_values": ["a", "b"]]
+        ]]
+
+        let matches = MPEventProjectionParser.matches(from: configuration, isCommerceEvent: false)
+
+        XCTAssertEqual(matches?.count, 1)
+        XCTAssertEqual(matches?.first?.attributeKey, "k")
+        XCTAssertEqual(matches?.first?.attributeValues as? [String], ["a", "b"])
+    }
+
+    func testMatchesReadsPropertyKeysForCommerceEvents() {
+        let configuration: [AnyHashable: Any] = ["matches": [
+            ["property_name": "p", "property_value": ["v"], "attribute_key": "ignored"]
+        ]]
+
+        let matches = MPEventProjectionParser.matches(from: configuration, isCommerceEvent: true)
+
+        XCTAssertEqual(matches?.first?.attributeKey, "p")
+        XCTAssertEqual(matches?.first?.attributeValues as? [String], ["v"])
+    }
+
+    func testMatchesRequiresBothAKeyAndNonEmptyValues() {
+        let configuration: [AnyHashable: Any] = ["matches": [
+            ["attribute_key": "no_values"],
+            ["attribute_values": ["no_key"]],
+            ["attribute_key": "", "attribute_values": ["empty_key"]],
+            ["attribute_key": "empty_values", "attribute_values": []],
+            ["attribute_key": "good", "attribute_values": ["v"]]
+        ]]
+
+        let matches = MPEventProjectionParser.matches(from: configuration, isCommerceEvent: false)
+
+        XCTAssertEqual(matches?.count, 1)
+        XCTAssertEqual(matches?.first?.attributeKey, "good")
+    }
+
+    func testMatchesIsNilWhenNothingQualifies() {
+        XCTAssertNil(MPEventProjectionParser.matches(from: nil, isCommerceEvent: false))
+        XCTAssertNil(MPEventProjectionParser.matches(from: [:], isCommerceEvent: false))
+        XCTAssertNil(MPEventProjectionParser.matches(from: ["matches": []], isCommerceEvent: false))
+        XCTAssertNil(MPEventProjectionParser.matches(from: ["matches": NSNull()], isCommerceEvent: false))
+        XCTAssertNil(MPEventProjectionParser.matches(
+            from: ["matches": [["attribute_key": "k"]]], isCommerceEvent: false
+        ))
+    }
+
+    func testMatchesKeepsNonStringValuesUntouched() {
+        let configuration: [AnyHashable: Any] = ["matches": [
+            ["attribute_key": "k", "attribute_values": [1, 2]]
+        ]]
+
+        let matches = MPEventProjectionParser.matches(from: configuration, isCommerceEvent: false)
+
+        XCTAssertEqual(matches?.first?.attributeValues.count, 2)
+    }
+
+    // MARK: - behavior
+
+    func testBehaviorDefaultsWithoutABehaviorBlock() {
+        for configuration in [nil, [:], ["behavior": NSNull()]] as [[AnyHashable: Any]?] {
+            let behavior = MPEventProjectionParser.behavior(from: configuration)
+
+            XCTAssertTrue(behavior.appendAsIs)
+            XCTAssertFalse(behavior.isDefault)
+            XCTAssertEqual(behavior.maxCustomParameters, unlimited)
+            XCTAssertFalse(behavior.selectsLast)
+        }
+    }
+
+    func testBehaviorDefaultsForAnEmptyBehaviorBlock() {
+        let behavior = MPEventProjectionParser.behavior(from: ["behavior": [:]])
+
+        XCTAssertTrue(behavior.appendAsIs)
+        XCTAssertFalse(behavior.isDefault)
+        XCTAssertEqual(behavior.maxCustomParameters, unlimited)
+        XCTAssertFalse(behavior.selectsLast)
+    }
+
+    func testBehaviorReadsEveryField() {
+        let behavior = MPEventProjectionParser.behavior(from: ["behavior": [
+            "append_unmapped_as_is": false,
+            "is_default": true,
+            "max_custom_params": 4,
+            "selector": "last"
+        ]])
+
+        XCTAssertFalse(behavior.appendAsIs)
+        XCTAssertTrue(behavior.isDefault)
+        XCTAssertEqual(behavior.maxCustomParameters, 4)
+        XCTAssertTrue(behavior.selectsLast)
+    }
+
+    func testBehaviorAcceptsStringEncodedNumbersAndBooleans() {
+        // Remote configuration sends these as JSON strings; -boolValue and
+        // -integerValue accepted an NSString.
+        let behavior = MPEventProjectionParser.behavior(from: ["behavior": [
+            "append_unmapped_as_is": "false",
+            "is_default": "true",
+            "max_custom_params": "9"
+        ]])
+
+        XCTAssertFalse(behavior.appendAsIs)
+        XCTAssertTrue(behavior.isDefault)
+        XCTAssertEqual(behavior.maxCustomParameters, 9)
+    }
+
+    func testAnySelectorOtherThanLastIsForEach() {
+        for selector in ["", "first", "Last", "LAST"] {
+            XCTAssertFalse(
+                MPEventProjectionParser.behavior(from: ["behavior": ["selector": selector]]).selectsLast,
+                selector
+            )
+        }
+    }
+
+    // MARK: - message types
+
+    func testMessageTypeComesFromTheFirstMatch() {
+        XCTAssertEqual(
+            MPEventProjectionParser.messageType(
+                fromMatchesIn: ["matches": [["message_type": 16], ["message_type": 4]]],
+                defaultValue: 4
+            ),
+            16
+        )
+    }
+
+    func testMessageTypeFallsBackToTheDefault() {
+        XCTAssertEqual(MPEventProjectionParser.messageType(fromMatchesIn: nil, defaultValue: 4), 4)
+        XCTAssertEqual(MPEventProjectionParser.messageType(fromMatchesIn: [:], defaultValue: 4), 4)
+        XCTAssertEqual(
+            MPEventProjectionParser.messageType(
+                fromMatchesIn: ["matches": [["message_type": NSNull()]]], defaultValue: 4
+            ),
+            4
+        )
+    }
+
+    func testOutboundMessageTypeReadsTheActionOrFallsBack() {
+        XCTAssertEqual(
+            MPEventProjectionParser.outboundMessageType(
+                from: ["outbound_message_type": 16], defaultValue: 4
+            ),
+            16
+        )
+        XCTAssertEqual(MPEventProjectionParser.outboundMessageType(from: nil, defaultValue: 4), 4)
+        XCTAssertEqual(MPEventProjectionParser.outboundMessageType(from: [:], defaultValue: 4), 4)
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -578,6 +578,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Kits/MPEventProjectionParserTests.swift,
 				Test/Kits/MPKitFilterEngineTests.swift,
 				Test/Kits/MPProjectionFieldParserTests.swift,
 				Test/Kits/MPKitProjectionEngineTests.swift,
@@ -639,6 +640,7 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
+				Test/Kits/MPEventProjectionParserTests.swift,
 				Test/Kits/MPKitFilterEngineTests.swift,
 				Test/Kits/MPProjectionFieldParserTests.swift,
 				Test/Kits/MPKitProjectionEngineTests.swift,

--- a/mParticle-Apple-SDK/Kits/MPEventProjection.m
+++ b/mParticle-Apple-SDK/Kits/MPEventProjection.m
@@ -103,66 +103,43 @@
     
     NSArray *matches = !MPIsNull(configuration[@"matches"]) ? configuration[@"matches"] : nil;
     NSDictionary *matchDictionary = !MPIsNull(matches) && matches.count > 0 ? matches[0] : nil;
-    __block NSString *auxString;
-    
-    auxString = matchDictionary[@"event"];
+
+    NSString *eventName = matchDictionary[@"event"];
     MParticle* mparticle = MParticle.sharedInstance;
     MPLog* logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue:mparticle.logLevel]];
     logger.customLogger = mparticle.customLogger;
     MPIHasher* hasher = [[MPIHasher alloc] initWithLogger:logger];
-    
-    _eventType = !MPIsNull(auxString) && auxString.length > 0 ? (MPEventType)[hasher eventTypeForHash:auxString] : MPEventTypeOther;
-    
-    _messageType = !MPIsNull(matchDictionary[@"message_type"]) ? (MPMessageType)[matchDictionary[@"message_type"] integerValue] : MPMessageTypeEvent;
-    
-    NSMutableArray<MPProjectionMatch *> *projectionMatches = !MPIsNull(matches) && matches.count > 0 ? [NSMutableArray array] : nil;
-    
-    [matches enumerateObjectsUsingBlock:^(NSDictionary * _Nonnull matchDictionary, NSUInteger idx, BOOL * _Nonnull stop) {
-        MPProjectionMatch *projectionMatch = [[MPProjectionMatch alloc] init];
-        if (self->_messageType == MPMessageTypeCommerceEvent) {
-            auxString = matchDictionary[@"property_name"];
-            projectionMatch.attributeKey = !MPIsNull(auxString) && auxString.length > 0 ? auxString : nil;
-            
-            NSArray<NSString *> *propertyValues = matchDictionary[@"property_value"];
-            projectionMatch.attributeValues = !MPIsNull(propertyValues) && propertyValues.count > 0 ? propertyValues : nil;
-        } else {
-            auxString = matchDictionary[@"attribute_key"];
-            projectionMatch.attributeKey = !MPIsNull(auxString) && auxString.length > 0 ? auxString : nil;
-            
-            NSArray<NSString *> *attributeValues = matchDictionary[@"attribute_values"];
-            projectionMatch.attributeValues = !MPIsNull(attributeValues) && attributeValues.count > 0 ? attributeValues : nil;
-        }
-        if (projectionMatch.attributeKey && projectionMatch.attributeValues) {
+
+    _eventType = !MPIsNull(eventName) && eventName.length > 0 ? (MPEventType)[hasher eventTypeForHash:eventName] : MPEventTypeOther;
+
+    _messageType = (MPMessageType)[MPEventProjectionParser messageTypeFromMatchesInConfiguration:configuration
+                                                                                    defaultValue:MPMessageTypeEvent];
+
+    NSArray<MPProjectionMatchFields *> *matchFields =
+        [MPEventProjectionParser matchesFromConfiguration:configuration
+                                          isCommerceEvent:_messageType == MPMessageTypeCommerceEvent];
+    if (matchFields) {
+        NSMutableArray<MPProjectionMatch *> *projectionMatches = [NSMutableArray arrayWithCapacity:matchFields.count];
+        for (MPProjectionMatchFields *fields in matchFields) {
+            MPProjectionMatch *projectionMatch = [[MPProjectionMatch alloc] init];
+            projectionMatch.attributeKey = fields.attributeKey;
+            projectionMatch.attributeValues = fields.attributeValues;
             [projectionMatches addObject:projectionMatch];
         }
-    }];
-    if (!MPIsNull(projectionMatches) && projectionMatches.count > 0) {
         _projectionMatches = projectionMatches;
     }
-    
-    NSDictionary *behaviorDictionary = !MPIsNull(configuration[@"behavior"]) ? configuration[@"behavior"] : nil;
-    if (behaviorDictionary) {
-        _appendAsIs = !MPIsNull(behaviorDictionary[@"append_unmapped_as_is"]) ? [behaviorDictionary[@"append_unmapped_as_is"] boolValue] : YES;
-        _isDefault = !MPIsNull(behaviorDictionary[@"is_default"]) ? [behaviorDictionary[@"is_default"] boolValue] : NO;
-        _maxCustomParameters = !MPIsNull(behaviorDictionary[@"max_custom_params"]) ? [behaviorDictionary[@"max_custom_params"] integerValue] : INT_MAX;
-        
-        auxString = behaviorDictionary[@"selector"];
-        if (!MPIsNull(auxString)) {
-            _behaviorSelector = [auxString isEqualToString:@"last"] ? MPProjectionBehaviorSelectorLast : MPProjectionBehaviorSelectorForEach;
-        } else {
-            _behaviorSelector = MPProjectionBehaviorSelectorForEach;
-        }
-    } else {
-        _appendAsIs = YES;
-        _isDefault = NO;
-        _maxCustomParameters = INT_MAX;
-        _behaviorSelector = MPProjectionBehaviorSelectorForEach;
-    }
+
+    MPEventProjectionBehavior *behavior = [MPEventProjectionParser behaviorFromConfiguration:configuration];
+    _appendAsIs = behavior.appendAsIs;
+    _isDefault = behavior.isDefault;
+    _maxCustomParameters = behavior.maxCustomParameters;
+    _behaviorSelector = behavior.selectsLast ? MPProjectionBehaviorSelectorLast : MPProjectionBehaviorSelectorForEach;
 
     NSDictionary *actionDictionary = configuration[@"action"];
-    
-    _outboundMessageType = !MPIsNull(actionDictionary[@"outbound_message_type"]) ? (MPMessageType)[actionDictionary[@"outbound_message_type"] integerValue] : MPMessageTypeEvent;
-    
+
+    _outboundMessageType = (MPMessageType)[MPEventProjectionParser outboundMessageTypeFromAction:actionDictionary
+                                                                                   defaultValue:MPMessageTypeEvent];
+
     NSArray *attributeMaps = !MPIsNull(actionDictionary[@"attribute_maps"]) ? actionDictionary[@"attribute_maps"] : nil;
     _attributeProjections = [self buildAttributeProjectionsFromMaps:attributeMaps configuration:configuration];
 


### PR DESCRIPTION
Second of the kit projection/filter series. Stacked on #901.

## What moves

`MPEventProjectionParser` owns four decisions from
`-[MPEventProjection initWithConfiguration:]`:

- which match keys apply (commerce vs everything else),
- which matches qualify,
- the `behavior` block and its defaults,
- the `message_type` / `outbound_message_type` lookups.

The `.m` still constructs the `MPProjectionMatch` objects and resolves the event
type through `MPIHasher`, which needs `MParticle.sharedInstance` for its log
level.

## MPJSONCoercion

`-boolValue` and `-integerValue` are defined on **both** `NSString` and
`NSNumber`, and remote configuration uses them interchangeably. Swift's
`as? NSNumber` bridge accepts only one. That is exactly what made `projectionId`
silently read `0` in #901, so every numeric and boolean read in this series now
goes through one shared helper rather than an ad-hoc cast.

## Behaviours preserved deliberately, each with a test

- Commerce events match on `property_name`/`property_value`; every other message
  type matches on `attribute_key`/`attribute_values`.
- A match needs **both** a non-empty key and a non-empty values array — either
  alone is dropped.
- An empty result set leaves `projectionMatches` nil rather than an empty array.
- `max_custom_params` defaults to `INT_MAX`, not `NSUIntegerMax`.
- Any selector other than the exact string `"last"` means ForEach — including
  `"Last"` and `"LAST"`.

**The values array stays untyped.** The ObjC assigned it straight across without
checking element types, so narrowing to `[String]` would silently drop matches
carrying non-string values. Pinned by a test.

## Gate

| Item | Result |
|---|---|
| 1. Zero public-ABI diff | pass — `abi-guard.sh check` clean |
| 2. `pod lib lint` x3 podspecs | **iOS pass**; tvOS not runnable locally |
| 3. Build iOS + tvOS | **iOS pass**, no new warnings; tvOS not runnable locally |
| 4. `trunk check` + `run-analyzer` | pass — no new issues, analyzer clean |
| 5. ObjC + Swift suites | pass — ObjC 996/996, Swift 514/514 (13 new here) |

Suites run with `-parallel-testing-enabled NO`; `MPKitContainerTests
testActiveKitsRegistryThreadSafety` hangs under parallelism on this machine,
pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
