### PR TITLE
fix: stop the NSNull plan sentinel crossing into Swift

### DIFF
--- a/UnitTests/ObjCTests/MPDataPlanFilterTests.m
+++ b/UnitTests/ObjCTests/MPDataPlanFilterTests.m
@@ -99,6 +99,47 @@
     XCTAssertEqualObjects([additionalAttrsAdapter transformEventForEvent:partlyUnplannedAttrEvent], partlyUnplannedAttrEvent);
 }
 
+#pragma mark Unconstrained user points
+
+- (MPDataPlanFilter *)filterWithUnconstrainedUserPointsBlocking:(BOOL)blocking {
+    NSDictionary *plan = @{@"version_document":@{@"data_points":@[
+        @{@"match":@{@"type":@"user_attributes"},
+          @"validator":@{@"definition":@{@"additionalProperties":@YES,
+                                         @"properties":@{@"planned attribute":@{}}}}},
+        @{@"match":@{@"type":@"user_identities"},
+          @"validator":@{@"definition":@{@"additionalProperties":@YES,
+                                         @"properties":@{@"7":@{}}}}}
+    ]}};
+
+    MPDataPlanOptions *options = [[MPDataPlanOptions alloc] init];
+    options.dataPlan = plan;
+    options.blockUserAttributes = blocking;
+    options.blockUserIdentities = blocking;
+
+    return [[MPDataPlanFilter alloc] initWithDataPlanOptions:options];
+}
+
+- (void)testUnconstrainedUserPointsAreStoredAsTheNullSentinel {
+    NSDictionary *pointInfo = [[self filterWithUnconstrainedUserPointsBlocking:YES] getPointInfo];
+
+    XCTAssertTrue((NSNull *)pointInfo[@"user_attributes"] == [NSNull null]);
+    XCTAssertTrue((NSNull *)pointInfo[@"user_identities"] == [NSNull null]);
+}
+
+- (void)testUnconstrainedUserPointsBlockNothingWhenBlockingIsOff {
+    MPDataPlanFilter *filter = [self filterWithUnconstrainedUserPointsBlocking:NO];
+
+    XCTAssertFalse([filter isBlockedUserAttributeKey:@"any attribute"]);
+    XCTAssertFalse([filter isBlockedUserIdentityType:MPIdentityEmail]);
+}
+
+- (void)testUnconstrainedUserPointsBlockNothingWhenBlockingIsOn {
+    MPDataPlanFilter *filter = [self filterWithUnconstrainedUserPointsBlocking:YES];
+
+    XCTAssertFalse([filter isBlockedUserAttributeKey:@"any attribute"]);
+    XCTAssertFalse([filter isBlockedUserIdentityType:MPIdentityEmail]);
+}
+
 @end
 
 

--- a/mParticle-Apple-SDK/Kits/MPDataPlanFilter.m
+++ b/mParticle-Apple-SDK/Kits/MPDataPlanFilter.m
@@ -68,15 +68,24 @@
     return (MPEvent *)[self mutateEvent:screenEvent isScreenEvent:true];
 }
 
+// An unconstrained point is stored as the NSNull sentinel rather than an array,
+// and NSNull cannot cross into a Swift [Any]? parameter. Unconstrained means
+// every key is planned, which is the same "block nothing" that filterProducts:
+// already reads the sentinel as.
+- (NSArray *)plannedKeysForPointInfoKey:(NSString *)pointInfoKey {
+    id planned = self.pointInfo[pointInfoKey];
+    return [planned isKindOfClass:[NSArray class]] ? planned : nil;
+}
+
 - (BOOL)isBlockedUserAttributeKey:(NSString *)userAttributeKey {
     return [MPDataPlanFilterPolicy isBlockedUserAttributeKey:userAttributeKey
-                                           plannedAttributes:self.pointInfo[@"user_attributes"]
+                                           plannedAttributes:[self plannedKeysForPointInfoKey:@"user_attributes"]
                                          blockUserAttributes:_blockUserAttributes];
 }
 
 - (BOOL)isBlockedUserIdentityType:(MPIdentity)userIdentityType {
     return [MPDataPlanFilterPolicy isBlockedUserIdentityType:userIdentityType
-                                           plannedIdentities:self.pointInfo[@"user_identities"]
+                                           plannedIdentities:[self plannedKeysForPointInfoKey:@"user_identities"]
                                          blockUserIdentities:_blockUserIdentities];
 }
 


