### PR TITLE
refactor: move upload batch-assembly logic to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPUploadBuilderFields.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPUploadBuilderFields.swift
@@ -62,6 +62,100 @@ public final class MPUploadBuilderFields: NSObject {
         }
         return result
     }
+
+    /// The five upload-header fields `build:` seeds the dictionary with.
+    /// `sdkVersion` and `apiKey` are passed in rather than mirrored, since
+    /// `kMParticleSDKVersion` changes every release and mirroring it here
+    /// would give the release workflow a second, unsynced place to edit.
+    @objc(headerFieldsWithMessageId:timestampMs:sdkVersion:apiKey:)
+    public static func headerFields(
+        messageId: String,
+        timestampMs: NSNumber,
+        sdkVersion: String,
+        apiKey: String?
+    ) -> [String: Any] {
+        var fields: [String: Any] = [
+            kMPMessageTypeKeySwift: kMPMessageTypeRequestHeaderSwift,
+            kMPmParticleSDKVersionKeySwift: sdkVersion,
+            kMPMessageIdKeySwift: messageId,
+            kMPTimestampKeySwift: timestampMs
+        ]
+        if let apiKey {
+            fields[kMPApplicationKeySwift] = apiKey
+        }
+        return fields
+    }
+
+    /// `nil` when the device shouldn't be updated with an advertiser id —
+    /// mirrors `build:`'s `if (authStatus && advertiserId && authStatus.intValue
+    /// == MPATTAuthorizationStatusAuthorized)` guard. The caller computes
+    /// `isATTAuthorized` since the raw `MPATTAuthorizationStatus` enum can't
+    /// cross into this Foundation-only module.
+    @objc(deviceInfoDictionaryByAddingAdvertiserId:isATTAuthorized:to:)
+    public static func deviceInfoDictionary(
+        byAddingAdvertiserId advertiserId: String?,
+        isATTAuthorized: Bool,
+        to deviceInfoDictionary: [String: Any]?
+    ) -> [String: Any]? {
+        guard isATTAuthorized, let advertiserId, let deviceInfoDictionary else {
+            return nil
+        }
+
+        var updated = deviceInfoDictionary
+        updated[kMPDeviceAdvertiserIdKeySwift] = advertiserId
+        return updated
+    }
+
+    /// Pairs each forward record's data dictionary with its record id and
+    /// drops any record without one — mirrors `build:`'s
+    /// `if (forwardRecord.dataDictionary)` filter, which keeps `dataDictionaries`
+    /// and `recordIds` in step so the caller only deletes the records it
+    /// actually queued for upload.
+    @objc(forwardRecordBatchFromDataDictionaries:recordIds:)
+    public static func forwardRecordBatch(dataDictionaries: [Any], recordIds: [NSNumber]) -> MPForwardRecordBatch {
+        var filteredDictionaries: [NSDictionary] = []
+        var filteredIds: [NSNumber] = []
+
+        for (index, dataDictionary) in dataDictionaries.enumerated() where index < recordIds.count {
+            guard let dictionary = dataDictionary as? NSDictionary else {
+                continue
+            }
+            filteredDictionaries.append(dictionary)
+            filteredIds.append(recordIds[index])
+        }
+
+        return MPForwardRecordBatch(dataDictionaries: filteredDictionaries, recordIds: filteredIds)
+    }
+
+    /// Merges every integration attribute's dictionary representation into
+    /// one dictionary, later entries winning on a key collision — mirrors
+    /// `build:`'s repeated `addEntriesFromDictionary:` calls.
+    @objc(mergedIntegrationAttributesDictionaryFrom:)
+    public static func mergedIntegrationAttributesDictionary(from dictionaries: [NSDictionary]) -> [String: Any] {
+        var merged: [String: Any] = [:]
+        for dictionary in dictionaries {
+            for (key, value) in dictionary {
+                if let key = key as? String {
+                    merged[key] = value
+                }
+            }
+        }
+        return merged
+    }
+}
+
+/// The parallel (data dictionary, record id) arrays `build:` uploads and,
+/// on success, deletes from persistence.
+@objc(MPForwardRecordBatch)
+public final class MPForwardRecordBatch: NSObject {
+    @objc public let dataDictionaries: [NSDictionary]
+    @objc public let recordIds: [NSNumber]
+
+    init(dataDictionaries: [NSDictionary], recordIds: [NSNumber]) {
+        self.dataDictionaries = dataDictionaries
+        self.recordIds = recordIds
+        super.init()
+    }
 }
 
 /// `kMPOptOutKey` (`MPIConstants.m:53`). Mirrored because the Swift module
