### PR TITLE
refactor: move message batching to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPMessageBatcher.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPMessageBatcher.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Pure packing arithmetic for grouping persisted messages into uploads. The
+/// caller marshals each message to its byte length and crash-report flag, keeps
+/// every side effect (fetching messages, building `MPUpload`s, persistence), and
+/// rebuilds the message batches from the index groups this type returns.
+@objc public final class MPMessageBatcher: NSObject {
+    /// Packs message indices into batches bounded by message count and byte size.
+    /// Crash reports use their own, larger per-batch and per-message ceilings. A
+    /// message larger than its applicable per-message ceiling is dropped. The
+    /// returned arrays hold indices into the input, in original order.
+    @objc(batchGroupsWithLengths:crashFlags:maxMessages:maxBatchBytes:maxMessageBytes:crashBatchBytes:crashMessageBytes:)
+    public static func batchIndexGroups(byteLengths: [Int],
+                                        isCrashReport: [Bool],
+                                        maxBatchMessages: Int,
+                                        maxBatchBytes: Int,
+                                        maxMessageBytes: Int,
+                                        crashMaxBatchBytes: Int,
+                                        crashMaxMessageBytes: Int) -> [[Int]] {
+        var batchIndexGroups: [[Int]] = []
+        var batchIndices: [Int] = []
+        var batchMessageCount = 0
+        var batchByteCount = 0
+
+        for index in 0..<byteLengths.count {
+            let byteLength = byteLengths[index]
+            let crashReport = index < isCrashReport.count && isCrashReport[index]
+            let iterationMaxBatchBytes = crashReport ? crashMaxBatchBytes : maxBatchBytes
+            let iterationMaxMessageBytes = crashReport ? crashMaxMessageBytes : maxMessageBytes
+
+            if byteLength > iterationMaxMessageBytes { continue }
+
+            if batchMessageCount + 1 > maxBatchMessages || batchByteCount + byteLength > iterationMaxBatchBytes {
+                batchIndexGroups.append(batchIndices)
+                batchIndices = []
+                batchMessageCount = 0
+                batchByteCount = 0
+            }
+
+            batchIndices.append(index)
+            batchMessageCount += 1
+            batchByteCount += byteLength
+        }
+
+        if !batchIndices.isEmpty {
+            batchIndexGroups.append(batchIndices)
+        }
+
+        return batchIndexGroups
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPMessageBatcherTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPMessageBatcherTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPMessageBatcherTests: XCTestCase {
+    // Generous ceilings so only the dimension under test forces a split.
+    private let big = 1_000_000
+
+    private func groups(_ byteLengths: [Int],
+                        crash: [Bool]? = nil,
+                        maxBatchMessages: Int = 100,
+                        maxBatchBytes: Int = 1_000_000,
+                        maxMessageBytes: Int = 1_000_000,
+                        crashMaxBatchBytes: Int = 2_048_000,
+                        crashMaxMessageBytes: Int = 1_024_000) -> [[Int]] {
+        MPMessageBatcher.batchIndexGroups(
+            byteLengths: byteLengths,
+            isCrashReport: crash ?? Array(repeating: false, count: byteLengths.count),
+            maxBatchMessages: maxBatchMessages,
+            maxBatchBytes: maxBatchBytes,
+            maxMessageBytes: maxMessageBytes,
+            crashMaxBatchBytes: crashMaxBatchBytes,
+            crashMaxMessageBytes: crashMaxMessageBytes
+        )
+    }
+
+    func testEmptyInputProducesNoBatches() {
+        XCTAssertEqual(groups([]), [])
+    }
+
+    func testEverythingFitsInOneBatch() {
+        XCTAssertEqual(groups([10, 20, 30]), [[0, 1, 2]])
+    }
+
+    func testMessageCountLimitSplitsBatches() {
+        XCTAssertEqual(groups([1, 1, 1, 1, 1], maxBatchMessages: 2), [[0, 1], [2, 3], [4]])
+    }
+
+    func testByteBudgetSplitsBatches() {
+        // 60 + 60 > 100 forces the second message into a new batch.
+        XCTAssertEqual(groups([60, 60, 30], maxBatchBytes: 100), [[0], [1, 2]])
+    }
+
+    func testOversizedMessageIsDropped() {
+        // Index 1 exceeds the per-message ceiling and is skipped entirely.
+        XCTAssertEqual(groups([10, 500, 20], maxMessageBytes: 100), [[0, 2]])
+    }
+
+    func testCrashReportUsesLargerCrashCeilings() {
+        // 700_000 bytes exceeds the normal per-message ceiling but fits the crash one.
+        let result = groups([700_000], crash: [true], maxMessageBytes: 100_000)
+        XCTAssertEqual(result, [[0]])
+    }
+
+    func testCrashReportExceedingCrashCeilingIsDropped() {
+        let result = groups([2_000_000], crash: [true])
+        XCTAssertEqual(result, [])
+    }
+
+    func testMixedCrashAndNormalRespectPerMessageCeilings() {
+        // Normal 500 (dropped, >100), crash 700_000 (kept), normal 50 (kept).
+        let result = groups([500, 700_000, 50],
+                            crash: [false, true, false],
+                            maxMessageBytes: 100)
+        XCTAssertEqual(result, [[1, 2]])
+    }
+}

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -240,8 +240,8 @@
 		72E8785C2F2AB29A00F355F2 /* MPSideloadedKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 72E8785B2F2AB29A00F355F2 /* MPSideloadedKit.m */; };
 		72FEBD182E86FE3B00B8341F /* MPIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FEBD162E86FE2D00B8341F /* MPIdentityTests.swift */; };
 		7AF100032F50000300E74801 /* MPLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AF100012F50000100E74801 /* MPLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7AF100072F89801000E74802 /* MPRoktKitDispatchTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AF100062F89801000E74801 /* MPRoktKitDispatchTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AF100042F50000400E74801 /* MPLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AF100022F50000200E74801 /* MPLocation.m */; };
