### PR TITLE
fix: preserve array attribute validation log details

### DIFF
--- a/UnitTests/ObjCTests/MPBackendControllerTests.m
+++ b/UnitTests/ObjCTests/MPBackendControllerTests.m
@@ -425,13 +425,51 @@
 
 - (void)testCheckAttributeArrayValueInvalidLongAttribute {
     NSError *error = nil;
-    id mockValue = [OCMockObject mockForClass:[NSString class]];
-    OCMStub([mockValue length]).andReturn(LIMIT_ATTR_VALUE_LENGTH);
     NSArray *arrayValue = @[@"foo", @10.0];
+
+    MParticle *mParticle = [MParticle sharedInstance];
+    MPILogLevel previousLogLevel = mParticle.logLevel;
+    void (^previousCustomLogger)(NSString *) = [mParticle.customLogger copy];
+    __block NSString *logMessage = nil;
+    mParticle.logLevel = MPILogLevelError;
+    mParticle.customLogger = ^(NSString *message) {
+        logMessage = message;
+    };
+
     BOOL success = [MPBackendController_PRIVATE checkAttribute:[NSDictionary dictionary] key:@"foo" value:arrayValue error:&error];
+
+    mParticle.customLogger = previousCustomLogger;
+    mParticle.logLevel = previousLogLevel;
+
     XCTAssertFalse(success);
     XCTAssertNotNil(error);
     XCTAssertEqual(kInvalidDataType, error.code);
+    XCTAssertEqualObjects(logMessage, @"mParticle -> Error while setting attribute value list: all user attribute entries in the array must be of type string. Error entry: 10");
+}
+
+- (void)testCheckAttributeArrayValuesTooLongLog {
+    NSError *error = nil;
+    NSString *longValue = [@"a" stringByPaddingToLength:LIMIT_ATTR_VALUE_LENGTH withString:@"a" startingAtIndex:0];
+    NSArray *arrayValue = @[@"foo", longValue];
+
+    MParticle *mParticle = [MParticle sharedInstance];
+    MPILogLevel previousLogLevel = mParticle.logLevel;
+    void (^previousCustomLogger)(NSString *) = [mParticle.customLogger copy];
+    __block NSString *logMessage = nil;
+    mParticle.logLevel = MPILogLevelError;
+    mParticle.customLogger = ^(NSString *message) {
+        logMessage = message;
+    };
+
+    BOOL success = [MPBackendController_PRIVATE checkAttribute:[NSDictionary dictionary] key:@"foo" value:arrayValue error:&error];
+
+    mParticle.customLogger = previousCustomLogger;
+    mParticle.logLevel = previousLogLevel;
+
+    XCTAssertFalse(success);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(kExceededAttributeValueMaximumLength, error.code);
+    XCTAssertEqualObjects(logMessage, @"mParticle -> Error while setting attribute value list: combined length of list values longer than the maximum alowed.");
 }
 
 

--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPAttributeValidator.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPAttributeValidator.swift
@@ -10,12 +10,21 @@ import Foundation
     case nilValue
     case invalidType
     case valueTooLong
