### PR TITLE
ci(migration): short term = Core SDK + Rokt kit, excluding public API

### DIFF
--- a/Tools/README.md
+++ b/Tools/README.md
@@ -92,28 +92,37 @@ out-of-bucket, and vendored entries.
 
 ### Metric definitions
 
-Every bucket reports two goal rows, because the migration has two horizons:
+The report has exactly two rows, because the migration has two horizons and
+each horizon covers a different scope:
 
-- **Short term — in scope.** Swift SLOC / (Swift SLOC + in-scope Objective-C).
-  In-scope excludes the implementations listed in
-  `Tools/swift-migration-retained-objc.txt` — the public/kit contract,
-  runtime-identity, and boundary-glue files that stay Objective-C by design.
-  **100% here is the end of this project**: every Objective-C implementation the
-  migration intends to delete is gone.
-- **Long term — all Objective-C.** Swift SLOC / (Swift SLOC + all Objective-C),
-  the original full-denominator number. **100% here means the public API itself
-  becomes Swift**, which is a breaking change reserved for a future major
-  release. It is kept so that goal stays measurable rather than being redefined
-  away.
+- **Short term — Core SDK and the Rokt kit, excluding the public API.**
+  Swift SLOC / (Swift SLOC + in-scope Objective-C), counted only across Core
+  SDK (including its kit infrastructure) and the Rokt kit. In-scope excludes
+  the implementations listed in `Tools/swift-migration-retained-objc.txt` —
+  the public/kit contract, runtime-identity, and boundary-glue files that stay
+  Objective-C by design. **100% here is the end of this project for that
+  scope**: every Objective-C implementation the migration intends to delete
+  is gone. Every kit other than Rokt never counts here, no matter what the
+  manifest says.
+- **Long term — everything, including all kits and the public API.** Swift
+  SLOC / (Swift SLOC + all Objective-C), summed across Core SDK, the Rokt
+  kit, and every other standalone kit, with no manifest exclusion. **100%
+  here means the public API itself becomes Swift and every kit converts**,
+  which is a breaking change reserved for a future major release. It is kept
+  so the goal stays measurable rather than being redefined away.
 
-The gap between the two rows is the retained surface. Its SLOC is also printed
-explicitly under the table, with a signed delta when it moved.
+The retained public API surface is printed explicitly under the table (SLOC,
+with a signed delta when it moved), but it is only part of the gap between
+the two rows: it is the boundary within Core SDK and the Rokt kit. The rest
+of the gap is every kit other than Rokt, which the short-term goal excludes
+outright.
 
 Retained wrappers keep their `@interface`, class name, selectors, and
 nullability, but their logic still moves to Swift and the wrapper thins to
-marshaling. That thinning moves the long-term row and the retained figure while
-leaving the short-term row flat — the short-term goal tracks file removal, the
-long-term goal tracks every Objective-C line.
+marshaling. That thinning moves the long-term row and the retained figure
+while leaving the short-term row flat — the short-term goal tracks file
+removal within its scope, the long-term goal tracks every Objective-C line
+everywhere.
 
 Both revisions are counted using the **head** revision's manifest. A PR that
 edits the manifest therefore re-measures its own base under the new definition
@@ -131,12 +140,15 @@ revisions.
 The three production-code buckets do not overlap:
 
 - **Core SDK:** Swift in `mParticle-Apple-SDK-Swift/Sources`, and Objective-C
-  or Objective-C++ in `mParticle-Apple-SDK`, excluding each tree's kit
-  infrastructure and excluding `mParticle-Apple-SDK/Libraries`.
-- **SDK kit infrastructure:** sources in `mParticle-Apple-SDK/Kits` and the
-  future `mParticle-Apple-SDK-Swift/Sources/Kits` subtree.
-- **Standalone kits:** Swift, Objective-C, and Objective-C++ only below
-  `Kits/**/Sources`.
+  or Objective-C++ in `mParticle-Apple-SDK` (including each tree's SDK kit
+  infrastructure — `mParticle-Apple-SDK/Kits` and the future
+  `mParticle-Apple-SDK-Swift/Sources/Kits` subtree), excluding
+  `mParticle-Apple-SDK/Libraries`. Shares the short-term goal.
+- **Rokt kit:** Swift, Objective-C, and Objective-C++ only below
+  `Kits/rokt/rokt/**/Sources`. Also shares the short-term goal.
+- **Other kits:** every other standalone kit's Swift, Objective-C, and
+  Objective-C++ below `Kits/**/Sources` (including `Kits/rokt-sdk-plus`).
+  Counted only toward the long-term goal.
 
 Current language composition is production SLOC reported by `cloc`, so blank
 and comment lines do not count. Objective-C++ (`.mm`) is grouped with
@@ -185,11 +197,16 @@ deleted.
 Removing an entry is the normal end of classification 4: when a boundary is
 redesigned and the glue is deleted, delete its line with it. A future major
 release that takes the public API itself to Swift would empty the manifest,
-which is the point at which the two goal rows converge.
+which converges the short-term goal to 100% for its own scope — Core SDK and
+the Rokt kit. The two rows themselves converge only once every other kit is
+also fully Swift, since the long-term row keeps summing those in regardless of
+the manifest.
 
