### PR TITLE
port: CI hang fixes and workspace-switch condition waits

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -25,6 +25,7 @@ jobs:
     name: Pod Lint ${{ matrix.kit.name }}
     needs: load-matrix
     runs-on: macos-15
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +55,7 @@ jobs:
     name: Build ${{ matrix.kit.name }}
     needs: load-matrix
     runs-on: macOS-latest
+    timeout-minutes: 60
     env:
       XCODE_VERSION: ${{ matrix.kit.xcode_version || '26.2' }}
       USE_LOCAL_VERSION: "1"
@@ -74,17 +76,79 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Resolve SPM dependencies
+        timeout-minutes: 20
+        env:
+          ATTEMPT_TIMEOUT_SECONDS: "480"
         run: |
-          SCHEME=$(echo '${{ toJson(matrix.kit.schemes) }}' | jq -r '.[0].scheme')
-          LOCAL_PATH="${{ matrix.kit.local_path }}"
-          if compgen -G "$LOCAL_PATH"/*.xcodeproj > /dev/null; then
-            PROJECT="$(ls -d "$LOCAL_PATH"/*.xcodeproj | head -1)"
-            xcodebuild -resolvePackageDependencies -project "$PROJECT" \
-              -scheme "$SCHEME" -derivedDataPath DerivedData
-          else
-            # Swift package without .xcodeproj (see rokt-sdk-plus-ios).
-            (cd "$LOCAL_PATH" && xcodebuild -resolvePackageDependencies -scheme "$SCHEME" -derivedDataPath "$OLDPWD/DerivedData")
-          fi
+          # Resolution pulls stripe-ios (~2.7 GB) transitively and normally takes
+          # 2-5 minutes, but the git fetch intermittently stalls indefinitely.
+          # git's own low-speed abort does not reliably fire on that stall (SwiftPM's
+          # fetch has been observed hung for 24+ minutes with this set), so each
+          # attempt is bounded by an explicit watchdog below instead.
+          git config --global http.lowSpeedLimit 1000
+          git config --global http.lowSpeedTime 180
+
+          resolve_dependencies() {
+            SCHEME=$(echo '${{ toJson(matrix.kit.schemes) }}' | jq -r '.[0].scheme')
+            LOCAL_PATH="${{ matrix.kit.local_path }}"
+            if compgen -G "$LOCAL_PATH"/*.xcodeproj > /dev/null; then
+              PROJECT="$(ls -d "$LOCAL_PATH"/*.xcodeproj | head -1)"
+              xcodebuild -resolvePackageDependencies -project "$PROJECT" \
+                -scheme "$SCHEME" -derivedDataPath DerivedData
+            else
+              # Swift package without .xcodeproj (see rokt-sdk-plus-ios).
+              (cd "$LOCAL_PATH" && xcodebuild -resolvePackageDependencies -scheme "$SCHEME" -derivedDataPath "$OLDPWD/DerivedData")
+            fi
+          }
+
+          # Run one attempt under a watchdog that kills the whole fetch tree if it
+          # stalls, so a hung attempt is retried instead of consuming the step budget.
+          # The watchdog only signals and TERMs; escalation and child cleanup happen
+          # in the parent after wait returns, because TERMing the resolve unblocks
+          # wait immediately and the parent then reaps the watchdog.
+          attempt_resolve() {
+            timeout_marker="${RUNNER_TEMP:-/tmp}/spm-resolve-timed-out.$$"
+            rm -f "$timeout_marker"
+
+            resolve_dependencies &
+            resolve_pid=$!
+
+            (
+              sleep "${ATTEMPT_TIMEOUT_SECONDS:-480}"
+              if kill -0 "$resolve_pid" 2>/dev/null; then
+                : > "$timeout_marker"
+                kill -TERM "$resolve_pid" 2>/dev/null || true
+              fi
+            ) &
+            watchdog_pid=$!
+
+            resolve_status=0
+            wait "$resolve_pid" 2>/dev/null || resolve_status=$?
+
+            kill "$watchdog_pid" 2>/dev/null || true
+            wait "$watchdog_pid" 2>/dev/null || true
+
+            if [ -f "$timeout_marker" ]; then
+              rm -f "$timeout_marker"
+              echo "::warning::Resolve stalled past ${ATTEMPT_TIMEOUT_SECONDS:-480}s; killing fetch and retrying"
+              kill -KILL "$resolve_pid" 2>/dev/null || true
+              # xcodebuild's git children outlive it; clear them so the retry does not
+              # race the previous fetch over SwiftPM's cache locks.
+              pkill -KILL -f 'xcodebuild -resolvePackageDependencies' 2>/dev/null || true
+              pkill -KILL -f 'git-remote-http' 2>/dev/null || true
+              sleep 5
+              resolve_status=124
+            fi
+
+            return "$resolve_status"
+          }
+
+          for attempt in 1 2; do
+            attempt_resolve && exit 0
+            [ "$attempt" -lt 2 ] && echo "Resolve attempt $attempt failed, retrying in 30s..." && sleep 30
+          done
+          echo "::error::SPM dependency resolution failed after 2 attempts"
+          exit 1
 
       - name: Build kit schemes
         run: |

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -42,5 +42,15 @@ jobs:
           wait_for_boot: true
           shutdown_after_job: false
 
+      - name: Wait for simulator to finish booting
+        run: xcrun simctl bootstatus '${{ steps.simulator.outputs.udid }}' -b
+
       - name: Run unit tests
-        run: xcodebuild -project mParticle-Apple-SDK.xcodeproj -scheme ${{ matrix.scheme }} -destination 'id=${{ steps.simulator.outputs.udid }}' test
+        run: |
+          xcodebuild -project mParticle-Apple-SDK.xcodeproj \
+            -scheme ${{ matrix.scheme }} \
+            -destination 'id=${{ steps.simulator.outputs.udid }}' \
+            -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 120 \
+            test

--- a/UnitTests/ObjCTests/MPRoktTests.m
+++ b/UnitTests/ObjCTests/MPRoktTests.m
@@ -111,8 +111,9 @@ static const NSTimeInterval kMPRoktDrainTimeout = 5.0;
 
 - (void)tearDown {
     [self drainPendingAsyncWork];
-    self.rokt = nil;
+    // Stop the partial mock before releasing the object it wraps, not after.
     [self.mockRokt stopMocking];
+    self.rokt = nil;
     [self.mockInstance stopMocking];
     [self.mockContainer stopMocking];
     [self.identityMock stopMocking];

--- a/UnitTests/ObjCTests/MParticleTests.m
+++ b/UnitTests/ObjCTests/MParticleTests.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) MPBackendController_PRIVATE *backendController;
 @property (nonatomic, strong) MParticleOptions *options;
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;
+@property (nonatomic) BOOL initialized;
 - (BOOL)isValidBridgeName:(NSString *)bridgeName;
 - (void)handleWebviewCommand:(NSString *)command dictionary:(NSDictionary *)dictionary;
 + (void)_setWrapperSdk_internal:(MPWrapperSdk)wrapperSdk version:(nonnull NSString *)wrapperSdkVersion;
@@ -1190,167 +1191,173 @@
 #pragma mark Workspace Switching Tests
 
 #define WORKSPACE_SWITCHING_TIMEOUT 60
-#define WORKSPACE_SWITCHING_DELAY (int64_t)(10 * NSEC_PER_SEC)
+
+// Spins the main run loop until condition() is true, so main-queue work the SDK
+// schedules during start-up and workspace switching still runs. Returns NO on timeout.
+static BOOL MPWaitForCondition(NSTimeInterval timeout, BOOL (^condition)(void)) {
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+    while (!condition()) {
+        if ([[NSDate date] compare:deadline] == NSOrderedDescending) {
+            return NO;
+        }
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
+    return YES;
+}
 
 - (void)testSwitchWorkspaceOptions {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-
     MParticle *instance = [MParticle sharedInstance];
     XCTAssertNotNil(instance);
     XCTAssertNil(instance.options);
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key1" secret:@"unit-test-secret1"];
-        [instance startWithOptions:options1];
-        XCTAssertNotNil(instance.options);
-        XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
-        XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
+    MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key1" secret:@"unit-test-secret1"];
+    [instance startWithOptions:options1];
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key2" secret:@"unit-test-secret2"];
-            [instance switchWorkspaceWithOptions:options2];
-            
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-                MParticle *instance3 = [MParticle sharedInstance];
-                MParticle *instance4 = [MParticle sharedInstance];
-                XCTAssertNotNil(instance.options);
-                XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
-                XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
-                
-                XCTAssertNotNil(instance3.options);
-                XCTAssertEqualObjects(instance3.options.apiKey, @"unit-test-key2");
-                XCTAssertEqualObjects(instance3.options.apiSecret, @"unit-test-secret2");
-                XCTAssertNotEqual(instance, instance3);
-                XCTAssertEqual(instance3, instance4);
-                
-                [expectation fulfill];
-            });
-        });
-    });
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return instance.options != nil;
+    }), @"SDK did not finish starting");
 
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
+    XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
+
+    MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key2" secret:@"unit-test-secret2"];
+    [instance switchWorkspaceWithOptions:options2];
+
+    // switchWorkspaceWithOptions: installs a replacement shared instance.
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instance && [MParticle sharedInstance].options != nil;
+    }), @"Workspace switch did not complete");
+
+    MParticle *instance3 = [MParticle sharedInstance];
+    MParticle *instance4 = [MParticle sharedInstance];
+    XCTAssertNotNil(instance.options);
+    XCTAssertEqualObjects(instance.options.apiKey, @"unit-test-key1");
+    XCTAssertEqualObjects(instance.options.apiSecret, @"unit-test-secret1");
+
+    XCTAssertNotNil(instance3.options);
+    XCTAssertEqualObjects(instance3.options.apiKey, @"unit-test-key2");
+    XCTAssertEqualObjects(instance3.options.apiSecret, @"unit-test-secret2");
+    XCTAssertNotEqual(instance, instance3);
+    XCTAssertEqual(instance3, instance4);
 }
 
 - (void)testSwitchWorkspaceSideloadedKits {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-     
     // Start with a sideloaded kit
     MParticleOptions *options1 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     MPKitTestClassSideloaded *kitTestSideloaded1 = [[MPKitTestClassSideloaded alloc] init];
     options1.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:kitTestSideloaded1]];
-    
+
     [[MParticle sharedInstance] startWithOptions:options1];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-        XCTAssertEqualObjects(((id<MPExtensionKitProtocol>)MPKitContainer_PRIVATE.registeredKits.anyObject).wrapperInstance, kitTestSideloaded1);
-       
-        // Switch workspace with a new sideloaded kit
-        MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-        MPKitTestClassSideloaded *kitTestSideloaded2 = [[MPKitTestClassSideloaded alloc] init];
-        options2.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:kitTestSideloaded2]];
-        
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options2];
-        
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-            XCTAssertEqualObjects(((id<MPExtensionKitProtocol>)MPKitContainer_PRIVATE.registeredKits.anyObject).wrapperInstance, kitTestSideloaded2);
-            
-            // Switch workspace with no sideloaded kits
-            MParticleOptions *options3 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-            [[MParticle sharedInstance] switchWorkspaceWithOptions:options3];
-            
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-                XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
-                
-                [expectation fulfill];
-            });
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:(WORKSPACE_SWITCHING_TIMEOUT) handler:nil];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return MPKitContainer_PRIVATE.registeredKits.count == 1;
+    }), @"Sideloaded kit was not registered");
+    XCTAssertEqualObjects(((id<MPExtensionKitProtocol>)MPKitContainer_PRIVATE.registeredKits.anyObject).wrapperInstance, kitTestSideloaded1);
+
+    // Switch workspace with a new sideloaded kit
+    MParticleOptions *options2 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+    MPKitTestClassSideloaded *kitTestSideloaded2 = [[MPKitTestClassSideloaded alloc] init];
+    options2.sideloadedKits = @[[[MPSideloadedKit alloc] initWithKitInstance:kitTestSideloaded2]];
+
+    [[MParticle sharedInstance] switchWorkspaceWithOptions:options2];
+
+    // Wait for the replacement kit itself, not just for the switch to start.
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return MPKitContainer_PRIVATE.registeredKits.count == 1
+            && ((id<MPExtensionKitProtocol>)MPKitContainer_PRIVATE.registeredKits.anyObject).wrapperInstance == kitTestSideloaded2;
+    }), @"Replacement sideloaded kit did not take over");
+
+    // Switch workspace with no sideloaded kits
+    MParticleOptions *options3 = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
+    [[MParticle sharedInstance] switchWorkspaceWithOptions:options3];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return MPKitContainer_PRIVATE.registeredKits.count == 0;
+    }), @"Sideloaded kits were not cleared");
 }
 
 // Kits without configurations should NOT be removed from the registry even if they implement `stop` becuase it means they weren't used by the previous workspace
 - (void)testSwitchWorkspaceKitsNoConfigurations {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-    
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
     [MParticle registerExtension:[[MPKitRegister alloc] initWithName:@"TestKitNoStop" className:@"MPKitTestClassNoStartImmediately"]];
     [MParticle registerExtension:[[MPKitRegister alloc] initWithName:@"TestKitWithStop" className:@"MPKitTestClassNoStartImmediatelyWithStop"]];
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
-    
+
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-    [[MParticle sharedInstance] startWithOptions:options];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
-       
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
-            [expectation fulfill];
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    MParticle *instanceBeforeSwitch = [MParticle sharedInstance];
+    [instanceBeforeSwitch startWithOptions:options];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized;
+    }), @"SDK did not finish starting");
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
+
+    [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeSwitch
+            && [MParticle sharedInstance].initialized;
+    }), @"Workspace switch did not complete");
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 2);
 }
 
 // Kits with configurations that don't implement `stop` should be removed from the registry because they can't be cleanly restarted
 - (void)testSwitchWorkspaceKitsWithoutStop {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-    
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
     MPKitRegister *registerNoStop = [[MPKitRegister alloc] initWithName:@"TestKitNoStop" className:@"MPKitTestClassNoStartImmediately"];
     [MParticle registerExtension:registerNoStop];
-    
+
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
     [[MParticle sharedInstance] startWithOptions:options];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        registerNoStop.wrapperInstance = [[MPKitTestClassNoStartImmediately alloc] init];
-        [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@42] = [[MPKitConfiguration alloc] init];
-        
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-                
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
-       
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
-            [expectation fulfill];
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized;
+    }), @"SDK did not finish starting");
+
+    registerNoStop.wrapperInstance = [[MPKitTestClassNoStartImmediately alloc] init];
+    [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@42] = [[MPKitConfiguration alloc] init];
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
+
+    [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
+
+    // The removal lands via the flush on the main queue, so wait for the outcome itself.
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return MPKitContainer_PRIVATE.registeredKits.count == 0;
+    }), @"Kit without stop was not removed on workspace switch");
 }
 
 // Kits with configurations that implement `stop` shouldn't be removed from the registry because they can be cleanly restarted
 - (void)testSwitchWorkspaceKitsWithStop {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"async work"];
-    
     XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 0);
     MPKitRegister *registerWithStop = [[MPKitRegister alloc] initWithName:@"TestKitWithStop" className:@"MPKitTestClassNoStartImmediatelyWithStop"];
     [MParticle registerExtension:registerWithStop];
-    
+
     MParticleOptions *options = [MParticleOptions optionsWithKey:@"unit-test-key" secret:@"unit-test-secret"];
-    [[MParticle sharedInstance] startWithOptions:options];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-        registerWithStop.wrapperInstance = [[MPKitTestClassNoStartImmediatelyWithStop alloc] init];
-        [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@43] = [[MPKitConfiguration alloc] init];
-        
-        XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-                
-        [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
-       
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, WORKSPACE_SWITCHING_DELAY), dispatch_get_main_queue(), ^{
-            XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
-            [expectation fulfill];
-        });
-    });
-    
-    [self waitForExpectationsWithTimeout:WORKSPACE_SWITCHING_TIMEOUT handler:nil];
+    MParticle *instanceBeforeSwitch = [MParticle sharedInstance];
+    [instanceBeforeSwitch startWithOptions:options];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance].initialized;
+    }), @"SDK did not finish starting");
+
+    registerWithStop.wrapperInstance = [[MPKitTestClassNoStartImmediatelyWithStop alloc] init];
+    [MParticle sharedInstance].kitContainer_PRIVATE.kitConfigurations[@43] = [[MPKitConfiguration alloc] init];
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
+
+    [[MParticle sharedInstance] switchWorkspaceWithOptions:options];
+
+    XCTAssertTrue(MPWaitForCondition(WORKSPACE_SWITCHING_TIMEOUT, ^BOOL{
+        return [MParticle sharedInstance] != instanceBeforeSwitch
+            && [MParticle sharedInstance].initialized;
+    }), @"Workspace switch did not complete");
+
+    XCTAssertEqual(MPKitContainer_PRIVATE.registeredKits.count, 1);
 }
+
 
 - (void)testSetWrapperSdk {
     MParticle *instance = [MParticle sharedInstance];


### PR DESCRIPTION
> **Draft.** Ports the subset of the main-line CI/test fixes that this branch is missing. Not a copy of #878 — see what was deliberately left out.

## Why

CI on PRs targeting this branch is failing and slow. From [run 33552140564](https://github.com/mParticle/mparticle-apple-sdk/actions/runs/33552140564) (PR #907):

| Job | Failure |
|---|---|
| `native-unit-tests (tvOS, mParticle-Apple-SDK)` | crash in `testSwitchWorkspaceKitsWithStop` |
| `native-unit-tests (iOS, mParticle-Apple-SDK)` | crash in `testActiveKitsRegistryThreadSafety` |

And the workspace tests are burning ~100 seconds of pure fixed delay per run:

```
testSwitchWorkspaceOptions          30.118s
testSwitchWorkspaceSideloadedKits   30.108s
testSwitchWorkspaceKitsWithoutStop  20.147s
testSwitchWorkspaceKitsNoConfigs    20.078s
```

None of the main-line fixes for this had reached this branch.

## What this ports

**CI workflows** — the #867 fixes: `-parallel-testing-enabled NO` (the Swift scheme was cloning simulators and starving the daemons one test blocks on), `simctl bootstatus`, a per-test timeout, plus the SPM resolve watchdog and job timeouts in `build-kits`. Taken from main after confirming this branch had no independent changes to those files.

**Five workspace-switch tests** — converted from nested 10-second `dispatch_after` chains to `MPWaitForCondition`, which spins the main run loop until the SDK is actually ready. `dispatch_after` and `WORKSPACE_SWITCHING_DELAY` are now gone from `MParticleTests`. Where a test asserts an outcome that arrives via the flush on the main queue, the wait includes that outcome so it cannot race the flush.

These were converted against **this branch's own test bodies**, not by copying main's file — that would have clobbered the migration-specific `resetRegistry`, `kitContainer_PRIVATE` and `registeredKits.anyObject` work here.

**`MPRoktTests` teardown** — stop the partial mock before releasing the object it wraps, rather than after.

## Deliberately not ported

**The `kitsRegistry` lock fix does not apply here.** The migration moved the registry into `MPKitContainer.swift`, where `registryLock` and `registry` are both `static` and every accessor takes the lock — `registeredKits` returns a locked copy, `removeRegisteredKit:` mutates under the lock. This branch's registry locking is sounder than main's; porting the fix would have been patching a defect that isn't here.

**The Rokt async timeouts and teardown drain are already present**, and `drainPendingAsyncWork` is a two-pass drain — more thorough than the main-line version.

## Honest limits

**The teardown ordering change is unvalidated.** `MPRoktTests` on this branch runs 10/10 clean locally *both with and without* it, so I have no local evidence it does anything. It is correct on its own terms — releasing a mocked object while its partial mock is installed is a real ordering bug — but I am not claiming it fixes anything observed.

**`testActiveKitsRegistryThreadSafety` is not addressed.** It crashes on this branch's CI too, and since the Swift registry here is correctly locked, the cause differs from the main-line one I fixed. Still open, still needs its own investigation.

**Local numbers are Xcode 26.3 / iOS 26; CI is Xcode 16.4 / iOS 18.** The workspace-test failures did not reproduce locally at all, so the conversion is justified by the CI evidence above plus the identical fix working on main, not by a local before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
