### PR TITLE
refactor: move webview product and identity parsing to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPConvertJSFields.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPConvertJSFields.swift
@@ -117,3 +117,151 @@ public final class MPConvertJSFields: NSObject {
         value as? NSNumber
     }
 }
+
+/// The values the webview bridge sends for one product. Every field is optional
+/// so the caller can keep the Objective-C guards: `name`, `sku` and `quantity`
+/// are `nonnull` on MPProduct, and `position` is a scalar, so "absent" and
+/// "nil" are not interchangeable the way they are for a promotion.
+@objc(MPProductFieldsJS)
+public final class MPProductFieldsJS: NSObject {
+    @objc public let brand: String?
+    @objc public let category: String?
+    @objc public let couponCode: String?
+    @objc public let name: String?
+    @objc public let price: NSNumber?
+    @objc public let sku: String?
+    @objc public let variant: String?
+    @objc public let position: NSNumber?
+    @objc public let quantity: NSNumber?
+    /// Already filtered to the string-key/string-value pairs the ObjC accepted.
+    @objc public let attributes: [String: String]
+
+    init(
+        brand: String?,
+        category: String?,
+        couponCode: String?,
+        name: String?,
+        price: NSNumber?,
+        sku: String?,
+        variant: String?,
+        position: NSNumber?,
+        quantity: NSNumber?,
+        attributes: [String: String]
+    ) {
+        self.brand = brand
+        self.category = category
+        self.couponCode = couponCode
+        self.name = name
+        self.price = price
+        self.sku = sku
+        self.variant = variant
+        self.position = position
+        self.quantity = quantity
+        self.attributes = attributes
+        super.init()
+    }
+}
+
+/// One `Identity`/`Type` pair from the webview bridge.
+@objc(MPWebviewIdentityPairJS)
+public final class MPWebviewIdentityPairJS: NSObject {
+    @objc public let identity: String
+    @objc public let identityType: UInt
+
+    init(identity: String, identityType: UInt) {
+        self.identity = identity
+        self.identityType = identityType
+        super.init()
+    }
+}
+
+/// Why an identity payload could not be read. The two failures are not
+/// interchangeable: a missing `UserIdentities` array logged before returning
+/// nil, while a malformed entry returned nil silently.
+@objc public enum MPWebviewIdentityOutcomeJS: Int {
+    case ok = 0
+    case missingUserIdentities = 1
+    case malformedEntry = 2
+}
+
+@objc(MPWebviewIdentityRequestJS)
+public final class MPWebviewIdentityRequestJS: NSObject {
+    @objc public let outcome: MPWebviewIdentityOutcomeJS
+    /// In application order: the `UserIdentities` entries, then the top-level
+    /// pair when present, so a duplicated type keeps its last-write-wins result.
+    @objc public let pairs: [MPWebviewIdentityPairJS]
+
+    init(outcome: MPWebviewIdentityOutcomeJS, pairs: [MPWebviewIdentityPairJS]) {
+        self.outcome = outcome
+        self.pairs = pairs
+        super.init()
+    }
+}
+
+public extension MPConvertJSFields {
+    @objc(productFieldsFromJSON:)
+    static func productFields(from json: [AnyHashable: Any]?) -> MPProductFieldsJS {
+        MPProductFieldsJS(
+            brand: json?["Brand"] as? String,
+            category: json?["Category"] as? String,
+            couponCode: json?["CouponCode"] as? String,
+            name: json?["Name"] as? String,
+            price: price(json?["Price"]),
+            sku: json?["Sku"] as? String,
+            variant: json?["Variant"] as? String,
+            position: json?["Position"] as? NSNumber,
+            quantity: json?["Quantity"] as? NSNumber,
+            attributes: stringAttributes(json?["Attributes"])
+        )
+    }
+
+    /// An NSNumber passes through; a string goes through `-doubleValue`, which
+    /// yields 0 for text that is not a number — the ObjC did exactly that, so a
+    /// `"Price": "abc"` still produces 0 rather than being dropped.
+    private static func price(_ value: Any?) -> NSNumber? {
+        switch value {
+        case let number as NSNumber: number
+        case let string as String: NSNumber(value: (string as NSString).doubleValue)
+        default: nil
+        }
+    }
+
+    /// Both the key and the value had to be strings; anything else was skipped.
+    private static func stringAttributes(_ value: Any?) -> [String: String] {
+        guard let dictionary = value as? [AnyHashable: Any] else {
+            return [:]
+        }
+
+        return dictionary.reduce(into: [String: String]()) { result, element in
+            if let key = element.key as? String, let value = element.value as? String {
+                result[key] = value
+            }
+        }
+    }
+
+    @objc(identityRequestFromJSON:)
+    static func identityRequest(from json: [AnyHashable: Any]?) -> MPWebviewIdentityRequestJS {
+        guard let userIdentities = json?["UserIdentities"] as? [Any] else {
+            return MPWebviewIdentityRequestJS(outcome: .missingUserIdentities, pairs: [])
+        }
+
+        var pairs: [MPWebviewIdentityPairJS] = []
+        for entry in userIdentities {
+            let dictionary = entry as? [AnyHashable: Any]
+            guard let identity = dictionary?["Identity"] as? String,
+                  let type = dictionary?["Type"] as? NSNumber
+            else {
+                // One bad entry abandoned the whole request, without logging.
+                return MPWebviewIdentityRequestJS(outcome: .malformedEntry, pairs: [])
+            }
+            pairs.append(MPWebviewIdentityPairJS(identity: identity, identityType: type.uintValue))
+        }
+
+        // Applied last, so it overwrites a type the array already set.
+        if let identity = json?["Identity"] as? String, let type = json?["Type"] as? NSNumber {
+            pairs.append(MPWebviewIdentityPairJS(identity: identity, identityType: type.uintValue))
+        }
+
+        return MPWebviewIdentityRequestJS(outcome: .ok, pairs: pairs)
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPConvertJSFieldsTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPConvertJSFieldsTests.swift
@@ -155,4 +155,128 @@ final class MPConvertJSFieldsTests: XCTestCase {
         XCTAssertEqual(fields.shipping, NSNumber(value: 0))
         XCTAssertEqual(fields.revenue, NSNumber(value: 0.0))
     }
+
+    // MARK: - product
+
+    func testProductFieldsReadsEveryValue() {
+        let fields = MPConvertJSFields.productFields(from: [
+            "Brand": "Acme",
+            "Category": "widgets",
+            "CouponCode": "SAVE5",
+            "Name": "Widget",
+            "Price": 9.99,
+            "Sku": "SKU-1",
+            "Variant": "blue",
+            "Position": 3,
+            "Quantity": 2
+        ])
+
+        XCTAssertEqual(fields.brand, "Acme")
+        XCTAssertEqual(fields.category, "widgets")
+        XCTAssertEqual(fields.couponCode, "SAVE5")
+        XCTAssertEqual(fields.name, "Widget")
+        XCTAssertEqual(fields.price, NSNumber(value: 9.99))
+        XCTAssertEqual(fields.sku, "SKU-1")
+        XCTAssertEqual(fields.variant, "blue")
+        XCTAssertEqual(fields.position, NSNumber(value: 3))
+        XCTAssertEqual(fields.quantity, NSNumber(value: 2))
+    }
+
+    func testProductPriceAcceptsAStringAndFallsBackToZero() {
+        // The ObjC had a second branch for NSString using -doubleValue, which
+        // yields 0 for text that is not a number rather than dropping the field.
+        XCTAssertEqual(MPConvertJSFields.productFields(from: ["Price": "9.99"]).price, NSNumber(value: 9.99))
+        XCTAssertEqual(MPConvertJSFields.productFields(from: ["Price": "abc"]).price, NSNumber(value: 0.0))
+        XCTAssertNil(MPConvertJSFields.productFields(from: ["Price": NSNull()]).price)
+        XCTAssertNil(MPConvertJSFields.productFields(from: ["Price": ["a": 1]]).price)
+    }
+
+    func testProductPositionIsNilWhenAbsentOrNotANumber() {
+        // position is a scalar on MPProduct, so nil has to mean "do not assign"
+        // rather than "assign zero".
+        XCTAssertNil(MPConvertJSFields.productFields(from: [:]).position)
+        XCTAssertNil(MPConvertJSFields.productFields(from: ["Position": "3"]).position)
+        XCTAssertEqual(MPConvertJSFields.productFields(from: ["Position": 0]).position, NSNumber(value: 0))
+    }
+
+    func testProductAttributesKeepsOnlyStringToStringPairs() {
+        let fields = MPConvertJSFields.productFields(from: ["Attributes": [
+            "good": "value",
+            "numeric": 42,
+            "null": NSNull(),
+            "nested": ["a": "b"]
+        ]])
+
+        XCTAssertEqual(fields.attributes, ["good": "value"])
+    }
+
+    func testProductAttributesIsEmptyWhenAbsentOrNotADictionary() {
+        for value: Any in ["not a dictionary", 7, NSNull(), ["a", "b"]] {
+            XCTAssertTrue(MPConvertJSFields.productFields(from: ["Attributes": value]).attributes.isEmpty)
+        }
+        XCTAssertTrue(MPConvertJSFields.productFields(from: nil).attributes.isEmpty)
+    }
+
+    // MARK: - identity request
+
+    func testIdentityRequestReadsThePairsInApplicationOrder() {
+        let parsed = MPConvertJSFields.identityRequest(from: [
+            "UserIdentities": [
+                ["Identity": "a@example.com", "Type": 7],
+                ["Identity": "cust-1", "Type": 1]
+            ],
+            "Identity": "last@example.com",
+            "Type": 7
+        ])
+
+        XCTAssertEqual(parsed.outcome, .ok)
+        XCTAssertEqual(parsed.pairs.count, 3)
+        XCTAssertEqual(parsed.pairs.map(\.identity), ["a@example.com", "cust-1", "last@example.com"])
+        // The top-level pair is applied last, so a duplicated type overwrites.
+        XCTAssertEqual(parsed.pairs.last?.identityType, 7)
+    }
+
+    func testIdentityRequestReportsAMissingUserIdentitiesArray() {
+        for json: [AnyHashable: Any]? in [[:], nil, ["UserIdentities": NSNull()], ["UserIdentities": "nope"]] {
+            XCTAssertEqual(MPConvertJSFields.identityRequest(from: json).outcome, .missingUserIdentities)
+        }
+    }
+
+    func testIdentityRequestReportsAMalformedEntrySeparately() {
+        // Distinct from the missing-array case: the ObjC logged for that one and
+        // returned nil silently for this one.
+        let cases: [Any] = [
+            ["Type": 7], // no Identity
+            ["Identity": "a@example.com"], // no Type
+            ["Identity": 42, "Type": 7], // Identity not a string
+            ["Identity": "a@example.com", "Type": "7"], // Type not a number
+            "not a dictionary" // crashed the ObjC outright
+        ]
+
+        for entry in cases {
+            let parsed = MPConvertJSFields.identityRequest(from: ["UserIdentities": [entry]])
+            XCTAssertEqual(parsed.outcome, .malformedEntry)
+            XCTAssertTrue(parsed.pairs.isEmpty)
+        }
+    }
+
+    func testIdentityRequestAcceptsAnEmptyArrayWithNoTopLevelPair() {
+        let parsed = MPConvertJSFields.identityRequest(from: ["UserIdentities": []])
+
+        XCTAssertEqual(parsed.outcome, .ok)
+        XCTAssertTrue(parsed.pairs.isEmpty)
+    }
+
+    func testIdentityRequestIgnoresAPartialTopLevelPair() {
+        for json: [AnyHashable: Any] in [
+            ["UserIdentities": [], "Identity": "a@example.com"],
+            ["UserIdentities": [], "Type": 7],
+            ["UserIdentities": [], "Identity": 42, "Type": 7]
+        ] {
+            let parsed = MPConvertJSFields.identityRequest(from: json)
+
+            XCTAssertEqual(parsed.outcome, .ok)
+            XCTAssertTrue(parsed.pairs.isEmpty)
+        }
+    }
 }

--- a/mParticle-Apple-SDK/Utils/MPConvertJS.m
+++ b/mParticle-Apple-SDK/Utils/MPConvertJS.m
@@ -228,11 +228,11 @@
     if (fields.category) { product.category = fields.category; }
     if (fields.couponCode) { product.couponCode = fields.couponCode; }
     if (fields.name) { product.name = fields.name; }
-    if (fields.price) { product.price = fields.price; }
+    if (fields.price != nil) { product.price = fields.price; }
     if (fields.sku) { product.sku = fields.sku; }
     if (fields.variant) { product.variant = fields.variant; }
-    if (fields.position) { product.position = fields.position.unsignedIntValue; }
-    if (fields.quantity) { product.quantity = fields.quantity; }
+    if (fields.position != nil) { product.position = fields.position.unsignedIntValue; }
+    if (fields.quantity != nil) { product.quantity = fields.quantity; }
 
     [fields.attributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, __unused BOOL *stop) {
         [product setValue:value forKey:key];

--- a/mParticle-Apple-SDK/Utils/MPConvertJS.m
+++ b/mParticle-Apple-SDK/Utils/MPConvertJS.m
@@ -220,113 +220,47 @@
 
 + (MPProduct *)product:(NSDictionary *)json {
     MPProduct *product = [[MPProduct alloc] init];
+    MPProductFieldsJS *fields = [MPConvertJSFields productFieldsFromJSON:json];
 
-    id brand = json[@"Brand"];
-    if ([brand isKindOfClass:[NSString class]]) {
-        product.brand = (NSString *)brand;
-    }
+    // Guarded rather than assigned straight through: name, sku and quantity are
+    // nonnull and position is a scalar, so "absent" is not the same as nil here.
+    if (fields.brand) { product.brand = fields.brand; }
+    if (fields.category) { product.category = fields.category; }
+    if (fields.couponCode) { product.couponCode = fields.couponCode; }
+    if (fields.name) { product.name = fields.name; }
+    if (fields.price) { product.price = fields.price; }
+    if (fields.sku) { product.sku = fields.sku; }
+    if (fields.variant) { product.variant = fields.variant; }
+    if (fields.position) { product.position = fields.position.unsignedIntValue; }
+    if (fields.quantity) { product.quantity = fields.quantity; }
 
-    id category = json[@"Category"];
-    if ([category isKindOfClass:[NSString class]]) {
-        product.category = (NSString *)category;
-    }
-
-    id couponCode = json[@"CouponCode"];
-    if ([couponCode isKindOfClass:[NSString class]]) {
-        product.couponCode = (NSString *)couponCode;
-    }
-
-    id name = json[@"Name"];
-    if ([name isKindOfClass:[NSString class]]) {
-        product.name = (NSString *)name;
-    }
-
-    id price = json[@"Price"];
-    if ([price isKindOfClass:[NSNumber class]]) {
-        product.price = (NSNumber *)price;
-    } else if ([price isKindOfClass:[NSString class]]) {
-        product.price = @([(NSString *)price doubleValue]);
-    }
-
-    id sku = json[@"Sku"];
-    if ([sku isKindOfClass:[NSString class]]) {
-        product.sku = (NSString *)sku;
-    }
-
-    id variant = json[@"Variant"];
-    if ([variant isKindOfClass:[NSString class]]) {
-        product.variant = (NSString *)variant;
-    }
-
-    id position = json[@"Position"];
-    if ([position isKindOfClass:[NSNumber class]]) {
-        product.position = [(NSNumber *)position unsignedIntValue];
-    }
-
-    id quantity = json[@"Quantity"];
-    if ([quantity isKindOfClass:[NSNumber class]]) {
-        product.quantity = (NSNumber *)quantity;
-    }
-
-    id attributes = json[@"Attributes"];
-    if ([attributes isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *jsonAttributes = (NSDictionary *)attributes;
-        [jsonAttributes enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            if ([key isKindOfClass:[NSString class]] && [obj isKindOfClass:[NSString class]]) {
-                [product setValue:obj forKey:key];
-            }
-        }];
-    }
+    [fields.attributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, __unused BOOL *stop) {
+        [product setValue:value forKey:key];
+    }];
 
     return product;
 }
 
 + (MPIdentityApiRequest *)identityApiRequest:(NSDictionary *)json {
+    // Built before validating, as it was before, in case requestWithEmptyUser
+    // ever does more than allocate.
     MPIdentityApiRequest *request = [MPIdentityApiRequest requestWithEmptyUser];
-    
-    NSArray *userIdentities = json[@"UserIdentities"];
-    if (!userIdentities || ![userIdentities isKindOfClass:[NSArray class]]) {
+    MPWebviewIdentityRequestJS *parsed = [MPConvertJSFields identityRequestFromJSON:json];
+
+    if (parsed.outcome == MPWebviewIdentityOutcomeJSMissingUserIdentities) {
         MPILogError(@"Unexpected user identity data received from webview");
         return nil;
     }
-    
-    if (userIdentities.count > 0) {
-        __block BOOL allSuccess = YES;
-        
-        [userIdentities enumerateObjectsUsingBlock:^(NSDictionary * _Nonnull identityDictionary, NSUInteger idx, BOOL * _Nonnull stop) {
-            NSString *identity = identityDictionary[@"Identity"];
-            NSNumber *identityTypeNumber = identityDictionary[@"Type"];
-            
-            if (!identity || ![identity isKindOfClass:[NSString class]]) {
-                allSuccess = NO;
-                *stop = YES;
-                return;
-            }
-            
-            if (identityTypeNumber == nil || ![identityTypeNumber isKindOfClass:[NSNumber class]]) {
-                allSuccess = NO;
-                *stop = YES;
-                return;
-            }
-            
-            MPIdentity identityType = (MPIdentity)[identityTypeNumber unsignedIntegerValue];
-            [request setIdentity:identity identityType:identityType];
-        }];
-        
-        if (!allSuccess) {
-            return nil;
-        }
+
+    // A malformed entry abandoned the whole request without logging.
+    if (parsed.outcome != MPWebviewIdentityOutcomeJSOk) {
+        return nil;
     }
-    
-    NSString *identity = json[@"Identity"];
-    NSNumber *identityTypeNumber = json[@"Type"];
-    
-    if (identity && [identity isKindOfClass:[NSString class]] && 
-        identityTypeNumber && [identityTypeNumber isKindOfClass:[NSNumber class]]) {
-        MPIdentity identityType = (MPIdentity)[identityTypeNumber unsignedIntegerValue];
-        [request setIdentity:identity identityType:identityType];
+
+    for (MPWebviewIdentityPairJS *pair in parsed.pairs) {
+        [request setIdentity:pair.identity identityType:(MPIdentity)pair.identityType];
     }
-    
+
     return request;
 }
 


### PR DESCRIPTION
## Background

Second slice of `MPConvertJS`: product and identity JSON parsing.

## What Has Changed

- Added `productFieldsFromJSON:` and `identityRequestFromJSON:` to `MPConvertJSFields.swift`. **262 → 210 SLOC.**
- Unlike promotion fields (#929), product fields keep per-field `if` guards in the `.m` — `MPProduct` has `nonnull` string/number properties and a scalar `position`, so "absent" and "nil" aren't interchangeable here.
- Preserved: string prices coerce via `-doubleValue` (non-numeric strings → 0); `position` reads via `-unsignedIntValue`; product attributes require both key and value to be strings; a missing/non-array `UserIdentities` vs. a single malformed identity entry log and fail differently (the Swift result reports which); last-write-wins on duplicate identity types.
- Hardened: a non-dictionary entry in `UserIdentities` previously crashed (`-[NSString objectForKeyedSubscript:]`); now reports a malformed entry instead.

## Validation

- `abi-guard` PASSED
- `trunk check` clean
- ObjC 1004 / Swift 650 tests green; new Swift coverage 21/21
- tvOS: CI only

## Stack

Depends on #929.

## Checklist

- [x] Self-review completed
- [x] Tests added or updated
- [x] Tested locally
