### PR TITLE
refactor: move backend upload-trigger and clean-up decisions to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPBackendMessageInfo.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPBackendMessageInfo.swift
@@ -43,4 +43,48 @@ import Foundation
         }
         return MPPushRegistrationDecision(status: "false", logToken: oldDeviceToken)
     }
+
+    /// How many bytes of the base64 crash report survive once the assembled message is trimmed to
+    /// `maxBytes`. Returns `nil` when the message already fits and no truncation is needed.
+    ///
+    /// The result can be negative when the rest of the message alone exceeds the limit; that is
+    /// the original arithmetic, and `truncateMessageDataProperty:toLength:` ignores a negative
+    /// length, so the report is left intact rather than emptied.
+    @objc(crashReportBytesToRetainForMessageLength:maxBytes:base64ReportLength:)
+    public static func crashReportBytesToRetain(
+        messageLength: Int,
+        maxBytes: Int,
+        base64ReportLength: Int
+    ) -> NSNumber? {
+        guard messageLength > maxBytes else { return nil }
+        return NSNumber(value: base64ReportLength - (messageLength - maxBytes))
+    }
+
+    /// Whether saving this message should trigger an upload.
+    ///
+    /// A message uploads when its type is one of the configured trigger message types, or — only
+    /// when trigger event types are configured at all — when its hashed `name`+`type` pair is one
+    /// of them. A message without both an event name and an event type can never match the second
+    /// rule.
+    @objc(shouldUploadMessageOfType:messageDictionary:triggerMessageTypes:triggerEventTypes:hasher:)
+    public static func shouldUploadMessage(
+        ofType messageType: String?,
+        messageDictionary: [AnyHashable: Any]?,
+        triggerMessageTypes: [AnyHashable]?,
+        triggerEventTypes: [AnyHashable]?,
+        hasher: MPIHasher
+    ) -> Bool {
+        if let messageType, triggerMessageTypes?.contains(messageType) == true {
+            return true
+        }
+
+        guard let triggerEventTypes,
+              let eventName = messageDictionary?[MessageKeys.kMPEventNameKey] as? String,
+              let eventType = messageDictionary?[MessageKeys.kMPEventTypeKey] as? String
+        else {
+            return false
+        }
+
+        return triggerEventTypes.contains(hasher.hashTriggerEventName(eventName, eventType: eventType))
+    }
 }

--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPSessionTimingPolicy.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPSessionTimingPolicy.swift
@@ -40,4 +40,35 @@ import Foundation
         }
         return now - lastEventInBackground >= sessionTimeout
     }
+
+    /// When the periodic database clean-up is due, what cutoff to prune to and when to run next.
+    ///
+    /// `nil` means the clean-up is not due yet, so the caller prunes nothing and leaves its stored
+    /// next-run time alone. `maxAgeSeconds` falls back to `defaultMaxAge` when the caller has not
+    /// configured a retention window.
+    @objc(cleanUpPlanWithNow:nextCleanUpTime:maxAgeSeconds:defaultMaxAge:interval:)
+    public static func cleanUpPlan(
+        now: TimeInterval,
+        nextCleanUpTime: TimeInterval,
+        maxAgeSeconds: NSNumber?,
+        defaultMaxAge: TimeInterval,
+        interval: TimeInterval
+    ) -> MPCleanUpPlan? {
+        guard nextCleanUpTime < now else { return nil }
+        let maxAge = maxAgeSeconds?.doubleValue ?? defaultMaxAge
+        return MPCleanUpPlan(deleteRecordsOlderThan: now - maxAge, nextCleanUpTime: now + interval)
+    }
+}
+
+/// The outcome of a due database clean-up: what to prune and when to run again.
+@objc(MPCleanUpPlan)
+public final class MPCleanUpPlan: NSObject {
+    @objc public let deleteRecordsOlderThan: TimeInterval
+    @objc public let nextCleanUpTime: TimeInterval
+
+    init(deleteRecordsOlderThan: TimeInterval, nextCleanUpTime: TimeInterval) {
+        self.deleteRecordsOlderThan = deleteRecordsOlderThan
+        self.nextCleanUpTime = nextCleanUpTime
+        super.init()
+    }
 }

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPBackendMessageInfoTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPBackendMessageInfoTests.swift
@@ -55,3 +55,119 @@ final class MPBackendMessageInfoTests: XCTestCase {
         XCTAssertEqual(decision?.logToken, tokenA)
     }
 }