-Standalone kits have no entries yet. Their `MPKit*` classes are resolved by
-name at runtime, so any kit-side conversion has to establish that contract
-before its implementation is listed here.
+The Rokt kit and every other standalone kit have no entries yet. Their
+`MPKit*` classes are resolved by name at runtime, so any kit-side conversion
+has to establish that contract before its implementation is listed here. An
+entry for a kit other than Rokt would only ever move the long-term figure,
+since the short-term goal never counts that kit regardless of the manifest.
 
 ### Workflow behavior and removal
 

--- a/Tools/swift-migration-progress.sh
+++ b/Tools/swift-migration-progress.sh
@@ -53,43 +53,44 @@ validate_cloc() {
 	[[ -x ${cloc_path} ]] || fail "cloc is not executable: ${cloc_path}"
 }
 
-append_matching_files() {
-	local root=$1
-	local output=$2
-
-	[[ -d ${root} ]] || return 0
-	find "${root}" -type f \( -name '*.swift' -o -name '*.m' -o -name '*.mm' \) -print >>"${output}"
-}
-
 build_bucket_file_list() {
 	local revision_root=$1
 	local bucket=$2
 	local output=$3
 	local objc_root="${revision_root}/mParticle-Apple-SDK"
 	local swift_root="${revision_root}/mParticle-Apple-SDK-Swift/Sources"
+	local rokt_root="${revision_root}/Kits/rokt/rokt"
 
 	: >"${output}"
 
 	case "${bucket}" in
 	core)
+		# Core SDK, including its SDK kit infrastructure (mParticle-Apple-SDK/Kits
+		# and the future mParticle-Apple-SDK-Swift/Sources/Kits subtree) — that
+		# infrastructure ships with the core, not with any standalone kit, so it
+		# shares the core's short-term goal.
 		if [[ -d ${objc_root} ]]; then
-			find "${objc_root}" \
-				\( -path "${objc_root}/Kits" -o -path "${objc_root}/Libraries" \) -prune -o \
+			find "${objc_root}" -path "${objc_root}/Libraries" -prune -o \
 				-type f \( -name '*.m' -o -name '*.mm' \) -print >>"${output}"
 		fi
 		if [[ -d ${swift_root} ]]; then
-			find "${swift_root}" -path "${swift_root}/Kits" -prune -o \
-				-type f -name '*.swift' -print >>"${output}"
+			find "${swift_root}" -type f -name '*.swift' -print >>"${output}"
 		fi
 		;;
-	kit)
-		append_matching_files "${objc_root}/Kits" "${output}"
-		append_matching_files "${swift_root}/Kits" "${output}"
+	rokt)
+		# The Rokt kit only. It shares the core's short-term goal; every other
+		# standalone kit does not.
+		if [[ -d ${rokt_root} ]]; then
+			find "${rokt_root}" -type f \( -name '*.swift' -o -name '*.m' -o -name '*.mm' \) \
+				-path '*/Sources/*' -print >>"${output}"
+		fi
 		;;
 	standalone)
+		# Every standalone kit package below Kits/**/Sources except the Rokt
+		# kit, which is counted separately above. No short-term goal here.
 		if [[ -d "${revision_root}/Kits" ]]; then
-			find "${revision_root}/Kits" -type f \
-				\( -name '*.swift' -o -name '*.m' -o -name '*.mm' \) \
+			find "${revision_root}/Kits" -path "${rokt_root}" -prune -o \
+				-type f \( -name '*.swift' -o -name '*.m' -o -name '*.mm' \) \
 				-path '*/Sources/*' -print >>"${output}"
 		fi
 		;;