### PR DESCRIPTION
Fixes the crash [Cursor Bugbot reported on #904](https://github.com/mParticle/mparticle-apple-sdk/pull/904#discussion_r3915294277) after that PR merged. The report is accurate; this is a regression #904 introduced.

## What breaks

`getConstrainedPropertiesKeySet:` represents an *unconstrained* data point as the `NSNull` sentinel rather than an array:

```objc
// MPDataPlanFilter.m:181
return (NSArray<NSString *> *)[NSNull null];
```

`#904` started handing that value straight to `MPDataPlanFilterPolicy`'s Swift `[Any]?` parameters. The `@objc` thunk bridges the argument **before any Swift runs**, so the sentinel raises at the call boundary — before the `guard blockUserAttributes` that used to make this path safe:

```
NSInvalidArgumentException: -[NSNull count]: unrecognized selector sent to instance
```

The pre-#904 body checked the flag first:

```objc
if (!_blockUserAttributes) { return NO; }          // returned before touching pointInfo
NSArray *info = self.pointInfo[@"user_attributes"];
```

So a plan that previously only crashed with blocking **on** now crashes with blocking **off** as well — the default configuration. Reachable from ordinary user-attribute writes: `MParticleUser.m:185,248,295,337,374`, `FilteredMParticleUser.m:66,88`, `MPKitContainerExecutionAdapter.m:1463,1486`.

## Fix

Keep the sentinel on the Objective-C side of the boundary, per [CONVERSION-RECIPE.md](docs/swift-migration/CONVERSION-RECIPE.md)'s rule that SDK-type and sentinel marshaling lives in the `.m`:

```objc
- (NSArray *)plannedKeysForPointInfoKey:(NSString *)pointInfoKey {
    id planned = self.pointInfo[pointInfoKey];
    return [planned isKindOfClass:[NSArray class]] ? planned : nil;
}
```

`-isKindOfClass:` covers nil, `NSNull`, and any other unexpected shape in one check, and `nil` already means "nothing planned, block nothing" in the existing Swift.

**Behaviour change:** an unconstrained point with blocking **on** used to crash and now blocks nothing. That is what unconstrained means, and it is how `filterProducts:` (`:272`) has always read the same sentinel.

## Verification

The three new tests fail on the unfixed tip and pass after the change — red first, then green, same tests:

```
testUnconstrainedUserPointsAreStoredAsTheNullSentinel      passed (both)
testUnconstrainedUserPointsBlockNothingWhenBlockingIsOff   FAILED → passed
testUnconstrainedUserPointsBlockNothingWhenBlockingIsOn    FAILED → passed
```

No new Swift test: `MPDataPlanFilterPolicyTests.testNothingIsBlockedWhenThePlanHasNoEntry` already pins the `nil → false` contract this fix relies on.

## Why the earlier audit missed it

My differential-oracle pass over #901–#905 excluded `MPDataPlanFilter`'s plan-shape readers from the port because of the pointer-identity `_emptyDictionary` and this very `NSNull` sentinel — then never checked what happens when those readers' *outputs* cross the new Swift boundary. There was also no existing test for `isBlockedUserAttributeKey:`/`isBlockedUserIdentityType:` at the Objective-C level at all; the Swift tests only exercise the policy directly with real arrays and `nil`. Excluding code from a port is not the same as excluding it from the blast radius.

## Gate

| # | Item | Result |
|---|---|---|
| 1 | `bash Tools/abi-guard.sh check` | PASSED — no public ABI diff, baseline untouched |
| 2 | `pod lib lint` ×3 podspecs | `mParticle-Apple-SDK passed validation` (iOS). **tvOS not run locally** — no matching simulator runtime on this machine; CI is the only tvOS check |
| 3 | iOS + tvOS build, no new warnings | iOS clean, zero warnings in the changed files. **tvOS via CI only** |
| 4 | `trunk check` | `No new issues` (43 pre-existing) |
| 5 | ObjC + Swift suites | ObjC **1000 passed, 0 failures, 0 restarts**; Swift **551 passed, 0 failures, 0 restarts** (serial; restart count checked so a truncated run can't read as green) |

No CHANGELOG entry: the bug never shipped — #904 is on `workstation/swift-migration` only. Flagging that for a human call rather than writing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)