+
+extension MPBackendMessageInfoTests {
+    // MARK: - crashReportBytesToRetain
+
+    func testNoTruncationWhenTheMessageAlreadyFits() {
+        XCTAssertNil(MPBackendMessageInfo.crashReportBytesToRetain(
+            messageLength: 100,
+            maxBytes: 100,
+            base64ReportLength: 40
+        ))
+        XCTAssertNil(MPBackendMessageInfo.crashReportBytesToRetain(
+            messageLength: 99,
+            maxBytes: 100,
+            base64ReportLength: 40
+        ))
+    }
+
+    func testOverflowIsSubtractedFromTheReportLength() {
+        // 120 byte message, 100 byte limit -> 20 bytes must go, all from the 40 byte report.
+        XCTAssertEqual(
+            MPBackendMessageInfo.crashReportBytesToRetain(messageLength: 120, maxBytes: 100, base64ReportLength: 40),
+            20
+        )
+    }
+
+    func testRetainedLengthGoesNegativeWhenTheRestOfTheMessageAlreadyOverflows() {
+        // The caller passes this straight to `truncateMessageDataProperty:toLength:`, which ignores
+        // a negative length and leaves the report intact — the original arithmetic did the same.
+        XCTAssertEqual(
+            MPBackendMessageInfo.crashReportBytesToRetain(messageLength: 200, maxBytes: 100, base64ReportLength: 40),
+            -60
+        )
+    }
+
+    // MARK: - shouldUploadMessage
+
+    private var hasher: MPIHasher { MPIHasher(logger: MPLog(logLevel: .none)) }
+
+    func testTriggerMessageTypeMatchUploads() {
+        XCTAssertTrue(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "e",
+            messageDictionary: nil,
+            triggerMessageTypes: ["x", "e"],
+            triggerEventTypes: nil,
+            hasher: hasher
+        ))
+    }
+
+    func testNoTriggersConfiguredNeverUploads() {
+        XCTAssertFalse(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "e",
+            messageDictionary: ["n": "purchase", "et": "1"],
+            triggerMessageTypes: nil,
+            triggerEventTypes: nil,
+            hasher: hasher
+        ))
+    }
+
+    func testUnknownMessageTypeDoesNotMatch() {
+        XCTAssertFalse(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "v",
+            messageDictionary: nil,
+            triggerMessageTypes: ["e"],
+            triggerEventTypes: nil,
+            hasher: hasher
+        ))
+        XCTAssertFalse(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: nil,
+            messageDictionary: nil,
+            triggerMessageTypes: ["e"],
+            triggerEventTypes: nil,
+            hasher: hasher
+        ))
+    }
+
+    func testHashedTriggerEventMatchUploads() {
+        let hashed = hasher.hashTriggerEventName("purchase", eventType: "1")
+
+        XCTAssertTrue(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "e",
+            messageDictionary: ["n": "purchase", "et": "1"],
+            triggerMessageTypes: ["x"],
+            triggerEventTypes: [hashed],
+            hasher: hasher
+        ))
+    }
+
+    func testHashedTriggerEventMissDoesNotUpload() {
+        XCTAssertFalse(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "e",
+            messageDictionary: ["n": "purchase", "et": "1"],
+            triggerMessageTypes: ["x"],
+            triggerEventTypes: ["some-other-hash"],
+            hasher: hasher
+        ))
+    }
+
+    func testAMessageMissingEventNameOrTypeCannotMatchAnEventTrigger() {
+        let hashed = hasher.hashTriggerEventName("purchase", eventType: "1")
+
+        XCTAssertFalse(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "e",
+            messageDictionary: ["n": "purchase"],
+            triggerMessageTypes: nil,
+            triggerEventTypes: [hashed],
+            hasher: hasher
+        ))
+        XCTAssertFalse(MPBackendMessageInfo.shouldUploadMessage(
+            ofType: "e",
+            messageDictionary: nil,
+            triggerMessageTypes: nil,
+            triggerEventTypes: [hashed],
+            hasher: hasher
+        ))
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPSessionTimingPolicyTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPSessionTimingPolicyTests.swift
@@ -58,3 +58,65 @@ final class MPSessionTimingPolicyTests: XCTestCase {
         XCTAssertFalse(MPSessionTimingPolicy.shouldEndSession(now: 1059.0, lastEventInBackground: 1000.0, sessionTimeout: 60.0))
     }
 }
