### PR TITLE
fix: code-sign the nested Swift framework inside the release XCFramework

### DIFF
--- a/Scripts/make_artifacts.sh
+++ b/Scripts/make_artifacts.sh
@@ -10,8 +10,25 @@ function build_xcframework_artifacts() {
 	# Build modern xcframeworks which work on M1 macs and include both platforms in one package
 	./Scripts/xcframework.sh mParticle-Apple-SDK mParticle_Apple_SDK
 
+	IDENTITY="Apple Distribution: mParticle, inc (DLD43Y3TRP)"
+
+	# mParticle_Apple_SDK.framework embeds mParticle_Apple_SDK_Swift.framework as a nested
+	# framework in each platform slice. Signing the xcframework wrapper only seals its file
+	# manifest - it does not add a code signature to the Mach-O binaries inside. The outer
+	# framework gets re-signed by a consuming app's own build when it is embedded, but a
+	# nested framework is just copied verbatim and is never re-signed by the consumer, so it
+	# must already carry a valid signature here. Sign inside-out: nested framework first,
+	# then the framework that embeds it, for every platform slice.
+	for framework in mParticle_Apple_SDK.xcframework/*/mParticle_Apple_SDK.framework; do
+		nested="${framework}/Frameworks/mParticle_Apple_SDK_Swift.framework"
+		if [[ -d ${nested} ]]; then
+			codesign --timestamp -s "${IDENTITY}" "${nested}"
+		fi
+		codesign --timestamp -s "${IDENTITY}" "${framework}"
+	done
+
 	# Sign the xcframework
-	codesign --timestamp -s "Apple Distribution: mParticle, inc (DLD43Y3TRP)" mParticle_Apple_SDK.xcframework
+	codesign --timestamp -s "${IDENTITY}" mParticle_Apple_SDK.xcframework
 
 	# Zip the xcframework
 	zip -r mParticle_Apple_SDK.xcframework.zip mParticle_Apple_SDK.xcframework

--- a/Scripts/make_artifacts.sh
+++ b/Scripts/make_artifacts.sh
@@ -18,17 +18,19 @@ function build_xcframework_artifacts() {
 	# framework gets re-signed by a consuming app's own build when it is embedded, but a
 	# nested framework is just copied verbatim and is never re-signed by the consumer, so it
 	# must already carry a valid signature here. Sign inside-out: nested framework first,
-	# then the framework that embeds it, for every platform slice.
+	# then the framework that embeds it, for every platform slice. Simulator slices already
+	# carry an automatic ad-hoc signature from the archive step (device slices do not), so
+	# --force is required or codesign refuses to replace it.
 	for framework in mParticle_Apple_SDK.xcframework/*/mParticle_Apple_SDK.framework; do
 		nested="${framework}/Frameworks/mParticle_Apple_SDK_Swift.framework"
 		if [[ -d ${nested} ]]; then
-			codesign --timestamp -s "${IDENTITY}" "${nested}"
+			codesign --force --timestamp -s "${IDENTITY}" "${nested}"
 		fi
-		codesign --timestamp -s "${IDENTITY}" "${framework}"
+		codesign --force --timestamp -s "${IDENTITY}" "${framework}"
 	done
 
 	# Sign the xcframework
-	codesign --timestamp -s "${IDENTITY}" mParticle_Apple_SDK.xcframework
+	codesign --force --timestamp -s "${IDENTITY}" mParticle_Apple_SDK.xcframework
 
 	# Zip the xcframework
 	zip -r mParticle_Apple_SDK.xcframework.zip mParticle_Apple_SDK.xcframework


### PR DESCRIPTION
## Background
- Customer-reported crash: `mParticle_Apple_SDK.xcframework`, consumed as an SPM binary target, fails to launch on a physical device in Debug with `dyld: ... missing code signature` for the nested `mParticle_Apple_SDK_Swift.framework`. Simulator and archive/export builds are unaffected.
- `mParticle_Apple_SDK.framework` embeds `mParticle_Apple_SDK_Swift.framework` in its own `Frameworks/` folder. `Scripts/make_artifacts.sh` only signed the top-level `.xcframework` wrapper, which seals a resource manifest but puts no real code signature on any Mach-O inside. The outer framework is fine because a consuming app's build re-signs anything it embeds directly, but the nested framework is copied verbatim and never re-signed by the consumer — confirmed locally that it reaches the app fully unsigned. Not a 9.3.4 regression: the nested-framework structure predates it and nothing in the signing pipeline has changed since.
- Device slices come off `xcodebuild archive` fully unsigned; Simulator slices already carry an automatic ad-hoc signature Xcode applies by default. That meant a plain `codesign -s` silently failed on Simulator slices ("is already signed"), so `--force` is required too.

## What Has Changed
- `Scripts/make_artifacts.sh`: sign inside-out — for every platform slice, code-sign the nested Swift framework first, then the framework that embeds it, before sealing the xcframework wrapper as before. `--force` on every call so it also replaces Simulator's pre-existing ad-hoc signature.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- Verified locally via real `xcodebuild archive` + `-create-xcframework` + `codesign` builds across both device and Simulator slices: nested framework is "not signed at all" pre-fix, has a real `CodeDirectory` post-fix on every slice (including Simulator, where `--force` correctly replaces the pre-existing ad-hoc signature instead of silently no-op'ing), and `codesign --verify --deep --strict` passes on the resulting xcframework.
- This environment has no access to the real Distribution certificate, so verification used an ad-hoc identity to prove the mechanism. Recommend a CI release build with the real cert followed by a physical-device Debug smoke test before shipping.
- No automated test added — this is a release-signing shell script with no existing test harness; verification is the local codesign repro described above plus the recommended CI/device check.