@@ -77,3 +171,17 @@ private let kMPDataPlanKeySwift = "dpln"
 private let kMPDataPlanIdKeySwift = "id"
 /// `kMPDataPlanVersionKey` (`MPIConstants.m:63`).
 private let kMPDataPlanVersionKeySwift = "v"
+/// `kMPMessageTypeKey` (`MPIConstants.m:7`).
+private let kMPMessageTypeKeySwift = "dt"
+/// `kMPMessageTypeRequestHeader` (`MPIConstants.m:8`).
+private let kMPMessageTypeRequestHeaderSwift = "h"
+/// `kMPmParticleSDKVersionKey` (`MPIConstants.m:15`).
+private let kMPmParticleSDKVersionKeySwift = "sdk"
+/// `kMPApplicationKey` (`MPIConstants.m:16`).
+private let kMPApplicationKeySwift = "a"
+/// `kMPMessageIdKey` (`MPIConstants.m:31`).
+private let kMPMessageIdKeySwift = "id"
+/// `kMPTimestampKey` (`MPIConstants.m:33`).
+private let kMPTimestampKeySwift = "ct"
+/// `kMPDeviceAdvertiserIdKey` (`MPIConstants.m:391`).
+private let kMPDeviceAdvertiserIdKeySwift = "aid"

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPUploadBuilderFieldsTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPUploadBuilderFieldsTests.swift
@@ -68,4 +68,116 @@ final class MPUploadBuilderFieldsTests: XCTestCase {
         let result = MPUploadBuilderFields.stringifiedUserAttributes(["color": "blue"])
         XCTAssertEqual(result["color"] as? String, "blue")
     }
+
+    // MARK: - headerFields
+
+    func testHeaderFieldsContainsEveryField() {
+        let fields = MPUploadBuilderFields.headerFields(
+            messageId: "uuid-1",
+            timestampMs: 123456,
+            sdkVersion: "9.4.1",
+            apiKey: "key-1"
+        )
+
+        XCTAssertEqual(fields["dt"] as? String, "h")
+        XCTAssertEqual(fields["sdk"] as? String, "9.4.1")
+        XCTAssertEqual(fields["id"] as? String, "uuid-1")
+        XCTAssertEqual(fields["ct"] as? NSNumber, 123456)
+        XCTAssertEqual(fields["a"] as? String, "key-1")
+    }
+
+    func testHeaderFieldsOmitsApplicationKeyWhenApiKeyIsNil() {
+        let fields = MPUploadBuilderFields.headerFields(
+            messageId: "uuid-1",
+            timestampMs: 123456,
+            sdkVersion: "9.4.1",
+            apiKey: nil
+        )
+
+        XCTAssertNil(fields["a"])
+    }
+
+    // MARK: - deviceInfoDictionary(byAddingAdvertiserId:isATTAuthorized:to:)
+
+    func testDeviceInfoDictionaryAddsAdvertiserIdWhenAuthorized() {
+        let result = MPUploadBuilderFields.deviceInfoDictionary(
+            byAddingAdvertiserId: "aid-1",
+            isATTAuthorized: true,
+            to: ["existing": "value"]
+        )
+
+        XCTAssertEqual(result?["aid"] as? String, "aid-1")
+        XCTAssertEqual(result?["existing"] as? String, "value")
+    }
+
+    func testDeviceInfoDictionaryIsNilWhenNotAuthorized() {
+        XCTAssertNil(MPUploadBuilderFields.deviceInfoDictionary(
+            byAddingAdvertiserId: "aid-1",
+            isATTAuthorized: false,
+            to: ["existing": "value"]
+        ))
+    }
+
+    func testDeviceInfoDictionaryIsNilWithoutAnAdvertiserId() {
+        XCTAssertNil(MPUploadBuilderFields.deviceInfoDictionary(
+            byAddingAdvertiserId: nil,
+            isATTAuthorized: true,
+            to: ["existing": "value"]
+        ))
+    }
+
+    func testDeviceInfoDictionaryIsNilWithoutAnExistingDictionary() {
+        XCTAssertNil(MPUploadBuilderFields.deviceInfoDictionary(
+            byAddingAdvertiserId: "aid-1",
+            isATTAuthorized: true,
+            to: nil
+        ))
+    }
+
+    // MARK: - forwardRecordBatch
+
+    func testForwardRecordBatchKeepsOnlyRecordsWithADataDictionary() {
+        let batch = MPUploadBuilderFields.forwardRecordBatch(
+            dataDictionaries: [["a": 1], NSNull(), ["b": 2]],
+            recordIds: [10, 20, 30]
+        )
+
+        XCTAssertEqual(batch.dataDictionaries as? [[String: Int]], [["a": 1], ["b": 2]])
+        XCTAssertEqual(batch.recordIds, [10, 30])
+    }
+
+    func testForwardRecordBatchIsEmptyWhenNoRecordHasData() {
+        let batch = MPUploadBuilderFields.forwardRecordBatch(
+            dataDictionaries: [NSNull(), NSNull()],
+            recordIds: [10, 20]
+        )
+
+        XCTAssertTrue(batch.dataDictionaries.isEmpty)
+        XCTAssertTrue(batch.recordIds.isEmpty)
+    }
+
+    // MARK: - mergedIntegrationAttributesDictionary
+
+    func testMergedIntegrationAttributesDictionaryMergesAllEntries() {
+        let merged = MPUploadBuilderFields.mergedIntegrationAttributesDictionary(from: [
+            ["a": "1"],
+            ["b": "2"]
+        ])
+
+        XCTAssertEqual(merged["a"] as? String, "1")
+        XCTAssertEqual(merged["b"] as? String, "2")
+    }
+
+    func testMergedIntegrationAttributesDictionaryLaterEntryWinsOnCollision() {
+        let merged = MPUploadBuilderFields.mergedIntegrationAttributesDictionary(from: [
+            ["a": "1"],
+            ["a": "2"]
+        ])
+
+        XCTAssertEqual(merged["a"] as? String, "2")
+    }
+
+    func testMergedIntegrationAttributesDictionaryIsEmptyForNoAttributes() {
+        XCTAssertTrue(MPUploadBuilderFields.mergedIntegrationAttributesDictionary(from: []).isEmpty)
+    }
 }

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
@@ -118,12 +118,12 @@
 #pragma mark Public instance methods
 - (void)build:(void (^)(MPUpload *upload))completionHandler {
     MPStateMachine_PRIVATE *stateMachine = [MParticle sharedInstance].stateMachine;
-    
-    _uploadDictionary[kMPMessageTypeKey] = kMPMessageTypeRequestHeader;
-    _uploadDictionary[kMPmParticleSDKVersionKey] = kMParticleSDKVersion;
-    _uploadDictionary[kMPMessageIdKey] = [[NSUUID UUID] UUIDString];
-    _uploadDictionary[kMPTimestampKey] = MPMilliseconds([[NSDate date] timeIntervalSince1970]);
-    _uploadDictionary[kMPApplicationKey] = stateMachine.apiKey;
+
+    NSDictionary *headerFields = [MPUploadBuilderFields headerFieldsWithMessageId:[[NSUUID UUID] UUIDString]
+                                                                       timestampMs:MPMilliseconds([[NSDate date] timeIntervalSince1970])
+                                                                        sdkVersion:kMParticleSDKVersion
+                                                                            apiKey:stateMachine.apiKey];
+    [_uploadDictionary addEntriesFromDictionary:headerFields];
     
     NSDictionary *appAndDeviceInfoDict = [[MParticle sharedInstance].persistenceController appAndDeviceInfoForSessionId:_sessionId];
     
@@ -164,11 +164,13 @@
     NSNumber *mpid = _uploadDictionary[kMPRemoteConfigMPIDKey];
     NSDictionary *userIdentities = [[[MParticle sharedInstance] identity] getUser:mpid].identities;
     NSString *advertiserId = userIdentities[@(MPIdentityIOSAdvertiserId)];
+    BOOL isATTAuthorized = authStatus != nil && authStatus.intValue == MPATTAuthorizationStatusAuthorized;
 
-    if (authStatus && advertiserId && authStatus.intValue == MPATTAuthorizationStatusAuthorized) {
-        NSMutableDictionary *deviceInfoDictCopy = [_uploadDictionary[kMPDeviceInformationKey] mutableCopy];
-        deviceInfoDictCopy[kMPDeviceAdvertiserIdKey] = advertiserId;
-        _uploadDictionary[kMPDeviceInformationKey] = [deviceInfoDictCopy copy];
+    NSDictionary *updatedDeviceInfo = [MPUploadBuilderFields deviceInfoDictionaryByAddingAdvertiserId:advertiserId
+                                                                                       isATTAuthorized:isATTAuthorized
+                                                                                                    to:_uploadDictionary[kMPDeviceInformationKey]];
+    if (updatedDeviceInfo) {
+        _uploadDictionary[kMPDeviceInformationKey] = updatedDeviceInfo;
     }
     
     MPConsumerInfo *consumerInfo = stateMachine.consumerInfo;
@@ -185,35 +187,30 @@
     
     MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
     NSArray<MPForwardRecord *> *forwardRecords = [persistence fetchForwardRecords];
-    NSMutableArray<NSNumber *> *forwardRecordsIds = nil;
-    
+
     if (forwardRecords) {
-        NSUInteger numberOfRecords = forwardRecords.count;
-        NSMutableArray *fsr = [[NSMutableArray alloc] initWithCapacity:numberOfRecords];
-        forwardRecordsIds = [[NSMutableArray alloc] initWithCapacity:numberOfRecords];
-        
+        NSMutableArray *dataDictionaries = [NSMutableArray arrayWithCapacity:forwardRecords.count];
+        NSMutableArray<NSNumber *> *recordIds = [NSMutableArray arrayWithCapacity:forwardRecords.count];
         for (MPForwardRecord *forwardRecord in forwardRecords) {
-            if (forwardRecord.dataDictionary) {
-                [fsr addObject:forwardRecord.dataDictionary];
-                [forwardRecordsIds addObject:@(forwardRecord.forwardRecordId)];
-            }
+            [dataDictionaries addObject:forwardRecord.dataDictionary ?: [NSNull null]];
+            [recordIds addObject:@(forwardRecord.forwardRecordId)];
         }
-        
-        if (fsr.count > 0) {
-            _uploadDictionary[kMPForwardStatsRecord] = fsr;
-            [persistence deleteForwardRecordsIds:forwardRecordsIds];
+
+        MPForwardRecordBatch *batch = [MPUploadBuilderFields forwardRecordBatchFromDataDictionaries:dataDictionaries recordIds:recordIds];
+        if (batch.dataDictionaries.count > 0) {
+            _uploadDictionary[kMPForwardStatsRecord] = batch.dataDictionaries;
+            [persistence deleteForwardRecordsIds:batch.recordIds];
         }
     }
-    
+
     NSArray<MPIntegrationAttributes *> *integrationAttributesArray = [persistence fetchIntegrationAttributes];
     if (integrationAttributesArray) {
-        NSMutableDictionary *integrationAttributesDictionary = [[NSMutableDictionary alloc] initWithCapacity:integrationAttributesArray.count];
-        
+        NSMutableArray<NSDictionary *> *integrationAttributesDictionaries = [NSMutableArray arrayWithCapacity:integrationAttributesArray.count];
         for (MPIntegrationAttributes *integrationAttributes in integrationAttributesArray) {
-            [integrationAttributesDictionary addEntriesFromDictionary:[integrationAttributes dictionaryRepresentation]];
+            [integrationAttributesDictionaries addObject:[integrationAttributes dictionaryRepresentation]];
         }
-        
-        _uploadDictionary[MPIntegrationAttributesKey] = integrationAttributesDictionary;
+
+        _uploadDictionary[MPIntegrationAttributesKey] = [MPUploadBuilderFields mergedIntegrationAttributesDictionaryFrom:integrationAttributesDictionaries];
     }
     
     MPConsentState *consentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:_uploadDictionary[kMPRemoteConfigMPIDKey]];


### PR DESCRIPTION
## Background

Picks up `build:`'s remaining extractable pieces after #937 descoped it: header fields, IDFA device-info update, forward-record filtering, and integration-attribute merging are pure Foundation logic once the SDK-object reads are marshaled to primitives first.

## What Has Changed

- Added four functions to `MPUploadBuilderFields.swift`: `headerFields`, `deviceInfoDictionary(byAddingAdvertiserId:isATTAuthorized:to:)`, `forwardRecordBatch(dataDictionaries:recordIds:)`, `mergedIntegrationAttributesDictionary(from:)`.
- `sdkVersion`/`apiKey` cross as parameters rather than mirrored constants, since `kMParticleSDKVersion` changes every release.
- Left in ObjC: the `onCreateBatch` customer-hook dispatch (public callback + defensive type check) and the `MPApplication`/`MPDevice` fallback construction (already Swift-native, no remaining logic to extract).

## Validation

- `abi-guard` PASSED, `trunk check` clean
- ObjC + Swift suites green (including `MPUploadBuilderTests`, the `build:` behavior contract)
- tvOS: iOS-only locally

## Stack

Depends on #937, which depends on #936, which depends on #932.

## Checklist

- [x] Self-review completed
- [x] Tests added or updated
- [x] Tested locally