+
+extension MPSessionTimingPolicyTests {
+    // MARK: - cleanUpPlan
+
+    private static let ninetyDays: TimeInterval = 90 * 24 * 60 * 60
+    private static let twentyFourHours: TimeInterval = 24 * 60 * 60
+
+    func testNoPlanBeforeTheNextCleanUpTime() {
+        XCTAssertNil(MPSessionTimingPolicy.cleanUpPlan(
+            now: 1000,
+            nextCleanUpTime: 1000,
+            maxAgeSeconds: nil,
+            defaultMaxAge: Self.ninetyDays,
+            interval: Self.twentyFourHours
+        ))
+        XCTAssertNil(MPSessionTimingPolicy.cleanUpPlan(
+            now: 1000,
+            nextCleanUpTime: 2000,
+            maxAgeSeconds: nil,
+            defaultMaxAge: Self.ninetyDays,
+            interval: Self.twentyFourHours
+        ))
+    }
+
+    func testDuePlanUsesTheDefaultRetentionWhenUnconfigured() throws {
+        let plan = try XCTUnwrap(MPSessionTimingPolicy.cleanUpPlan(
+            now: 1_000_000,
+            nextCleanUpTime: 0,
+            maxAgeSeconds: nil,
+            defaultMaxAge: Self.ninetyDays,
+            interval: Self.twentyFourHours
+        ))
+
+        XCTAssertEqual(plan.deleteRecordsOlderThan, 1_000_000 - Self.ninetyDays)
+        XCTAssertEqual(plan.nextCleanUpTime, 1_000_000 + Self.twentyFourHours)
+    }
+
+    func testConfiguredRetentionOverridesTheDefault() throws {
+        let plan = try XCTUnwrap(MPSessionTimingPolicy.cleanUpPlan(
+            now: 1_000_000,
+            nextCleanUpTime: 0,
+            maxAgeSeconds: NSNumber(value: 60),
+            defaultMaxAge: Self.ninetyDays,
+            interval: Self.twentyFourHours
+        ))
+
+        XCTAssertEqual(plan.deleteRecordsOlderThan, 999_940)
+        XCTAssertEqual(plan.nextCleanUpTime, 1_000_000 + Self.twentyFourHours)
+    }
+
+    func testAZeroRetentionPrunesEverythingUpToNow() throws {
+        let plan = try XCTUnwrap(MPSessionTimingPolicy.cleanUpPlan(
+            now: 500,
+            nextCleanUpTime: 0,
+            maxAgeSeconds: NSNumber(value: 0),
+            defaultMaxAge: Self.ninetyDays,
+            interval: Self.twentyFourHours
+        ))
+
+        XCTAssertEqual(plan.deleteRecordsOlderThan, 500)
+    }
+}

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1087,11 +1087,11 @@ static BOOL skipNextUpload = NO;
     MPMessageBuilder *messageBuilder = [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeCrashReport session:crashSession messageInfo:messageInfo context:self.messageBuilderContext];
     MPMessage *crashMessage = [messageBuilder build];
     
-    NSInteger maxBytes = [MPPersistenceController_PRIVATE maxBytesPerEvent:crashMessage.messageType];
-    if(crashMessage.messageData.length > maxBytes) {
-        NSInteger bytesToTruncate = crashMessage.messageData.length - maxBytes;
-        NSInteger bytesToRetain = plCrashReportBase64.length - bytesToTruncate;
-        [crashMessage truncateMessageDataProperty:kMPPLCrashReport toLength:bytesToRetain];
+    NSNumber *bytesToRetain = [MPBackendMessageInfo crashReportBytesToRetainForMessageLength:crashMessage.messageData.length
+                                                                                    maxBytes:[MPPersistenceController_PRIVATE maxBytesPerEvent:crashMessage.messageType]
+                                                                          base64ReportLength:plCrashReportBase64.length];
+    if (bytesToRetain != nil) {
+        [crashMessage truncateMessageDataProperty:kMPPLCrashReport toLength:bytesToRetain.integerValue];
     }
     [persistence saveMessage:crashMessage];
     
@@ -1374,24 +1374,13 @@ static BOOL skipNextUpload = NO;
     }
     
     MPStateMachine_PRIVATE *stateMachine = [MParticle sharedInstance].stateMachine;
