### PR TITLE
chore: classify MPIConstants.m as retained Objective-C

### DIFF
--- a/Tools/swift-migration-retained-objc.txt
+++ b/Tools/swift-migration-retained-objc.txt
@@ -77,6 +77,15 @@ mParticle-Apple-SDK/Utils/MPUploadSettings.m
 
 mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m
 
+# 360 C global definitions (`NSString *const`, `const NSTimeInterval`,
+# `const NSInteger`) declared extern in the internal MPIConstants.h and referenced by
+# bare identifier from 51 Objective-C files. Swift cannot emit C globals, so these
+# symbols cannot move; the Swift module mirrors the values it needs in
+# Sources/MessageKeys.swift instead, which is the pattern every conversion so far has
+# used. Also pinned by release tooling: .github/workflows/release-draft.yml:87 rewrites
+# kMParticleSDKVersion in this exact file.
+mParticle-Apple-SDK/MPIConstants.m
+
 # The ObjC<->Swift kit execution bridge. It has no ObjC callers and no public
 # header; the Swift MPKitContainer_PRIVATE reaches it only by
 # NSClassFromString("MPKitContainerExecutionAdapter"). It owns the Swift kit


### PR DESCRIPTION
Independent of #952 — touches only `Tools/`, so it can merge in any order.

## What and why

`Tools/swift-migration-retained-objc.txt` is the boundary between the progress report's two goal
rows. `PR-GATE.md` defines the short-term row as *"100% is reachable and marks the end of this
project."* `mParticle-Apple-SDK/MPIConstants.m` was being counted against that row, and it can never
leave it.

This adds one entry, under classification 4 (internal boundary glue).

## Audit

Per `Tools/README.md` → "Retained Objective-C manifest".

**The declaration.** 360 C global definitions — `NSString *const`, `const NSTimeInterval`,
`const NSInteger` — defined in `MPIConstants.m` and declared `extern` in `MPIConstants.h`.

**Why it cannot move.** Swift cannot emit C globals. Objective-C references these by bare
identifier (`kMPMessageTypeKey`, `DEFAULT_UPLOAD_INTERVAL`, …) from **51** files that
`#import "MPIConstants.h"`. The Swift module already handles this the way every conversion in this
project has: it mirrors the values it needs privately, in `Sources/MessageKeys.swift` (37 entries)
and in per-conversion enums like the `AudienceKeys` added in #941. So the ObjC definitions are the
boundary, not a wrapper waiting to be deleted.

**A second, independent pin.** `.github/workflows/release-draft.yml:87` rewrites
`kMParticleSDKVersion` in this exact file. `AGENTS.md` warns that introducing a new place the
version lives means teaching that workflow about it, or it goes stale silently.

**Compatibility audit — all clear:**

| Surface | Result |
| --- | --- |
| `Tools/abi-baseline.txt` | **no entries** — `MPIConstants.h` is not under `Include/`, so the guard never saw it |
| Exported header | no — not in `Include/`, no `ATTRIBUTES = (Public, )` |
| Kits (`Kits/`) | **0** files reference `MPIConstants` |
| Wrapper-SDK integration points | none |
| Archiving / `NSClassFromString` / KVC | not applicable — no classes, only constants |
| `CONVERSION-RECIPE.md` compatibility inventory | not listed, so this classification does not contradict it |

Note the manifest's evidence bar asks you to "point at its `Tools/abi-baseline.txt` entry". There
isn't one, and that is the correct result here rather than a gap in the audit — the same is true of
the existing classification-4 entry `MPUserDefaultsConnector.m`.

## Measured effect

Core SDK, before → after:

| | Before | After |
| --- | ---: | ---: |
| Short term — in scope | 55.68% | **57.09%** |
| Objective-C remaining (in scope) | 7,105 | **6,711** |
| Retained by design | 5,803 | **6,197** |
| Long term — all Objective-C | 40.88% | 40.88% |

394 SLOC moves from the in-scope denominator into the retained column. The long-term row is
unchanged, which is correct — it keeps the full denominator.

**The PR comment will show `➖ 0.00 pp`, and that is by design, not a bug.** The report measures both
revisions with the manifest from the head revision, precisely so a manifest edit cannot move the
reported change. Verified locally with the CI-pinned cloc 2.10 (SHA256 checked against
`swift-migration-progress.yml`): `selftest` passes and the new entry validates.

## Deliberately not included

**`MPPersistenceController.m`** — a teammate is actively working on this file, so it is untouched
here. Worth recording anyway that its classification is contested: the wave-A plan calls it "a raw
sqlite boundary [that] stays ObjC by rule", while the committed
`docs/swift-migration/CONVERSION-RECIPE.md:91` lists `MPPersistenceController_PRIVATE` under
**"Internal, wrapper-removal candidates"** — classification 2, which must stay *out* of this
manifest. At 1,787 LOC it is 27% of the remaining in-scope Core SDK figure, so which of those two is
right materially changes what the short-term goal means. That is a call for whoever owns the file.

**`MPNotificationController.m`** — and this is me correcting myself. On #952 I recommended adding it
to this manifest. That was wrong: `CONVERSION-RECIPE.md:91` also lists
`MPNotificationController_PRIVATE` as a wrapper-removal candidate. It is genuinely blocked today —
`-setDeviceToken:` reaches `MParticle.backendController.networkCommunication` — but "blocked" is not
"retained", and the fix is a network seam, not a reclassification. Please disregard that suggestion.

## Note on the push

The local pre-push hook reports 11 unformatted Swift test files. All 11 are pre-existing on
`workstation/swift-migration`, arrived with the network wave (#944 and siblings), and none is in
this diff — this PR changes exactly one `.txt` file. I did not run `trunk fmt` over them, because
two (`MPMessageBuilderFieldsTests.swift`, `MPUploadBuilderFieldsTests.swift`) are squarely in the
active wave-A stack's territory and formatting them here would create conflicts. They want their own
small chore PR, coordinated with that stack:

```
Test/Kits/MPDataPlanFilterPolicyTests.swift        Test/Utils/MPConvertJSFieldsTests.swift
Test/Kits/MPKitConfigurationParserTests.swift      Test/Utils/MPMessageBuilderFieldsTests.swift
Test/Kits/MPProjectionFieldParserTests.swift       Test/Utils/MPSessionTimingPolicyTests.swift
Test/Network/MPEndpointHostResolverTests.swift     Test/Utils/MPUploadBuilderFieldsTests.swift
Test/Network/MPUploadResponseHandlerTests.swift    Test/Utils/MPUploadSettingsTests.swift
Test/Notifications/SceneDelegateLogicTests.swift
```

## Validation

| Gate | Result |
| --- | --- |
| `bash Tools/abi-guard.sh check` | PASSED, baseline untouched |
| `Tools/swift-migration-progress.sh selftest` | SELFTEST PASS |
| Manifest entry validation (exists, `.m`, inside a counted bucket) | passes |
| Builds / test suites | not re-run — no source file changed |

## Checklist

- [ ] Classification reviewed and agreed
- [ ] Audit evidence recorded above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