@@ -385,17 +386,22 @@ classify_path() {
 	local path=$1
 
 	case "${path}" in
+	Kits/rokt/rokt/Sources/*)
+		# The Rokt kit shares the core's short-term goal; every other
+		# standalone kit below does not.
+		printf 'rokt'
+		;;
 	Kits/*/Sources/*)
 		printf 'standalone'
-		;;
-	mParticle-Apple-SDK-Swift/Sources/Kits/* | mParticle-Apple-SDK/Kits/*)
-		printf 'kit'
 		;;
 	mParticle-Apple-SDK-Swift/Sources/*)
 		printf 'core'
 		;;
 	mParticle-Apple-SDK/Libraries/*) ;;
 	mParticle-Apple-SDK/*)
+		# Includes mParticle-Apple-SDK/Kits: SDK kit infrastructure ships with
+		# the core, so it counts toward the core's goal, not a standalone
+		# kit's.
 		printf 'core'
 		;;
 	*) ;;
@@ -404,8 +410,8 @@ classify_path() {
 
 CORE_SWIFT_ADDED=0
 CORE_OBJC_REMOVED=0
-KIT_SWIFT_ADDED=0
-KIT_OBJC_REMOVED=0
+ROKT_SWIFT_ADDED=0
+ROKT_OBJC_REMOVED=0
 STANDALONE_SWIFT_ADDED=0
 STANDALONE_OBJC_REMOVED=0
 
@@ -415,7 +421,7 @@ add_swift_movement() {
 
 	case "${bucket}" in
 	core) CORE_SWIFT_ADDED=$((CORE_SWIFT_ADDED + lines)) ;;
-	kit) KIT_SWIFT_ADDED=$((KIT_SWIFT_ADDED + lines)) ;;
+	rokt) ROKT_SWIFT_ADDED=$((ROKT_SWIFT_ADDED + lines)) ;;
 	standalone) STANDALONE_SWIFT_ADDED=$((STANDALONE_SWIFT_ADDED + lines)) ;;
 	*) ;;
 	esac
@@ -427,7 +433,7 @@ add_objc_movement() {
 
 	case "${bucket}" in
 	core) CORE_OBJC_REMOVED=$((CORE_OBJC_REMOVED + lines)) ;;
-	kit) KIT_OBJC_REMOVED=$((KIT_OBJC_REMOVED + lines)) ;;
+	rokt) ROKT_OBJC_REMOVED=$((ROKT_OBJC_REMOVED + lines)) ;;
 	standalone) STANDALONE_OBJC_REMOVED=$((STANDALONE_OBJC_REMOVED + lines)) ;;
 	*) ;;
 	esac
@@ -447,8 +453,8 @@ measure_diff_movement() {
 
 	CORE_SWIFT_ADDED=0
 	CORE_OBJC_REMOVED=0
-	KIT_SWIFT_ADDED=0
-	KIT_OBJC_REMOVED=0
+	ROKT_SWIFT_ADDED=0
+	ROKT_OBJC_REMOVED=0
 	STANDALONE_SWIFT_ADDED=0
 	STANDALONE_OBJC_REMOVED=0
 
@@ -474,39 +480,27 @@ measure_diff_movement() {
 	done <"${diff_file}"
 }
 
-# Emits both goal rows for one area: the short-term target (in-scope
-# Objective-C only) and the long-term target (all Objective-C, which the
-# retained public API surface can only satisfy in a future major release).
-write_area_rows() {
-	local label=$1
+# Emits one goal row: the given Swift total against the given Objective-C
+# total for that goal. The two goals differ in which buckets count at all
+# (short term is core + Rokt kit; long term adds every other kit), and short
+# term additionally excludes the retained public API surface.
+write_progress_row() {
+	local goal=$1
 	local base_swift=$2
-	local base_inscope=$3
-	local base_retained=$4
-	local head_swift=$5
-	local head_inscope=$6
-	local head_retained=$7
-	local base_total=$((base_inscope + base_retained))
-	local head_total=$((head_inscope + head_retained))
+	local base_objc=$3
+	local head_swift=$4
+	local head_objc=$5
 	local base_percent
 	local head_percent
 	local bar
 
-	base_percent=$(percentage "${base_swift}" "${base_inscope}")
-	head_percent=$(percentage "${head_swift}" "${head_inscope}")
+	base_percent=$(percentage "${base_swift}" "${base_objc}")
+	head_percent=$(percentage "${head_swift}" "${head_objc}")
 	bar=$(progress_bar "${head_percent}")
 	calculate_delta "${base_percent}" "${head_percent}"
-	printf '| %s | Short term — in scope | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
-		"${label}" "${bar}" "${base_percent}" "${head_percent}" \
-		"$(format_integer "${head_swift}")" "$(format_integer "${head_inscope}")" \
-		"${DELTA_ICON}" "${DELTA_TEXT}"
-
-	base_percent=$(percentage "${base_swift}" "${base_total}")
-	head_percent=$(percentage "${head_swift}" "${head_total}")
-	bar=$(progress_bar "${head_percent}")
-	calculate_delta "${base_percent}" "${head_percent}"
-	printf '| %s | Long term — all Objective-C | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
-		"${label}" "${bar}" "${base_percent}" "${head_percent}" \
-		"$(format_integer "${head_swift}")" "$(format_integer "${head_total}")" \
+	printf '| %s | `%s` | %s%% | %s%% | %s | %s | %s %s pp |\n' \
+		"${goal}" "${bar}" "${base_percent}" "${head_percent}" \
+		"$(format_integer "${head_swift}")" "$(format_integer "${head_objc}")" \
 		"${DELTA_ICON}" "${DELTA_TEXT}"
 }
 
@@ -517,47 +511,50 @@ write_report() {
 	local cloc_version=$4
 	local short_base=${base:0:12}
 	local short_head=${head:0:12}
+	local base_short_swift=$((BASE_CORE_SWIFT + BASE_ROKT_SWIFT))
+	local base_short_objc=$((BASE_CORE_OBJC + BASE_ROKT_OBJC))
+	local head_short_swift=$((HEAD_CORE_SWIFT + HEAD_ROKT_SWIFT))
+	local head_short_objc=$((HEAD_CORE_OBJC + HEAD_ROKT_OBJC))
+	local base_long_swift=$((BASE_CORE_SWIFT + BASE_ROKT_SWIFT + BASE_STANDALONE_SWIFT))
+	local base_long_objc=$((BASE_CORE_OBJC + BASE_CORE_OBJC_RETAINED + BASE_ROKT_OBJC + BASE_ROKT_OBJC_RETAINED + BASE_STANDALONE_OBJC + BASE_STANDALONE_OBJC_RETAINED))
+	local head_long_swift=$((HEAD_CORE_SWIFT + HEAD_ROKT_SWIFT + HEAD_STANDALONE_SWIFT))
+	local head_long_objc=$((HEAD_CORE_OBJC + HEAD_CORE_OBJC_RETAINED + HEAD_ROKT_OBJC + HEAD_ROKT_OBJC_RETAINED + HEAD_STANDALONE_OBJC + HEAD_STANDALONE_OBJC_RETAINED))
 
 	mkdir -p "$(dirname "${output}")"
 	{
 		printf '%s\n' "${COMMENT_MARKER}"
 		printf '%s\n\n' '## 🐦 Swift Migration Progress'
 		printf 'Production implementation code at `%s` compared with `%s`.\n\n' "${short_head}" "${short_base}"
-		printf '%s\n' '| Area | Goal | Progress | Base | This PR | Swift SLOC | Objective-C remaining | Change |'
-		printf '%s\n' '|---|---|:---:|---:|---:|---:|---:|---:|'
-		write_area_rows 'Core SDK' \
-			"${BASE_CORE_SWIFT}" "${BASE_CORE_OBJC}" "${BASE_CORE_OBJC_RETAINED}" \
-			"${HEAD_CORE_SWIFT}" "${HEAD_CORE_OBJC}" "${HEAD_CORE_OBJC_RETAINED}"
-		write_area_rows 'SDK kit infrastructure' \
-			"${BASE_KIT_SWIFT}" "${BASE_KIT_OBJC}" "${BASE_KIT_OBJC_RETAINED}" \
-			"${HEAD_KIT_SWIFT}" "${HEAD_KIT_OBJC}" "${HEAD_KIT_OBJC_RETAINED}"
-		write_area_rows 'Standalone kits' \
-			"${BASE_STANDALONE_SWIFT}" "${BASE_STANDALONE_OBJC}" "${BASE_STANDALONE_OBJC_RETAINED}" \
-			"${HEAD_STANDALONE_SWIFT}" "${HEAD_STANDALONE_OBJC}" "${HEAD_STANDALONE_OBJC_RETAINED}"
+		printf '%s\n' '| Goal | Progress | Base | This PR | Swift SLOC | Objective-C remaining | Change |'
+		printf '%s\n' '|---|:---:|---:|---:|---:|---:|---:|'
+		write_progress_row 'Short term — Core SDK and the Rokt kit, excluding the public API' \
+			"${base_short_swift}" "${base_short_objc}" \
+			"${head_short_swift}" "${head_short_objc}"
+		write_progress_row 'Long term — everything, including all kits and the public API' \
+			"${base_long_swift}" "${base_long_objc}" \
+			"${head_long_swift}" "${head_long_objc}"
 		printf '\n'
-		printf 'Objective-C retained by design: Core SDK %s · SDK kit infrastructure %s · Standalone kits %s.\n\n' \
-			"$(format_retained "${BASE_CORE_OBJC_RETAINED}" "${HEAD_CORE_OBJC_RETAINED}")" \
-			"$(format_retained "${BASE_KIT_OBJC_RETAINED}" "${HEAD_KIT_OBJC_RETAINED}")" \
-			"$(format_retained "${BASE_STANDALONE_OBJC_RETAINED}" "${HEAD_STANDALONE_OBJC_RETAINED}")"
+		printf 'Objective-C retained by design in Core SDK and the Rokt kit (the permanent public API surface): %s.\n\n' \
+			"$(format_retained "$((BASE_CORE_OBJC_RETAINED + BASE_ROKT_OBJC_RETAINED))" "$((HEAD_CORE_OBJC_RETAINED + HEAD_ROKT_OBJC_RETAINED))")"
 		printf '%s\n\n' "### This PR's code movement"
 		printf '%s\n' '| Area | Swift lines added | Objective-C lines removed |'
 		printf '%s\n' '|---|---:|---:|'
-		printf '| Core SDK | %s | %s |\n' \
+		printf '| Core SDK (including kit infrastructure) | %s | %s |\n' \
 			"$(format_integer "${CORE_SWIFT_ADDED}")" "$(format_integer "${CORE_OBJC_REMOVED}")"
-		printf '| SDK kit infrastructure | %s | %s |\n' \
-			"$(format_integer "${KIT_SWIFT_ADDED}")" "$(format_integer "${KIT_OBJC_REMOVED}")"
-		printf '| Standalone kits | %s | %s |\n\n' \
+		printf '| Rokt kit | %s | %s |\n' \
+			"$(format_integer "${ROKT_SWIFT_ADDED}")" "$(format_integer "${ROKT_OBJC_REMOVED}")"
+		printf '| Other kits | %s | %s |\n\n' \
 			"$(format_integer "${STANDALONE_SWIFT_ADDED}")" "$(format_integer "${STANDALONE_OBJC_REMOVED}")"
 		printf '%s\n\n' '<details>'
 		printf '%s\n\n' '<summary>How this is measured</summary>'
 		printf '%s\n' '- Current composition uses production source lines of code (SLOC) from `cloc`; comments and blank lines are excluded.'
-		printf '%s\n' '- **Short term — in scope** excludes the Objective-C the migration will not delete, so 100% is the end of this project: every in-scope implementation gone.'
-		printf '%s\n' '- **Long term — all Objective-C** keeps the full denominator. Reaching 100% there means the public API itself becomes Swift, which is a breaking change reserved for a future major release.'
-		printf '%s\n' '- The gap between the two rows is the retained public/kit contract, runtime-identity, and boundary-glue surface listed in `Tools/swift-migration-retained-objc.txt`.'
+		printf '%s\n' '- **Short term** is Core SDK (including SDK kit infrastructure) and the Rokt kit, excluding the Objective-C the migration will not delete (the retained public API surface). 100% here is the end of this project for that scope.'
+		printf '%s\n' '- **Long term** is everything: Core SDK, SDK kit infrastructure, the Rokt kit, every other standalone kit, and the retained public API surface. 100% here means the public API itself becomes Swift and every kit converts, which is a breaking change reserved for a future major release.'
+		printf '%s\n' '- The retained public API surface (`Tools/swift-migration-retained-objc.txt`) is the boundary within Core SDK and the Rokt kit that separates the two goals there. The rest of the gap between the two rows is every kit other than Rokt, which the short-term goal never counts regardless of the manifest.'
 		printf '%s\n' '- Retained wrappers keep their Objective-C interface but still shed logic to Swift. That thinning moves the long-term row and the retained figure, not the short-term row.'
 		printf '%s\n' '- Both revisions are measured with the manifest from the head revision, so a manifest edit does not by itself move the reported change. A retained file this pull request renamed or deleted still counts as retained at the base.'
 		printf '%s\n' '- Pull request movement uses physical additions/deletions from `git diff base...head --numstat`; it counts retained files too and is intentionally separate from SLOC totals.'
-		printf '%s\n' '- Core excludes SDK kit infrastructure and vendored libraries. Standalone kits include only files below `Kits/**/Sources`.'
+		printf '%s\n' '- Core SDK includes SDK kit infrastructure (`mParticle-Apple-SDK/Kits`, and the future `mParticle-Apple-SDK-Swift/Sources/Kits`) and excludes vendored libraries. Rokt kit is `Kits/rokt/rokt/**/Sources` only. Other kits covers every other standalone kit below `Kits/**/Sources` — no other kit has a short-term goal.'
 		printf '%s\n' '- Tests, examples, headers, build outputs, vendored libraries, and the `MParticle/Sources` Swift overlay are excluded.'
 		printf '%s\n\n' '- Objective-C++ (`.mm`) is included in the Objective-C figures and removed counts.'
 		printf 'Generated with `cloc` %s. This report is informational and does not gate migration direction.\n\n' "${cloc_version}"
@@ -568,18 +565,18 @@ write_report() {
 BASE_CORE_SWIFT=0
 BASE_CORE_OBJC=0
 BASE_CORE_OBJC_RETAINED=0
-BASE_KIT_SWIFT=0
-BASE_KIT_OBJC=0
-BASE_KIT_OBJC_RETAINED=0
+BASE_ROKT_SWIFT=0
+BASE_ROKT_OBJC=0
+BASE_ROKT_OBJC_RETAINED=0
 BASE_STANDALONE_SWIFT=0
 BASE_STANDALONE_OBJC=0
 BASE_STANDALONE_OBJC_RETAINED=0
 HEAD_CORE_SWIFT=0
 HEAD_CORE_OBJC=0
 HEAD_CORE_OBJC_RETAINED=0
-HEAD_KIT_SWIFT=0
-HEAD_KIT_OBJC=0
-HEAD_KIT_OBJC_RETAINED=0
+HEAD_ROKT_SWIFT=0
+HEAD_ROKT_OBJC=0
+HEAD_ROKT_OBJC_RETAINED=0
 HEAD_STANDALONE_SWIFT=0
 HEAD_STANDALONE_OBJC=0
 HEAD_STANDALONE_OBJC_RETAINED=0
@@ -626,10 +623,10 @@ generate_report() {
 	BASE_CORE_SWIFT=${COUNT_SWIFT}
 	BASE_CORE_OBJC=${COUNT_OBJC}
 	BASE_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
-	count_bucket "${base_root}" kit "${cloc_path}" "${workspace}/base-kit" "${base_retained_paths}"
-	BASE_KIT_SWIFT=${COUNT_SWIFT}
-	BASE_KIT_OBJC=${COUNT_OBJC}
-	BASE_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${base_root}" rokt "${cloc_path}" "${workspace}/base-rokt" "${base_retained_paths}"
+	BASE_ROKT_SWIFT=${COUNT_SWIFT}
+	BASE_ROKT_OBJC=${COUNT_OBJC}
+	BASE_ROKT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 	count_bucket "${base_root}" standalone "${cloc_path}" "${workspace}/base-standalone" "${base_retained_paths}"
 	BASE_STANDALONE_SWIFT=${COUNT_SWIFT}
 	BASE_STANDALONE_OBJC=${COUNT_OBJC}
@@ -639,10 +636,10 @@ generate_report() {
 	HEAD_CORE_SWIFT=${COUNT_SWIFT}
 	HEAD_CORE_OBJC=${COUNT_OBJC}
 	HEAD_CORE_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
-	count_bucket "${head_root}" kit "${cloc_path}" "${workspace}/head-kit" "${head_retained_paths}"
-	HEAD_KIT_SWIFT=${COUNT_SWIFT}
-	HEAD_KIT_OBJC=${COUNT_OBJC}
-	HEAD_KIT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
+	count_bucket "${head_root}" rokt "${cloc_path}" "${workspace}/head-rokt" "${head_retained_paths}"
+	HEAD_ROKT_SWIFT=${COUNT_SWIFT}
+	HEAD_ROKT_OBJC=${COUNT_OBJC}
+	HEAD_ROKT_OBJC_RETAINED=${COUNT_OBJC_RETAINED}
 	count_bucket "${head_root}" standalone "${cloc_path}" "${workspace}/head-standalone" "${head_retained_paths}"
 	HEAD_STANDALONE_SWIFT=${COUNT_SWIFT}
 	HEAD_STANDALONE_OBJC=${COUNT_OBJC}
@@ -754,6 +751,8 @@ run_selftest() {
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK-Swift/Sources/Kits/Kit.swift' $'let kit = 1\n'
 	write_fixture_file "${fixture}" 'Kits/vendor/vendor-1/Sources/Kit.m' $'@implementation Standalone\n@end\n'
 	write_fixture_file "${fixture}" 'Kits/vendor/vendor-1/Sources/Kit.swift' $'let standalone = 1\n'
+	write_fixture_file "${fixture}" 'Kits/rokt/rokt/Sources/Kit.m' $'@implementation Rokt\n@end\n'
+	write_fixture_file "${fixture}" 'Kits/rokt-sdk-plus/plus/Sources/Kit.swift' $'let roktPlus = 1\n'
 	write_fixture_file "${fixture}" 'UnitTests/SwiftTests/Excluded.swift' $'let excludedTest = 1\nlet excludedTestTwo = 2\n'
 	write_fixture_file "${fixture}" 'Example/Excluded.m' $'int excludedExample(void) { return 1; }\n'
 	write_fixture_file "${fixture}" 'build/Generated/Excluded.swift' $'let excludedBuildOutput = 1\n'
@@ -783,18 +782,17 @@ run_selftest() {
 
 	migration_report="${fixture}/migration-report.md"
 	generate_report "${fixture}" "${base_sha}" "${migration_sha}" "${cloc_path}" "${migration_report}"
-	assert_contains "${migration_report}" '| Core SDK | Short term — in scope |'
-	assert_contains "${migration_report}" '| Core SDK | Long term — all Objective-C |'
-	assert_contains "${migration_report}" '| 25.00% | 42.86% | 3 | 4 | 🚀 +17.86 pp |'
-	assert_contains "${migration_report}" '| 16.67% | 27.27% | 3 | 8 | 🚀 +10.60 pp |'
-	assert_contains "${migration_report}" '| 33.33% | 100.00% | 2 | 0 | 🚀 +66.67 pp |'
-	assert_contains "${migration_report}" '| 100.00% | 100.00% | 1 | 0 | ➖ 0.00 pp |'
-	assert_contains "${migration_report}" '| 33.33% | 33.33% | 1 | 2 | ➖ 0.00 pp |'
 	assert_contains "${migration_report}" \
-		'Objective-C retained by design: Core SDK 4 · SDK kit infrastructure 0 · Standalone kits 2.'
-	assert_contains "${migration_report}" '| Core SDK | 1 | 4 |'
-	assert_contains "${migration_report}" '| SDK kit infrastructure | 1 | 2 |'
-	assert_contains "${migration_report}" '| Standalone kits | 0 | 0 |'
+		'| Short term — Core SDK and the Rokt kit, excluding the public API |'
+	assert_contains "${migration_report}" \
+		'| Long term — everything, including all kits and the public API |'
+	assert_contains "${migration_report}" '| 23.08% | 45.45% | 5 | 6 | 🚀 +22.37 pp |'
+	assert_contains "${migration_report}" '| 23.81% | 36.84% | 7 | 12 | 🚀 +13.03 pp |'
+	assert_contains "${migration_report}" \
+		'Objective-C retained by design in Core SDK and the Rokt kit (the permanent public API surface): 4.'
+	assert_contains "${migration_report}" '| Core SDK (including kit infrastructure) | 2 | 6 |'
+	assert_contains "${migration_report}" '| Rokt kit | 0 | 0 |'
+	assert_contains "${migration_report}" '| Other kits | 0 | 0 |'
 
 	write_fixture_file "${fixture}" 'README.md' $'No production source changes.\n'
 	git -C "${fixture}" add README.md
@@ -803,7 +801,7 @@ run_selftest() {
 	flat_report="${fixture}/flat-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${flat_sha}" "${cloc_path}" "${flat_report}"
 	flat_count=$(grep -Fc '➖ 0.00 pp' "${flat_report}")
-	[[ ${flat_count} -eq 6 ]] || fail 'self-test expected six flat migration goal rows'
+	[[ ${flat_count} -eq 2 ]] || fail 'self-test expected two flat migration goal rows'
 
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Event/Regression.m' $'@implementation Regression\n@end\n'
 	git -C "${fixture}" add 'mParticle-Apple-SDK/Event/Regression.m'
@@ -811,8 +809,8 @@ run_selftest() {
 	regression_sha=$(git -C "${fixture}" rev-parse HEAD)
 	regression_report="${fixture}/regression-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${regression_sha}" "${cloc_path}" "${regression_report}"
-	assert_contains "${regression_report}" '| 42.86% | 33.33% | 3 | 6 | ↩️ -9.53 pp |'
-	assert_contains "${regression_report}" '| 27.27% | 23.08% | 3 | 10 | ↩️ -4.19 pp |'
+	assert_contains "${regression_report}" '| 45.45% | 38.46% | 5 | 8 | ↩️ -6.99 pp |'
+	assert_contains "${regression_report}" '| 36.84% | 33.33% | 7 | 14 | ↩️ -3.51 pp |'
 
 	git -C "${fixture}" switch -q -c selftest-thin "${migration_sha}"
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK/Utils/Retained Contract.m' \
@@ -824,11 +822,11 @@ run_selftest() {
 	generate_report "${fixture}" "${migration_sha}" "${thin_sha}" "${cloc_path}" "${thin_report}"
 	# Thinning a retained wrapper is invisible to the short-term goal and real
 	# progress toward the long-term one.
-	assert_contains "${thin_report}" '| 42.86% | 42.86% | 3 | 4 | ➖ 0.00 pp |'
-	assert_contains "${thin_report}" '| 27.27% | 33.33% | 3 | 6 | 🚀 +6.06 pp |'
+	assert_contains "${thin_report}" '| 45.45% | 45.45% | 5 | 6 | ➖ 0.00 pp |'
+	assert_contains "${thin_report}" '| 36.84% | 41.18% | 7 | 10 | 🚀 +4.34 pp |'
 	assert_contains "${thin_report}" \
-		'Objective-C retained by design: Core SDK 2 (-2) · SDK kit infrastructure 0 · Standalone kits 2.'
-	assert_contains "${thin_report}" '| Core SDK | 0 | 2 |'
+		'Objective-C retained by design in Core SDK and the Rokt kit (the permanent public API surface): 2 (-2).'
+	assert_contains "${thin_report}" '| Core SDK (including kit infrastructure) | 0 | 2 |'
 
 	# Renaming a retained implementation and updating the manifest moves no
 	# logic, so every goal row and the retained figure must stay flat.
@@ -843,10 +841,10 @@ run_selftest() {
 	renamed_sha=$(git -C "${fixture}" rev-parse HEAD)
 	renamed_report="${fixture}/renamed-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${renamed_sha}" "${cloc_path}" "${renamed_report}"
-	assert_contains "${renamed_report}" '| 42.86% | 42.86% | 3 | 4 | ➖ 0.00 pp |'
-	assert_contains "${renamed_report}" '| 27.27% | 27.27% | 3 | 8 | ➖ 0.00 pp |'
+	assert_contains "${renamed_report}" '| 45.45% | 45.45% | 5 | 6 | ➖ 0.00 pp |'
+	assert_contains "${renamed_report}" '| 36.84% | 36.84% | 7 | 12 | ➖ 0.00 pp |'
 	assert_contains "${renamed_report}" \
-		'Objective-C retained by design: Core SDK 4 · SDK kit infrastructure 0 · Standalone kits 2.'
+		'Objective-C retained by design in Core SDK and the Rokt kit (the permanent public API surface): 4.'
 
 	# Retiring a retained implementation is long-term progress only; the
 	# short-term goal never counted it.
@@ -859,10 +857,10 @@ run_selftest() {
 	retired_sha=$(git -C "${fixture}" rev-parse HEAD)
 	retired_report="${fixture}/retired-report.md"
 	generate_report "${fixture}" "${migration_sha}" "${retired_sha}" "${cloc_path}" "${retired_report}"
-	assert_contains "${retired_report}" '| 42.86% | 42.86% | 3 | 4 | ➖ 0.00 pp |'
-	assert_contains "${retired_report}" '| 27.27% | 42.86% | 3 | 4 | 🚀 +15.59 pp |'
+	assert_contains "${retired_report}" '| 45.45% | 45.45% | 5 | 6 | ➖ 0.00 pp |'
+	assert_contains "${retired_report}" '| 36.84% | 46.67% | 7 | 8 | 🚀 +9.83 pp |'
 	assert_contains "${retired_report}" \
-		'Objective-C retained by design: Core SDK 0 (-4) · SDK kit infrastructure 0 · Standalone kits 2.'
+		'Objective-C retained by design in Core SDK and the Rokt kit (the permanent public API surface): 0 (-4).'
 
 	git -C "${fixture}" switch -q -c selftest-pr "${migration_sha}"
 	write_fixture_file "${fixture}" 'mParticle-Apple-SDK-Swift/Sources/PR Only.swift' $'let prOne = 1\nlet prTwo = 2\n'
@@ -880,8 +878,9 @@ run_selftest() {
 
 	divergent_report="${fixture}/divergent-report.md"
 	generate_report "${fixture}" "${advanced_base_sha}" "${pr_head_sha}" "${cloc_path}" "${divergent_report}"
-	assert_contains "${divergent_report}" '| Core SDK | 2 | 2 |'
-	assert_contains "${divergent_report}" '| Standalone kits | 0 | 0 |'
+	assert_contains "${divergent_report}" '| Core SDK (including kit infrastructure) | 2 | 2 |'
+	assert_contains "${divergent_report}" '| Rokt kit | 0 | 0 |'
+	assert_contains "${divergent_report}" '| Other kits | 0 | 0 |'
 
 	[[ "$(percentage 0 0)" == '0.00' ]] || fail 'self-test expected a zero-denominator percentage of 0.00'
 	run_manifest_validation_selftest "${fixture}/manifest-validation"

--- a/Tools/swift-migration-retained-objc.txt
+++ b/Tools/swift-migration-retained-objc.txt
@@ -5,11 +5,13 @@
 # supported contract, a runtime-identity-pinned type, or unavoidable boundary
 # glue.
 #
-# Tools/swift-migration-progress.sh reports two goals per area. The short-term
-# goal excludes these files, so its 100% is the end of this project. The
-# long-term goal keeps the full denominator; its 100% means the public API
-# itself becomes Swift, which is a breaking change for a future major release.
-# This manifest is the gap between the two.
+# Tools/swift-migration-progress.sh reports a short-term and a long-term goal.
+# The short-term goal (Core SDK and the Rokt kit) excludes these files, so its
+# 100% is the end of this project for that scope. The long-term goal keeps the
+# full denominator across every kit too; its 100% means the public API itself
+# becomes Swift, which is a breaking change for a future major release. This
+# manifest is the boundary between the two goals within Core SDK and the Rokt
+# kit.
 #
 # Listing a file here does not freeze its contents. A contract wrapper keeps
 # its @interface, class name, selectors, and nullability, but its logic still

--- a/docs/swift-migration/PR-GATE.md
+++ b/docs/swift-migration/PR-GATE.md
@@ -55,17 +55,22 @@ kit and wrapper-SDK contract surface, runtime-identity-pinned classes, and the
 boundary glue in `CONVERSION-RECIPE.md`'s classifications 1, 3, and 4 stay
 Objective-C by design — that is the intended end state, not unfinished work.
 
-This project is complete when every **in-scope** Objective-C implementation is
-gone: the classification 2 wrappers and the internal types behind them. The
-retained boundary is enumerated in `Tools/swift-migration-retained-objc.txt`.
+This phase's scope is Core SDK (including its SDK kit infrastructure) and the
+Rokt kit. It is complete when every **in-scope** Objective-C implementation
+within that scope is gone: the classification 2 wrappers and the internal
+types behind them. The retained boundary is enumerated in
+`Tools/swift-migration-retained-objc.txt`. Every other standalone kit is
+outside this phase entirely — not retained, just not yet started.
 
-The progress report on each PR therefore carries two goal rows per area:
+The progress report on each PR therefore carries two goal rows:
 
-- **Short term — in scope** excludes the retained boundary, so 100% is
-  reachable and marks the end of this project.
-- **Long term — all Objective-C** keeps the full denominator. 100% there
-  requires taking the public API itself to Swift — a breaking change reserved
-  for a future major release, tracked rather than redefined away.
+- **Short term — Core SDK and the Rokt kit, excluding the public API**
+  excludes the retained boundary, so 100% is reachable and marks the end of
+  this phase.
+- **Long term — everything, including all kits and the public API** keeps
+  the full denominator across every kit too. 100% there requires taking the
+  public API itself to Swift and converting every kit — a breaking change
+  reserved for a future major release, tracked rather than redefined away.
 
 Two consequences for a conversion PR:
 


### PR DESCRIPTION
## Summary
- Redefines the short-term migration-progress goal row's scope: it now covers Core SDK (including SDK kit infrastructure) **and the Rokt kit**, excluding the retained public API surface. The long-term row is unchanged (everything, including every other kit and the public API).
- `classify_path`/`build_bucket_file_list` move from three buckets (`core`/`kit`/`standalone`) to `core`/`rokt`/`standalone`: SDK kit infrastructure folds into `core` (it ships with the core, not with any standalone kit), and the Rokt kit is split out of `standalone` since it now shares the short-term goal that no other kit gets.
- Self-test rewrites every percentage assertion for the new bucket model, with a new Rokt fixture and a `rokt-sdk-plus` fixture proving that kit stays out of the Rokt bucket.
- `Tools/README.md`, `Tools/swift-migration-retained-objc.txt`, and `docs/swift-migration/PR-GATE.md` updated to describe the new scope.

## Test plan
- [x] `Tools/swift-migration-progress.sh selftest --cloc <pinned cloc 2.10>` → `SELFTEST PASS`
- [x] Ran `Tools/swift-migration-progress.sh report` against real repo history (last 3 commits) — output renders correctly with the new scope
- [x] `shellcheck` clean, `bash -n` clean
- [x] `trunk check` clean (pre-commit/pre-push hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)