-    BOOL shouldUpload = [stateMachine.triggerMessageTypes containsObject:message.messageType];
-    
-    if (!shouldUpload && stateMachine.triggerEventTypes) {
-        NSError *error = nil;
-        NSDictionary *messageDictionary = [message dictionaryRepresentation];
-        NSString *eventName = messageDictionary[kMPEventNameKey];
-        NSString *eventType = messageDictionary[kMPEventTypeKey];
-        
-        if (!error && eventName && eventType) {
-            MParticle* mparticle = MParticle.sharedInstance;
-            MPLog* logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue:mparticle.logLevel]];
-            logger.customLogger = mparticle.customLogger;
-            MPIHasher* hasher = [[MPIHasher alloc] initWithLogger:logger];
-            NSString *hashedEvent = [hasher hashTriggerEventName:eventName eventType:eventType];
-            shouldUpload = [stateMachine.triggerEventTypes containsObject:hashedEvent];
-        }
-    }
-    
+    MPIHasher *hasher = [[MPIHasher alloc] initWithLogger:[[MParticle sharedInstance] getLogger]];
+    BOOL shouldUpload = [MPBackendMessageInfo shouldUploadMessageOfType:message.messageType
+                                                      messageDictionary:[message dictionaryRepresentation]
+                                                    triggerMessageTypes:stateMachine.triggerMessageTypes
+                                                      triggerEventTypes:stateMachine.triggerEventTypes
+                                                                 hasher:hasher];
+
     if (shouldUpload) {
         dispatch_async([MParticle messageQueue], ^{
             [self waitForKitsAndUploadWithCompletionHandler:nil];
@@ -1810,11 +1799,14 @@ static BOOL skipNextUpload = NO;
 
 - (void)cleanUp:(NSTimeInterval)currentTime {
     MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
-    if (nextCleanUpTime < currentTime) {
-        NSNumber *persistanceMaxAgeSeconds = [MParticle sharedInstance].persistenceMaxAgeSeconds;
-        NSTimeInterval maxAgeSeconds = persistanceMaxAgeSeconds == nil ? NINETY_DAYS : persistanceMaxAgeSeconds.doubleValue;
-        [persistence deleteRecordsOlderThan:(currentTime - maxAgeSeconds)];
-        nextCleanUpTime = currentTime + TWENTY_FOUR_HOURS;
+    MPCleanUpPlan *plan = [MPSessionTimingPolicy cleanUpPlanWithNow:currentTime
+                                                   nextCleanUpTime:nextCleanUpTime
+                                                     maxAgeSeconds:[MParticle sharedInstance].persistenceMaxAgeSeconds
+                                                     defaultMaxAge:NINETY_DAYS
+                                                          interval:TWENTY_FOUR_HOURS];
+    if (plan) {
+        [persistence deleteRecordsOlderThan:plan.deleteRecordsOlderThan];
+        nextCleanUpTime = plan.nextCleanUpTime;
     }
     [persistence purgeMemory];
     MPIdentityCaching *identityCaching = [[MPIdentityCaching alloc] initWithUserDefaults:MPUserDefaultsConnector.userDefaults


### PR DESCRIPTION
Stacked on #953 (`refactor/swift-upload-batch-preparation`).

Three pure decisions in `MPBackendController` move into the Swift helpers that already own their neighbours. No new files — each slice joins the helper it belongs with.

## What moved

**`MPBackendMessageInfo.shouldUploadMessageOfType:...`** — the `saveMessage:updateSession:` upload trigger (`.m:1376-1393`): trigger message-type membership, and, only when trigger event types are configured, the hashed `name`+`type` lookup. `MPIHasher` is already Swift, so the caller passes one in and no new singleton read crosses the boundary.

Two incidental cleanups: the `NSError *error` the original declared was never assigned, so the `!error` guard is gone; and the caller now reuses `MParticle.getLogger` instead of constructing a second `MPLog`.

**`MPBackendMessageInfo.crashReportBytesToRetainForMessageLength:...`** — the crash-report truncation arithmetic in `logCrash:`. It joins `base64CrashReport:maxBytes:`, which already handles the other half of the same concern. Returns nil when the message already fits. The retained length can still go negative when the rest of the message alone overflows; `truncateMessageDataProperty:toLength:` ignores a negative length so the report is left intact — the original arithmetic behaved the same way, and there is a test pinning it.

**`MPSessionTimingPolicy.cleanUpPlanWithNow:...`** — `cleanUp:`'s due-time check, the `NINETY_DAYS` retention fallback and the next-run time. Both constants stay in `MPIConstants` and are passed in.

## Three planned slices deliberately left in Objective-C

- **`eventWithName:`** filters a set of `MPEvent`. `MPEvent` is Objective-C only and pinned there by the kit ABI (101 files under `Kits/` reference it), so Swift cannot take the set. This one was in the plan before I checked the type.
- **The crash-session pick** and **the `didBecomeActive` launch flag** are a `first(where:)` and a nil check embedded in dictionary assembly. Extracting them adds a boundary for no clarity gain — the same call #924 made for the other trivial `messageInfo` builders.

## Validation

- `Tools/abi-guard.sh check` → exit 0, no baseline or retained-manifest change
- `trunk check` → clean
- iOS build → 0 errors
- Swift suite: **844 passed, 0 failed**, including 13 new mirror tests
- Objective-C contract tests: **165/165** across `MPBackendControllerTests`, `MPPersistenceControllerTests`, `MPUploadBuilderTests`, `MPMessageBuilderTests` — run twice, clean both times

Delegated to CI: full Objective-C suite, tvOS, three-podspec `pod lib lint`, migration-progress report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)