+    case invalidArrayEntry
+    case arrayValueTooLong
 }
 
 @objc public final class MPAttributeValidator: NSObject {
-    @objc(validateKey:value:keyLengthLimit:valueLengthLimit:)
-    public static func validate(key: Any?, value: Any?, keyLengthLimit: Int,
-                                valueLengthLimit: Int) -> MPAttributeValidationResult {
+    @objc(validateKey:value:keyLengthLimit:valueLengthLimit:invalidArrayEntry:)
+    public static func validate(
+        key: Any?,
+        value: Any?,
+        keyLengthLimit: Int,
+        valueLengthLimit: Int,
+        invalidArrayEntry: AutoreleasingUnsafeMutablePointer<AnyObject?>?
+    ) -> MPAttributeValidationResult {
+        invalidArrayEntry?.pointee = nil
+
         if key == nil || key is NSNull {
             return .invalidKey
         }
@@ -47,12 +56,13 @@ import Foundation
             var totalValueLength = 0
             for entry in values {
                 guard let entryString = entry as? NSString else {
-                    return .invalidType
+                    invalidArrayEntry?.pointee = entry as AnyObject
+                    return .invalidArrayEntry
                 }
                 totalValueLength += entryString.length
             }
             if totalValueLength > valueLengthLimit {
-                return .valueTooLong
+                return .arrayValueTooLong
             }
         }
 

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPAttributeValidatorTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPAttributeValidatorTests.swift
@@ -6,7 +6,13 @@ final class MPAttributeValidatorTests: XCTestCase {
     private let valueLimit = 4096
 
     private func validate(key: Any?, value: Any?) -> MPAttributeValidationResult {
-        MPAttributeValidator.validate(key: key, value: value, keyLengthLimit: keyLimit, valueLengthLimit: valueLimit)
+        MPAttributeValidator.validate(
+            key: key,
+            value: value,
+            keyLengthLimit: keyLimit,
+            valueLengthLimit: valueLimit,
+            invalidArrayEntry: nil
+        )
     }
 
     // MARK: - Valid values
@@ -60,11 +66,21 @@ final class MPAttributeValidatorTests: XCTestCase {
     }
 
     func testAnArrayWithANonStringEntryIsInvalid() {
-        XCTAssertEqual(validate(key: "foo", value: ["a", NSNumber(value: 1), "c"]), .invalidType)
+        var invalidArrayEntry: AnyObject?
+        let result = MPAttributeValidator.validate(
+            key: "foo",
+            value: ["a", NSNumber(value: 1), "c"],
+            keyLengthLimit: keyLimit,
+            valueLengthLimit: valueLimit,
+            invalidArrayEntry: &invalidArrayEntry
+        )
+
+        XCTAssertEqual(result, .invalidArrayEntry)
+        XCTAssertEqual(invalidArrayEntry as? NSNumber, NSNumber(value: 1))
     }
 
     func testAnArrayWhoseCombinedLengthExceedsTheLimitIsTooLong() {
         let half = String(repeating: "v", count: valueLimit/2 + 1)
-        XCTAssertEqual(validate(key: "foo", value: [half, half]), .valueTooLong)
+        XCTAssertEqual(validate(key: "foo", value: [half, half]), .arrayValueTooLong)
     }
 }

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -879,10 +879,12 @@ static BOOL skipNextUpload = NO;
 
 + (BOOL)checkAttribute:(NSDictionary *)attributesDictionary key:(NSString *)key value:(id)value error:(out NSError *__autoreleasing *)error  {
     static NSString *attributeValidationErrorDomain = @"Attribute Validation";
+    id invalidArrayEntry = nil;
     MPAttributeValidationResult result = [MPAttributeValidator validateKey:key
                                                                      value:value
                                                             keyLengthLimit:LIMIT_ATTR_KEY_LENGTH
-                                                          valueLengthLimit:LIMIT_ATTR_VALUE_LENGTH];
+                                                          valueLengthLimit:LIMIT_ATTR_VALUE_LENGTH
+                                                         invalidArrayEntry:&invalidArrayEntry];
 
     if (result == MPAttributeValidationResultValid) {
         return YES;
@@ -909,6 +911,14 @@ static BOOL skipNextUpload = NO;
         case MPAttributeValidationResultValueTooLong:
             code = kExceededAttributeValueMaximumLength;
             MPILogError(@"Error while setting attribute value: value is longer than the maximum allowed %@", value);
+            break;
+        case MPAttributeValidationResultInvalidArrayEntry:
+            code = kInvalidDataType;
+            MPILogError(@"Error while setting attribute value list: all user attribute entries in the array must be of type string. Error entry: %@", invalidArrayEntry);
+            break;
+        case MPAttributeValidationResultArrayValueTooLong:
+            code = kExceededAttributeValueMaximumLength;
+            MPILogError(@"Error while setting attribute value list: combined length of list values longer than the maximum alowed.");
             break;
         case MPAttributeValidationResultValid:
             break;


### PR DESCRIPTION
## Background

The Swift attribute-validation migration generalized the console messages for array failures. This removed the offending entry from invalid-array logs and replaced the combined-length message, making customer diagnostics less specific.

## What Has Changed

- Distinguish invalid array entries and excessive combined array length in the Swift validator.
- Carry the offending entry back to Objective-C without formatting it when logging is disabled.
- Restore the legacy array-specific console messages.
- Add Swift result coverage and Objective-C logger regression tests.

## Screenshots/Video

N/A — no visual changes

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally
