### PR TITLE
refactor: route network upload deletion through a Swift persistence seam

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Network/MPUploadPersisting.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Network/MPUploadPersisting.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// The single persistence operation the network upload paths depend on, expressed
+/// as a Foundation-only seam so upload handling can move to Swift without reaching
+/// the Objective-C persistence controller (which the Swift module cannot import).
+/// The concrete conformer forwards to `MParticle.sharedInstance.persistenceController`.
+@objc public protocol MPUploadPersisting: AnyObject {
+    @objc func deleteUpload(_ upload: MPUploadPRIVATE)
+}

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -82,10 +82,23 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 @end
 
+/// Thin boundary glue: the Swift upload seam forwarding to the retained ObjC
+/// persistence controller. Lets the upload paths depend on the Swift
+/// `MPUploadPersisting` protocol instead of the concrete controller.
+@interface MPUploadPersistenceAdapter : NSObject <MPUploadPersisting>
+@end
+
+@implementation MPUploadPersistenceAdapter
+- (void)deleteUpload:(MPUpload *)upload {
+    [[MParticle sharedInstance].persistenceController deleteUpload:upload];
+}
+@end
+
 @interface MPNetworkCommunication_PRIVATE()
 
 @property (nonatomic, strong) NSString *context;
 @property (nonatomic) BOOL identifying;
+@property (nonatomic, strong) id<MPUploadPersisting> persistence;
 
 @end
 
@@ -432,6 +445,13 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     }
 }
 
+- (id<MPUploadPersisting>)persistence {
+    if (!_persistence) {
+        _persistence = [[MPUploadPersistenceAdapter alloc] init];
+    }
+    return _persistence;
+}
+
 #pragma mark Private methods
 - (BOOL)isRetriableTransportError:(NSError *)error {
     return [MPTransportErrorDetector isRetriableTransportError:error];
@@ -716,7 +736,6 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 - (BOOL)performMessageUpload:(MPUpload *)upload {
     MParticle *mParticle = MParticle.sharedInstance;
     MPStateMachine_PRIVATE *stateMachine = mParticle.stateMachine;
-    MPPersistenceController_PRIVATE *persistenceController = mParticle.persistenceController;
 
     NSDate *minUploadDate = [stateMachine minUploadDateForUploadType:MPUploadTypeMessage];
     if ([minUploadDate compare:[NSDate date]] == NSOrderedDescending) {
@@ -773,7 +792,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     }
 
     if (zipUploadData == nil || zipUploadData.length <= 0) {
-        [persistenceController deleteUpload:upload];
+        [self.persistence deleteUpload:upload];
         return NO;
     }
     NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
@@ -794,7 +813,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         [MPTransportErrorDetector resetTransportErrorCounter];
     }
     if (isSuccessCode || isInvalidCode) {
-        [persistenceController deleteUpload:upload];
+        [self.persistence deleteUpload:upload];
         if (isSuccessCode && uploadString.length) {
             [mParticle logKitBatch:uploadString];
         }
@@ -854,7 +873,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     MPILogVerbose(@"Beginning alias request with upload ID: %@", upload.uuid);
 
     if (upload.uploadData == nil || upload.uploadData.length <= 0) {
-        [[MParticle sharedInstance].persistenceController deleteUpload:upload];
+        [self.persistence deleteUpload:upload];
         return NO;
     }
     NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
@@ -881,7 +900,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         [MPTransportErrorDetector resetTransportErrorCounter];
     }
     if (plan.isSuccessCode || plan.isInvalidCode) {
-        [[MParticle sharedInstance].persistenceController deleteUpload:upload];
+        [self.persistence deleteUpload:upload];
     }
 
     NSString *responseString = [[NSString alloc] initWithData:response.data encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
## Background

`MPNetworkCommunication` reaches the ObjC `MPPersistenceController` directly for the only persistence op the upload paths use: `deleteUpload:` (×4, in `performMessageUpload:`/`performAliasUpload:`). To let upload handling move to Swift next (Swift can't import the ObjC module), that dependency needs a Foundation-only seam. Continues the network migration (transport already Swift — #928/#933/#934; response mapping in #941).

## What Has Changed

- Add `MPUploadPersisting` — Foundation-only `@objc` protocol, `deleteUpload(_: MPUploadPRIVATE)` — the seam a future Swift upload handler will take instead of the concrete controller.
- Add a thin private `MPUploadPersistenceAdapter` in `MPNetworkCommunication.m` conforming to it and forwarding to `MParticle.sharedInstance.persistenceController` (boundary glue, in-file → no new ObjC file / pbxproj churn).
- Route the four upload-path `deleteUpload:` calls through an injectable `id<MPUploadPersisting> persistence` (lazily the adapter). **No behavior change** — NC now depends on the Swift protocol, not the concrete controller. Consumer-info ops stay direct (they pass the ObjC `MPConsumerInfo`, only in the ObjC `parseConfiguration`) — deferred.

## Testing

- `trunk check` + `abi-guard.sh check` — no public ABI diff (NC signatures unchanged)
- iOS build — 0 warnings
- ObjC `MPNetworkCommunicationTests` upload/delete tests (7) green — seam exercised end-to-end
- Full ObjC suite / tvOS / pod lib lint → CI

No Swift mirror test: this is a plumbing seam (no logic), so the ObjC upload tests are the contract.

**Stacked on #941.** Retarget to `workstation/swift-migration` once #941 merges. **Next:** an `@objc` MParticle-access context → move the upload effect handling (delete/logKitBatch/throttle) into a Swift upload handler consuming this seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)