### PR TITLE
refactor: move webview commerce event parsing to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPConvertJSFields.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPConvertJSFields.swift
@@ -265,3 +265,258 @@ public extension MPConvertJSFields {
         return MPWebviewIdentityRequestJS(outcome: .ok, pairs: pairs)
     }
 }
+
+/// Why a promotion container payload could not be read. Each case maps to a
+/// distinct MPILogError the caller still emits.
+@objc public enum MPPromotionContainerOutcomeJS: Int {
+    case ok = 0
+    case missingAction = 1
+    case missingActionType = 2
+    case missingList = 3
+}
+
+@objc(MPPromotionContainerFieldsJS)
+public final class MPPromotionContainerFieldsJS: NSObject {
+    @objc public let outcome: MPPromotionContainerOutcomeJS
+    /// The ObjC ternary was `== 1 ? View : Click`, so every other value — including
+    /// a negative one — is Click.
+    @objc public let isViewAction: Bool
+    /// Only the dictionary entries of PromotionList.
+    @objc public let promotions: [[AnyHashable: Any]]
+
+    init(
+        outcome: MPPromotionContainerOutcomeJS,
+        isViewAction: Bool,
+        promotions: [[AnyHashable: Any]]
+    ) {
+        self.outcome = outcome
+        self.isViewAction = isViewAction
+        self.promotions = promotions
+        super.init()
+    }
+}
+
+/// Why a commerce event payload could not be read.
+@objc public enum MPCommerceEventOutcomeJS: Int {
+    case ok = 0
+    case malformedProductAction = 1
+    case invalidPayload = 2
+    case malformedProductActionType = 3
+}
+
+/// Which initialiser the caller should use.
+@objc public enum MPCommerceEventKindJS: Int {
+    case none = 0
+    case productAction = 1
+    case promotion = 2
+    case impression = 3
+}
+
+@objc(MPCommerceFlagJS)
+public final class MPCommerceFlagJS: NSObject {
+    @objc public let key: String
+    @objc public let values: [String]
+
+    init(key: String, values: [String]) {
+        self.key = key
+        self.values = values
+        super.init()
+    }
+}
+
+@objc(MPCommerceImpressionJS)
+public final class MPCommerceImpressionJS: NSObject {
+    @objc public let listName: String
+    @objc public let products: [[AnyHashable: Any]]
+
+    init(listName: String, products: [[AnyHashable: Any]]) {
+        self.listName = listName
+        self.products = products
+        super.init()
+    }
+}
+
+@objc(MPCommerceEventFieldsJS)
+public final class MPCommerceEventFieldsJS: NSObject {
+    @objc public let outcome: MPCommerceEventOutcomeJS
+    @objc public let kind: MPCommerceEventKindJS
+    /// The raw ProductActionType, still to go through commerceEventActionForJSValue:.
+    @objc public let productActionType: NSNumber?
+    /// Present whenever ProductAction was a dictionary, which is what gated
+    /// reading transaction attributes off it.
+    @objc public let productAction: [AnyHashable: Any]?
+    @objc public let customAttributes: [AnyHashable: Any]?
+    @objc public let checkoutOptions: String?
+    @objc public let productListName: String?
+    @objc public let productListSource: String?
+    @objc public let currency: String?
+    @objc public let checkoutStep: NSNumber?
+    @objc public let customFlags: [MPCommerceFlagJS]
+    @objc public let products: [[AnyHashable: Any]]
+    @objc public let impressions: [MPCommerceImpressionJS]
+
+    // swiftlint:disable:next function_parameter_count
+    init(
+        outcome: MPCommerceEventOutcomeJS,
+        kind: MPCommerceEventKindJS,
+        productActionType: NSNumber?,
+        productAction: [AnyHashable: Any]?,
+        customAttributes: [AnyHashable: Any]?,
+        checkoutOptions: String?,
+        productListName: String?,
+        productListSource: String?,
+        currency: String?,
+        checkoutStep: NSNumber?,
+        customFlags: [MPCommerceFlagJS],
+        products: [[AnyHashable: Any]],
+        impressions: [MPCommerceImpressionJS]
+    ) {
+        self.outcome = outcome
+        self.kind = kind
+        self.productActionType = productActionType
+        self.productAction = productAction
+        self.customAttributes = customAttributes
+        self.checkoutOptions = checkoutOptions
+        self.productListName = productListName
+        self.productListSource = productListSource
+        self.currency = currency
+        self.checkoutStep = checkoutStep
+        self.customFlags = customFlags
+        self.products = products
+        self.impressions = impressions
+        super.init()
+    }
+
+    static func failed(_ outcome: MPCommerceEventOutcomeJS) -> MPCommerceEventFieldsJS {
+        MPCommerceEventFieldsJS(
+            outcome: outcome, kind: .none, productActionType: nil, productAction: nil,
+            customAttributes: nil, checkoutOptions: nil, productListName: nil,
+            productListSource: nil, currency: nil, checkoutStep: nil,
+            customFlags: [], products: [], impressions: []
+        )
+    }
+}
+
+public extension MPConvertJSFields {
+    @objc(promotionContainerFieldsFromJSON:)
+    static func promotionContainerFields(from json: [AnyHashable: Any]?) -> MPPromotionContainerFieldsJS {
+        guard let action = json?["PromotionAction"] as? [AnyHashable: Any] else {
+            return MPPromotionContainerFieldsJS(outcome: .missingAction, isViewAction: false, promotions: [])
+        }
+        guard let type = action["PromotionActionType"] as? NSNumber else {
+            return MPPromotionContainerFieldsJS(outcome: .missingActionType, isViewAction: false, promotions: [])
+        }
+        // -intValue, then `== 1 ? View : Click`.
+        let isViewAction = type.intValue == 1
+        guard let list = action["PromotionList"] as? [Any] else {
+            return MPPromotionContainerFieldsJS(outcome: .missingList, isViewAction: isViewAction, promotions: [])
+        }
+
+        return MPPromotionContainerFieldsJS(
+            outcome: .ok,
+            isViewAction: isViewAction,
+            promotions: dictionaries(in: list)
+        )
+    }
+
+    @objc(commerceEventFieldsFromJSON:)
+    static func commerceEventFields(from json: [AnyHashable: Any]?) -> MPCommerceEventFieldsJS {
+        let rawProductAction = json?["ProductAction"]
+        if rawProductAction != nil, !(rawProductAction is [AnyHashable: Any]) {
+            return .failed(.malformedProductAction)
+        }
+        let productAction = rawProductAction as? [AnyHashable: Any]
+
+        // Each of these was a bare nil check, so an explicit null still counts as
+        // present, exactly as before.
+        let isProductAction = productAction?["ProductActionType"] != nil
+        let isPromotion = json?["PromotionAction"] != nil
+        let isImpression = json?["ProductImpressions"] != nil
+
+        guard isProductAction || isPromotion || isImpression else {
+            return .failed(.invalidPayload)
+        }
+
+        var productActionType: NSNumber?
+        if isProductAction {
+            guard let type = productAction?["ProductActionType"] as? NSNumber else {
+                return .failed(.malformedProductActionType)
+            }
+            productActionType = type
+        }
+
+        // The ObjC chain was if/else-if/else, so a payload that is both a product
+        // action and a promotion is a product action.
+        let kind: MPCommerceEventKindJS = if isProductAction {
+            .productAction
+        } else if isPromotion {
+            .promotion
+        } else {
+            .impression
+        }
+
+        return MPCommerceEventFieldsJS(
+            outcome: .ok,
+            kind: kind,
+            productActionType: productActionType,
+            productAction: productAction,
+            customAttributes: json?["EventAttributes"] as? [AnyHashable: Any],
+            checkoutOptions: json?["CheckoutOptions"] as? String,
+            productListName: json?["productActionListName"] as? String,
+            productListSource: json?["productActionListSource"] as? String,
+            currency: json?["CurrencyCode"] as? String,
+            checkoutStep: json?["CheckoutStep"] as? NSNumber,
+            customFlags: commerceFlags(json?["CustomFlags"]),
+            products: dictionaries(in: productAction?["ProductList"] as? [Any] ?? []),
+            impressions: impressions(json?["ProductImpressions"])
+        )
+    }
+
+    /// A string value becomes a single-element array: -addCustomFlag:withKey:
+    /// forwards to -addCustomFlags:@[flag]:withKey: (MPBaseEvent.m:100), and its
+    /// only extra behaviour is a nil check the isKindOfClass: guard already made
+    /// unreachable. An array is kept only when every element is a string.
+    private static func commerceFlags(_ value: Any?) -> [MPCommerceFlagJS] {
+        guard let dictionary = value as? [AnyHashable: Any] else {
+            return []
+        }
+
+        return dictionary.compactMap { element in
+            guard let key = element.key as? String else {
+                return nil
+            }
+            if let single = element.value as? String {
+                return MPCommerceFlagJS(key: key, values: [single])
+            }
+            guard let array = element.value as? [Any] else {
+                return nil
+            }
+            let strings = array.compactMap { $0 as? String }
+            guard strings.count == array.count else {
+                return nil
+            }
+            return MPCommerceFlagJS(key: key, values: strings)
+        }
+    }
+
+    /// An impression needs both a string list name and an array of products;
+    /// anything else was skipped rather than partially applied.
+    private static func impressions(_ value: Any?) -> [MPCommerceImpressionJS] {
+        guard let list = value as? [Any] else {
+            return []
+        }
+
+        return dictionaries(in: list).compactMap { entry in
+            guard let listName = entry["ProductImpressionList"] as? String,
+                  let products = entry["ProductList"] as? [Any]
+            else {
+                return nil
+            }
+            return MPCommerceImpressionJS(listName: listName, products: dictionaries(in: products))
+        }
+    }
+
+    private static func dictionaries(in list: [Any]) -> [[AnyHashable: Any]] {
+        list.compactMap { $0 as? [AnyHashable: Any] }
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPConvertJSFieldsTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPConvertJSFieldsTests.swift
@@ -279,4 +279,204 @@ final class MPConvertJSFieldsTests: XCTestCase {
             XCTAssertTrue(parsed.pairs.isEmpty)
         }
     }
+
+    // MARK: - promotion container
+
+    private func promotionAction(_ inner: [AnyHashable: Any]) -> [AnyHashable: Any] {
+        ["PromotionAction": inner]
+    }
+
+    func testPromotionContainerReadsTheActionAndList() {
+        let fields = MPConvertJSFields.promotionContainerFields(from: promotionAction([
+            "PromotionActionType": 1,
+            "PromotionList": [["Name": "a"], ["Name": "b"]]
+        ]))
+
+        XCTAssertEqual(fields.outcome, .ok)
+        XCTAssertTrue(fields.isViewAction)
+        XCTAssertEqual(fields.promotions.count, 2)
+    }
+
+    func testPromotionContainerTreatsEveryNonOneActionAsClick() {
+        // The ObjC ternary was `== 1 ? View : Click`.
+        for raw in [0, 2, 99, -1] {
+            let fields = MPConvertJSFields.promotionContainerFields(from: promotionAction([
+                "PromotionActionType": raw,
+                "PromotionList": []
+            ]))
+
+            XCTAssertEqual(fields.outcome, .ok)
+            XCTAssertFalse(fields.isViewAction, "raw \(raw) should be Click")
+        }
+    }
+
+    func testPromotionContainerReportsEachFailureSeparately() {
+        // Three distinct MPILogError messages hang off these, so they cannot collapse.
+        XCTAssertEqual(MPConvertJSFields.promotionContainerFields(from: [:]).outcome, .missingAction)
+        XCTAssertEqual(MPConvertJSFields.promotionContainerFields(from: nil).outcome, .missingAction)
+        XCTAssertEqual(
+            MPConvertJSFields.promotionContainerFields(from: ["PromotionAction": "nope"]).outcome,
+            .missingAction
+        )
+        XCTAssertEqual(
+            MPConvertJSFields.promotionContainerFields(from: promotionAction([:])).outcome,
+            .missingActionType
+        )
+        XCTAssertEqual(
+            MPConvertJSFields.promotionContainerFields(from: promotionAction(["PromotionActionType": "1"])).outcome,
+            .missingActionType
+        )
+        XCTAssertEqual(
+            MPConvertJSFields.promotionContainerFields(from: promotionAction(["PromotionActionType": 1])).outcome,
+            .missingList
+        )
+    }
+
+    func testPromotionContainerSkipsNonDictionaryPromotions() {
+        // Each of these crashed the ObjC, which passed the element straight into
+        // +promotion: and subscripted it.
+        let fields = MPConvertJSFields.promotionContainerFields(from: promotionAction([
+            "PromotionActionType": 1,
+            "PromotionList": ["a string", 7, NSNull(), ["Name": "kept"]]
+        ]))
+
+        XCTAssertEqual(fields.promotions.count, 1)
+        XCTAssertEqual(fields.promotions.first?["Name"] as? String, "kept")
+    }
+
+    // MARK: - commerce event
+
+    func testCommerceEventReportsAMalformedProductAction() {
+        XCTAssertEqual(
+            MPConvertJSFields.commerceEventFields(from: ["ProductAction": "not a dictionary"]).outcome,
+            .malformedProductAction
+        )
+    }
+
+    func testCommerceEventReportsAnInvalidPayload() {
+        for json: [AnyHashable: Any]? in [[:], nil, ["ProductAction": [:]], ["Unrelated": 1]] {
+            XCTAssertEqual(MPConvertJSFields.commerceEventFields(from: json).outcome, .invalidPayload)
+        }
+    }
+
+    func testCommerceEventReportsAMalformedProductActionType() {
+        XCTAssertEqual(
+            MPConvertJSFields.commerceEventFields(from: ["ProductAction": ["ProductActionType": "1"]]).outcome,
+            .malformedProductActionType
+        )
+    }
+
+    func testCommerceEventTreatsAnExplicitNullActionTypeAsPresentThenMalformed() {
+        // The ObjC presence check was a bare != nil, so NSNull counted as present
+        // and then failed the isKindOfClass: check.
+        XCTAssertEqual(
+            MPConvertJSFields.commerceEventFields(from: ["ProductAction": ["ProductActionType": NSNull()]]).outcome,
+            .malformedProductActionType
+        )
+    }
+
+    func testCommerceEventKindPrefersProductActionThenPromotion() {
+        // The ObjC was if / else if / else, so a payload that is several things
+        // at once resolves in that order.
+        let all: [AnyHashable: Any] = [
+            "ProductAction": ["ProductActionType": 1],
+            "PromotionAction": ["PromotionActionType": 1],
+            "ProductImpressions": []
+        ]
+        XCTAssertEqual(MPConvertJSFields.commerceEventFields(from: all).kind, .productAction)
+
+        var withoutAction = all
+        withoutAction["ProductAction"] = nil
+        XCTAssertEqual(MPConvertJSFields.commerceEventFields(from: withoutAction).kind, .promotion)
+
+        XCTAssertEqual(
+            MPConvertJSFields.commerceEventFields(from: ["ProductImpressions": []]).kind,
+            .impression
+        )
+    }
+
+    func testCommerceEventReadsTheSimpleFields() {
+        let fields = MPConvertJSFields.commerceEventFields(from: [
+            "ProductImpressions": [],
+            "EventAttributes": ["k": "v"],
+            "CheckoutOptions": "options",
+            "productActionListName": "list",
+            "productActionListSource": "source",
+            "CurrencyCode": "USD",
+            "CheckoutStep": 3
+        ])
+
+        XCTAssertEqual(fields.customAttributes?["k"] as? String, "v")
+        XCTAssertEqual(fields.checkoutOptions, "options")
+        XCTAssertEqual(fields.productListName, "list")
+        XCTAssertEqual(fields.productListSource, "source")
+        XCTAssertEqual(fields.currency, "USD")
+        XCTAssertEqual(fields.checkoutStep, NSNumber(value: 3))
+    }
+
+    func testCommerceEventCheckoutStepIsNilUnlessItIsANumber() {
+        // checkoutStep is a scalar on MPCommerceEvent, so nil must mean "leave it".
+        XCTAssertNil(MPConvertJSFields.commerceEventFields(from: ["ProductImpressions": []]).checkoutStep)
+        XCTAssertNil(
+            MPConvertJSFields.commerceEventFields(from: ["ProductImpressions": [], "CheckoutStep": "3"]).checkoutStep
+        )
+    }
+
+    func testCommerceEventCustomFlagsAcceptAStringOrAnAllStringArray() {
+        let fields = MPConvertJSFields.commerceEventFields(from: [
+            "ProductImpressions": [],
+            "CustomFlags": [
+                "single": "one",
+                "many": ["a", "b"],
+                "mixed": ["a", 2],
+                "numeric": 7,
+                "null": NSNull()
+            ]
+        ])
+
+        let byKey = Dictionary(uniqueKeysWithValues: fields.customFlags.map { ($0.key, $0.values) })
+        XCTAssertEqual(byKey["single"], ["one"])
+        XCTAssertEqual(byKey["many"], ["a", "b"])
+        // A partially-string array was dropped whole, not filtered.
+        XCTAssertNil(byKey["mixed"])
+        XCTAssertNil(byKey["numeric"])
+        XCTAssertNil(byKey["null"])
+        XCTAssertEqual(fields.customFlags.count, 2)
+    }
+
+    func testCommerceEventProductsComeFromTheProductActionAndSkipNonDictionaries() {
+        let fields = MPConvertJSFields.commerceEventFields(from: [
+            "ProductAction": [
+                "ProductActionType": 1,
+                "ProductList": [["Name": "a"], "skip me", NSNull(), ["Name": "b"]]
+            ]
+        ])
+
+        XCTAssertEqual(fields.products.count, 2)
+        XCTAssertEqual(fields.products.compactMap { $0["Name"] as? String }, ["a", "b"])
+    }
+
+    func testCommerceEventImpressionsNeedBothAListNameAndAnArray() {
+        let fields = MPConvertJSFields.commerceEventFields(from: ["ProductImpressions": [
+            ["ProductImpressionList": "kept", "ProductList": [["Name": "a"], "skip"]],
+            ["ProductImpressionList": 7, "ProductList": [["Name": "b"]]],
+            ["ProductImpressionList": "no list"],
+            "not a dictionary"
+        ]])
+
+        XCTAssertEqual(fields.impressions.count, 1)
+        XCTAssertEqual(fields.impressions.first?.listName, "kept")
+        XCTAssertEqual(fields.impressions.first?.products.count, 1)
+    }
+
+    func testCommerceEventProductActionIsExposedWheneverItIsADictionary() {
+        // Reading transaction attributes was gated on this, not on the kind.
+        let fields = MPConvertJSFields.commerceEventFields(from: [
+            "ProductImpressions": [],
+            "ProductAction": ["Affiliation": "store"]
+        ])
+
+        XCTAssertEqual(fields.kind, .impression)
+        XCTAssertEqual(fields.productAction?["Affiliation"] as? String, "store")
+    }
 }