+		7AF100072F89801000E74802 /* MPRoktKitDispatchTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AF100062F89801000E74801 /* MPRoktKitDispatchTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B0C1A022F70000100000002 /* NSDictionaryMPCaseInsensitiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B0C1A012F70000100000001 /* NSDictionaryMPCaseInsensitiveTests.m */; };
 		7E0387812DB913D2003B7D5E /* MPRokt.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E03877F2DB913D2003B7D5E /* MPRokt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E0387822DB913D2003B7D5E /* MPRokt.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0387802DB913D2003B7D5E /* MPRokt.m */; };
@@ -546,8 +546,8 @@
 		72E8785B2F2AB29A00F355F2 /* MPSideloadedKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPSideloadedKit.m; sourceTree = "<group>"; };
 		72FEBD162E86FE2D00B8341F /* MPIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPIdentityTests.swift; sourceTree = "<group>"; };
 		7AF100012F50000100E74801 /* MPLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPLocation.h; sourceTree = "<group>"; };
-		7AF100062F89801000E74801 /* MPRoktKitDispatchTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPRoktKitDispatchTarget.h; sourceTree = "<group>"; };
 		7AF100022F50000200E74801 /* MPLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPLocation.m; sourceTree = "<group>"; };
+		7AF100062F89801000E74801 /* MPRoktKitDispatchTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPRoktKitDispatchTarget.h; sourceTree = "<group>"; };
 		7B0C1A012F70000100000001 /* NSDictionaryMPCaseInsensitiveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSDictionaryMPCaseInsensitiveTests.m; sourceTree = "<group>"; };
 		7E03877F2DB913D2003B7D5E /* MPRokt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPRokt.h; sourceTree = "<group>"; };
 		7E0387802DB913D2003B7D5E /* MPRokt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPRokt.m; sourceTree = "<group>"; };
@@ -574,22 +574,22 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
-				Test/Kits/MPEventProjectionParserTests.swift,
 				Test/Kits/MPDataPlanFilterPolicyTests.swift,
-				Test/Kits/MPKitFilterEngineTests.swift,
+				Test/Kits/MPEventProjectionParserTests.swift,
 				Test/Kits/MPKitConfigurationParserTests.swift,
-				Test/Kits/MPProjectionFieldParserTests.swift,
+				Test/Kits/MPKitFilterEngineTests.swift,
 				Test/Kits/MPKitProjectionEngineTests.swift,
 				Test/Kits/MPKitSelectorInvokerTests.swift,
+				Test/Kits/MPProjectionFieldParserTests.swift,
 				Test/Network/MParticleReachabilityTests.swift,
 				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
 				Test/Network/MPEndpointPathStyleTests.swift,
 				Test/Network/MPRequestSignerTests.swift,
 				Test/Network/MPURLRequestPlanTests.swift,
+				Test/Notifications/MParticleUserNotificationTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,
 				Test/Notifications/MPPushTrackingLogicTests.swift,
-				Test/Notifications/MParticleUserNotificationTests.swift,
 				Test/Notifications/SceneDelegateLogicTests.swift,
 				Test/Persistence/MPPersistenceFileSystemTests.swift,
 				Test/Persistence/MPPersistenceSchemaTests.swift,
@@ -623,6 +623,7 @@
 				Test/Utils/MPNetworkCommunicationHelperTests.swift,
 				Test/Utils/MPResponseConfigTests.swift,
 				Test/Utils/MPSessionTimingPolicyTests.swift,
+				Test/Utils/MPMessageBatcherTests.swift,
 				Test/Utils/MPSettingsProviderTests.swift,
 				Test/Utils/MPStateMachineTests.swift,
 				Test/Utils/MPUploadSettingsTests.swift,
@@ -641,22 +642,22 @@
 			membershipExceptions = (
 				Test/Identity/MPIdentityDTOTests.swift,
 				Test/Identity/MPUserIdentityChangeTests.m,
-				Test/Kits/MPEventProjectionParserTests.swift,
 				Test/Kits/MPDataPlanFilterPolicyTests.swift,
-				Test/Kits/MPKitFilterEngineTests.swift,
+				Test/Kits/MPEventProjectionParserTests.swift,
 				Test/Kits/MPKitConfigurationParserTests.swift,
-				Test/Kits/MPProjectionFieldParserTests.swift,
+				Test/Kits/MPKitFilterEngineTests.swift,
 				Test/Kits/MPKitProjectionEngineTests.swift,
 				Test/Kits/MPKitSelectorInvokerTests.swift,
+				Test/Kits/MPProjectionFieldParserTests.swift,
 				Test/Network/MParticleReachabilityTests.swift,
 				Test/Network/MPDataPlanQueryTests.swift,
 				Test/Network/MPEndpointHostResolverTests.swift,
 				Test/Network/MPEndpointPathStyleTests.swift,
 				Test/Network/MPRequestSignerTests.swift,
 				Test/Network/MPURLRequestPlanTests.swift,
+				Test/Notifications/MParticleUserNotificationTests.swift,
 				Test/Notifications/MPDeviceTokenStoreTests.swift,
 				Test/Notifications/MPPushTrackingLogicTests.swift,
-				Test/Notifications/MParticleUserNotificationTests.swift,
 				Test/Notifications/SceneDelegateLogicTests.swift,
 				Test/Persistence/MPPersistenceFileSystemTests.swift,
 				Test/Persistence/MPPersistenceSchemaTests.swift,
@@ -690,6 +691,7 @@
 				Test/Utils/MPNetworkCommunicationHelperTests.swift,
 				Test/Utils/MPResponseConfigTests.swift,
 				Test/Utils/MPSessionTimingPolicyTests.swift,
+				Test/Utils/MPMessageBatcherTests.swift,
 				Test/Utils/MPSettingsProviderTests.swift,
 				Test/Utils/MPStateMachineTests.swift,
 				Test/Utils/MPUploadSettingsTests.swift,

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -483,40 +483,27 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
 }
 
 - (NSArray *)batchMessageArraysFromMessageArray:(NSArray *)messages maxBatchMessages:(NSInteger)maxBatchMessages maxBatchBytes:(NSInteger)maxBatchBytes maxMessageBytes:(NSInteger)maxMessageBytes {
-    NSMutableArray *batchMessageArrays = [NSMutableArray array];
-    int batchMessageCount = 0;
-    int batchByteCount = 0;
-    
-    NSMutableArray *batchMessages = [NSMutableArray array];
-    
-    for (int i = 0; i < messages.count; i += 1) {
-        MPMessage *message = messages[i];
-        
-        NSInteger iterationMaxBatchBytes = maxBatchBytes;
-        NSInteger iterationMaxMessageBytes = maxMessageBytes;
-        bool isCrashReport = [message.messageType isEqualToString:kMPMessageTypeStringCrashReport];
-        if(isCrashReport) {
-            iterationMaxBatchBytes = MAX_BYTES_PER_BATCH_CRASH;
-            iterationMaxMessageBytes = MAX_BYTES_PER_EVENT_CRASH;
-        }
-        
-        if (message.messageData.length > iterationMaxMessageBytes) continue;
-        
-        if (batchMessageCount + 1 > maxBatchMessages || batchByteCount + message.messageData.length > iterationMaxBatchBytes) {
-            
-            [batchMessageArrays addObject:[batchMessages copy]];
-            
-            batchMessages = [NSMutableArray array];
-            batchMessageCount = 0;
-            batchByteCount = 0;
-            
-        }
-        [batchMessages addObject:message];
-        batchMessageCount += 1;
-        batchByteCount += message.messageData.length;
+    NSMutableArray<NSNumber *> *byteLengths = [NSMutableArray arrayWithCapacity:messages.count];
+    NSMutableArray<NSNumber *> *isCrashReport = [NSMutableArray arrayWithCapacity:messages.count];
+    for (MPMessage *message in messages) {
+        [byteLengths addObject:@(message.messageData.length)];
+        [isCrashReport addObject:@([message.messageType isEqualToString:kMPMessageTypeStringCrashReport])];
     }
-    
-    if (batchMessages.count > 0) {
+
+    NSArray<NSArray<NSNumber *> *> *indexGroups = [MPMessageBatcher batchGroupsWithLengths:byteLengths
+                                                                                crashFlags:isCrashReport
+                                                                               maxMessages:maxBatchMessages
+                                                                             maxBatchBytes:maxBatchBytes
+                                                                           maxMessageBytes:maxMessageBytes
+                                                                            crashBatchBytes:MAX_BYTES_PER_BATCH_CRASH
+                                                                          crashMessageBytes:MAX_BYTES_PER_EVENT_CRASH];
+
+    NSMutableArray *batchMessageArrays = [NSMutableArray arrayWithCapacity:indexGroups.count];
+    for (NSArray<NSNumber *> *indexGroup in indexGroups) {
+        NSMutableArray *batchMessages = [NSMutableArray arrayWithCapacity:indexGroup.count];
+        for (NSNumber *index in indexGroup) {
+            [batchMessages addObject:messages[index.unsignedIntegerValue]];
+        }
         [batchMessageArrays addObject:[batchMessages copy]];
     }
     return [batchMessageArrays copy];


### PR DESCRIPTION
## Background

`MPBackendController`'s `batchMessageArraysFromMessageArray:` packs persisted messages into count- and byte-bounded uploads — pure arithmetic with no SDK-object, queue, or persistence dependency. Next Foundation-only slice extracted from the backend controller, continuing attribute validation (#911) and session timing (#912).

## What Has Changed

- Add `MPMessageBatcher.batchGroups(...)` (Foundation-only): packs message indices into batches by count and byte size, applies the larger crash-report ceilings, drops over-sized messages, returns index groups in order.
- Thin `batchMessageArraysFromMessageArray:` to marshal each `MPMessage` → `(byteLength, isCrashReport)`, call the Swift batcher, and rebuild `MPMessage` batches from the index groups. Crash byte limits stay in `MPIConstants.m`, passed in.
- Add Swift mirror tests (count / byte / per-message / crash-ceiling / mixed); keep the ObjC `MPBackendControllerTests` byte-limit suite as the behavior contract.

## Testing

- `trunk check` — clean
- `bash Tools/abi-guard.sh check` — no public ABI diff (signature unchanged)
- iOS build of `mParticle-Apple-SDK` — succeeded, 0 warnings
- Swift unit suite incl. new `MPMessageBatcher` mirror tests
- ObjC `MPBackendControllerTests` batch/byte-limit tests (9) — green
- Full ObjC suite, tvOS, three-podspec `pod lib lint` — delegated to CI

Continues the `MPBackendController` → Swift extraction; #911/#912 are already merged into `workstation/swift-migration`. Next in the stack (user-attribute value logic) will branch from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)