### PR TITLE
docs: correct 8.27.0 release month in migration guide

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -135,7 +135,7 @@ Support for migrating from SDK versions prior to **SDK 8.27.0** (internal databa
 
 This change only affects users who:
 
-1. Are upgrading directly from mParticle SDK versions **before 8.27.0** (released August 2024)
+1. Are upgrading directly from mParticle SDK versions **before 8.27.0** (released September 2024)
 2. Have pending events that have not yet been uploaded to mParticle
 
 ---


### PR DESCRIPTION
## Background

- The 9.x migration guide dated SDK 8.27.0 to August 2024. It shipped
  2024-09-04; August 2024 was 8.26.0 (2024-08-16).

## What Has Changed

- Corrected the release month in the parenthetical under "Removed Legacy
  Database Migration Support". The version number 8.27.0 is unchanged.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.