--- a/mParticle-Apple-SDK/Utils/MPConvertJS.m
+++ b/mParticle-Apple-SDK/Utils/MPConvertJS.m
@@ -63,7 +63,7 @@
     }
 
     // checkoutStep is a scalar, so it is only written when the payload had one.
-    if (fields.checkoutStep) { commerceEvent.checkoutStep = fields.checkoutStep.intValue; }
+    if (fields.checkoutStep != nil) { commerceEvent.checkoutStep = fields.checkoutStep.intValue; }
 
     for (MPCommerceFlagJS *flag in fields.customFlags) {
         [commerceEvent addCustomFlags:flag.values withKey:flag.key];

--- a/mParticle-Apple-SDK/Utils/MPConvertJS.m
+++ b/mParticle-Apple-SDK/Utils/MPConvertJS.m
@@ -17,136 +17,71 @@
 }
 
 + (MPCommerceEvent *)commerceEvent:(NSDictionary *)json {
-    if (json[@"ProductAction"] != nil && ![json[@"ProductAction"] isKindOfClass:[NSDictionary class]]) {
-        MPILogError(@"Unexpected commerce event data received from webview");
-        return nil;
-    }
-    
-    NSDictionary *productAction = json[@"ProductAction"];
-    BOOL isProductAction = productAction[@"ProductActionType"] != nil;
-    BOOL isPromotion = json[@"PromotionAction"] != nil;
-    BOOL isImpression = json[@"ProductImpressions"] != nil;
-    BOOL isValid = isProductAction || isPromotion || isImpression;
+    MPCommerceEventFieldsJS *fields = [MPConvertJSFields commerceEventFieldsFromJSON:json];
 
-    if (!isValid) {
-        MPILogError(@"Invalid commerce event dictionary received from webview: %@", json);
-        return nil;
+    switch (fields.outcome) {
+        case MPCommerceEventOutcomeJSMalformedProductAction:
+            MPILogError(@"Unexpected commerce event data received from webview");
+            return nil;
+        case MPCommerceEventOutcomeJSInvalidPayload:
+            MPILogError(@"Invalid commerce event dictionary received from webview: %@", json);
+            return nil;
+        case MPCommerceEventOutcomeJSMalformedProductActionType:
+            MPILogError(@"Unexpected product action type received from webview");
+            return nil;
+        case MPCommerceEventOutcomeJSOk:
+            break;
     }
 
     MPCommerceEvent *commerceEvent = nil;
-    if (isProductAction) {
-        id productActionType = productAction[@"ProductActionType"];
-        if (!productActionType || ![productActionType isKindOfClass:[NSNumber class]]) {
-            MPILogError(@"Unexpected product action type received from webview");
-            return nil;
+    switch (fields.kind) {
+        case MPCommerceEventKindJSProductAction: {
+            MPCommerceEventAction action = [MPConvertJS_PRIVATE commerceEventAction:fields.productActionType];
+            commerceEvent = [[MPCommerceEvent alloc] initWithAction:action];
+            break;
         }
-        MPCommerceEventAction action = [MPConvertJS_PRIVATE commerceEventAction:productActionType];
-        commerceEvent = [[MPCommerceEvent alloc] initWithAction:action];
-    }
-    else if (isPromotion) {
-        MPPromotionContainer *promotionContainer = [MPConvertJS_PRIVATE promotionContainer:json];
-        commerceEvent = [[MPCommerceEvent alloc] initWithPromotionContainer:promotionContainer];
-    }
-    else {
-        commerceEvent = [[MPCommerceEvent alloc] initWithImpressionName:nil product:nil];
-    }
-    
-    id eventAttributes = json[@"EventAttributes"];
-    if ([eventAttributes isKindOfClass:[NSDictionary class]]) {
-        commerceEvent.customAttributes = (NSDictionary *)eventAttributes;
-    }
-    
-    id checkoutOptionsObj = json[@"CheckoutOptions"];
-    if ([checkoutOptionsObj isKindOfClass:[NSString class]]) {
-        commerceEvent.checkoutOptions = (NSString *)checkoutOptionsObj;
-    }
-
-    id productActionListNameObj = json[@"productActionListName"];
-    if ([productActionListNameObj isKindOfClass:[NSString class]]) {
-        commerceEvent.productListName = (NSString *)productActionListNameObj;
-    }
-
-    id productActionListSourceObj = json[@"productActionListSource"];
-    if ([productActionListSourceObj isKindOfClass:[NSString class]]) {
-        commerceEvent.productListSource = (NSString *)productActionListSourceObj;
-    }
-
-    id currencyCodeObj = json[@"CurrencyCode"];
-    if ([currencyCodeObj isKindOfClass:[NSString class]]) {
-        commerceEvent.currency = (NSString *)currencyCodeObj;
-    }
-    
-    if (productAction != nil) {
-        commerceEvent.transactionAttributes = [self transactionAttributes:productAction];
-    }
-    
-    id checkoutStepObj = json[@"CheckoutStep"];
-    if ([checkoutStepObj isKindOfClass:[NSNumber class]]) {
-        commerceEvent.checkoutStep = [(NSNumber *)checkoutStepObj intValue];
-    }
-    
-    id customFlagsObj = json[@"CustomFlags"];
-    if ([customFlagsObj isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *customFlags = (NSDictionary *)customFlagsObj;
-
-        for (id key in customFlags) {
-            id value = customFlags[key];
-
-            if ([value isKindOfClass:[NSArray class]]) {
-                BOOL allStrings = YES;
-                for (id item in (NSArray *)value) {
-                    if (![item isKindOfClass:[NSString class]]) { allStrings = NO; break; }
-                }
-                if (allStrings && [key isKindOfClass:[NSString class]]) {
-                    [commerceEvent addCustomFlags:(NSArray<NSString *> *)value withKey:(NSString *)key];
-                }
-
-            } else if ([value isKindOfClass:[NSString class]]) {
-                if ([key isKindOfClass:[NSString class]]) {
-                    [commerceEvent addCustomFlag:(NSString *)value withKey:(NSString *)key];
-                }
-            }
+        case MPCommerceEventKindJSPromotion: {
+            MPPromotionContainer *promotionContainer = [MPConvertJS_PRIVATE promotionContainer:json];
+            commerceEvent = [[MPCommerceEvent alloc] initWithPromotionContainer:promotionContainer];
+            break;
         }
+        case MPCommerceEventKindJSImpression:
+        case MPCommerceEventKindJSNone:
+            commerceEvent = [[MPCommerceEvent alloc] initWithImpressionName:nil product:nil];
+            break;
     }
 
-    id productListObj = productAction[@"ProductList"];
-    if ([productListObj isKindOfClass:[NSArray class]]) {
-        NSArray *jsonProducts = (NSArray *)productListObj;
+    if (fields.customAttributes) { commerceEvent.customAttributes = fields.customAttributes; }
+    if (fields.checkoutOptions) { commerceEvent.checkoutOptions = fields.checkoutOptions; }
+    if (fields.productListName) { commerceEvent.productListName = fields.productListName; }
+    if (fields.productListSource) { commerceEvent.productListSource = fields.productListSource; }
+    if (fields.currency) { commerceEvent.currency = fields.currency; }
 
-        NSMutableArray<MPProduct *> *products = [NSMutableArray arrayWithCapacity:jsonProducts.count];
-        for (id item in jsonProducts) {
-            if (![item isKindOfClass:[NSDictionary class]]) { continue; }
+    // Gated on ProductAction being a dictionary, as it was.
+    if (fields.productAction != nil) {
+        commerceEvent.transactionAttributes = [self transactionAttributes:fields.productAction];
+    }
 
-            MPProduct *p = [self product:(NSDictionary *)item];
-            if (p) { [products addObject:p]; }
+    // checkoutStep is a scalar, so it is only written when the payload had one.
+    if (fields.checkoutStep) { commerceEvent.checkoutStep = fields.checkoutStep.intValue; }
+
+    for (MPCommerceFlagJS *flag in fields.customFlags) {
+        [commerceEvent addCustomFlags:flag.values withKey:flag.key];
+    }
+
+    if (fields.products.count > 0) {
+        NSMutableArray<MPProduct *> *products = [NSMutableArray arrayWithCapacity:fields.products.count];
+        for (NSDictionary *productJson in fields.products) {
+            MPProduct *product = [self product:productJson];
+            if (product) { [products addObject:product]; }
         }
         [commerceEvent addProducts:products];
     }
 
-    id impressionsObj = json[@"ProductImpressions"];
-    if ([impressionsObj isKindOfClass:[NSArray class]]) {
-        NSArray *jsonImpressions = (NSArray *)impressionsObj;
-
-        for (id impressionItem in jsonImpressions) {
-            if (![impressionItem isKindOfClass:[NSDictionary class]]) { continue; }
-
-            NSDictionary *jsonImpression = (NSDictionary *)impressionItem;
-            id listNameObj = jsonImpression[@"ProductImpressionList"];
-            id impressionProductsObj = jsonImpression[@"ProductList"];
-
-            if ([listNameObj isKindOfClass:[NSString class]] &&
-                [impressionProductsObj isKindOfClass:[NSArray class]]) {
-
-                NSString *listName = (NSString *)listNameObj;
-                NSArray *impressionProducts = (NSArray *)impressionProductsObj;
-
-                for (id prodItem in impressionProducts) {
-                    if (![prodItem isKindOfClass:[NSDictionary class]]) { continue; }
-
-                    MPProduct *product = [MPConvertJS_PRIVATE product:(NSDictionary *)prodItem];
-                    [commerceEvent addImpression:product listName:listName];
-                }
-            }
+    for (MPCommerceImpressionJS *impression in fields.impressions) {
+        for (NSDictionary *productJson in impression.products) {
+            MPProduct *product = [MPConvertJS_PRIVATE product:productJson];
+            [commerceEvent addImpression:product listName:impression.listName];
         }
     }
 
@@ -154,32 +89,29 @@
 }
 
 + (MPPromotionContainer *)promotionContainer:(NSDictionary *)json {
-    NSDictionary *promotionActionDictionary = json[@"PromotionAction"];
-    if (!promotionActionDictionary || ![promotionActionDictionary isKindOfClass:[NSDictionary class]]) {
-        MPILogError(@"Unexpected promotion container action data received from webview");
-        return nil;
+    MPPromotionContainerFieldsJS *fields = [MPConvertJSFields promotionContainerFieldsFromJSON:json];
+
+    switch (fields.outcome) {
+        case MPPromotionContainerOutcomeJSMissingAction:
+            MPILogError(@"Unexpected promotion container action data received from webview");
+            return nil;
+        case MPPromotionContainerOutcomeJSMissingActionType:
+            MPILogError(@"Unexpected promotion container action type data received from webview");
+            return nil;
+        case MPPromotionContainerOutcomeJSMissingList:
+            MPILogError(@"Unexpected promotion container list data received from webview");
+            return nil;
+        case MPPromotionContainerOutcomeJSOk:
+            break;
     }
-    
-    NSNumber *promotionActionTypeNumber = promotionActionDictionary[@"PromotionActionType"];
-    if (promotionActionTypeNumber == nil || ![promotionActionTypeNumber isKindOfClass:[NSNumber class]]) {
-        MPILogError(@"Unexpected promotion container action type data received from webview");
-        return nil;
+
+    MPPromotionAction promotionAction = fields.isViewAction ? MPPromotionActionView : MPPromotionActionClick;
+    MPPromotionContainer *promotionContainer = [[MPPromotionContainer alloc] initWithAction:promotionAction
+                                                                                  promotion:nil];
+
+    for (NSDictionary *promotionJson in fields.promotions) {
+        [promotionContainer addPromotion:[MPConvertJS_PRIVATE promotion:promotionJson]];
     }
-    
-    int promotionActionInt = [promotionActionTypeNumber intValue];
-    MPPromotionAction promotionAction = promotionActionInt == 1 ? MPPromotionActionView : MPPromotionActionClick;
-    MPPromotionContainer *promotionContainer = [[MPPromotionContainer alloc] initWithAction:promotionAction promotion:nil];
-    
-    NSArray *jsonPromotions = promotionActionDictionary[@"PromotionList"];
-    if (!jsonPromotions || ![jsonPromotions isKindOfClass:[NSArray class]]) {
-        MPILogError(@"Unexpected promotion container list data received from webview");
-        return nil;
-    }
-    
-    [jsonPromotions enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        MPPromotion *promotion = [MPConvertJS_PRIVATE promotion:obj];
-        [promotionContainer addPromotion:promotion];
-    }];
 
     return promotionContainer;
 }


### PR DESCRIPTION
## Background

Final slice of `MPConvertJS`: commerce-event and promotion-container parsing. **307 → 159 SLOC across #929/#931/this PR.**

## What Has Changed

- Added `commerceEventFieldsFromJSON:` and `promotionContainerFieldsFromJSON:`. SDK-type construction and all six `MPILogError` call sites stay in the `.m`, each still logging at its original point.
- Preserved: product-action-and-promotion-action payloads resolve as product action (original `if/else if` order); an explicit JSON `null` still counts as "present" for the three presence checks; custom flags require an all-string array (partial matches dropped whole); transaction attributes read whenever `ProductAction` is a dictionary, independent of the event's action kind; `checkoutStep`/`position` are scalars, written only when present; unrecognized `PromotionActionType` defaults to `Click`.
- Hardened: a non-dictionary entry in `PromotionList` previously crashed; now skipped (matching existing `ProductList`/`ProductImpressions` behavior).

## Validation

- `abi-guard` PASSED
- `trunk check` clean
- ObjC 1012 / Swift 689 tests green; new Swift coverage 36/36
- tvOS: CI only

## Stack

Depends on #931.

## Checklist

- [x] Self-review completed
- [x] Tests added or updated
- [x] Tested locally
