### PR TITLE
refactor: move the user-identity change decision to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Utils/MPUserIdentityLogic.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Utils/MPUserIdentityLogic.swift
@@ -8,8 +8,11 @@ import Foundation
     /// the first non-user identity type (`maxValidTypeExclusive`). Malformed or
     /// out-of-range entries are dropped; order is preserved.
     @objc(validIdentities:typeKey:maxValidTypeExclusive:)
-    public static func validIdentities(_ identities: [[AnyHashable: Any]], typeKey: String,
-                                       maxValidTypeExclusive: Int) -> [[AnyHashable: Any]] {
+    public static func validIdentities(
+        _ identities: [[AnyHashable: Any]],
+        typeKey: String,
+        maxValidTypeExclusive: Int
+    ) -> [[AnyHashable: Any]] {
         identities.filter { entry in
             guard let type = entry[typeKey] as? NSNumber else { return false }
             return type.intValue < maxValidTypeExclusive
@@ -20,8 +23,12 @@ import Foundation
     /// dropped (e.g. the advertiser id while ATT is not authorized). Order is
     /// preserved; a no-op when the flag is false or no entry matches.
     @objc(identities:removingType:when:typeKey:)
-    public static func identities(_ identities: [[AnyHashable: Any]], removingType type: Int,
-                                  when shouldRemove: Bool, typeKey: String) -> [[AnyHashable: Any]] {
+    public static func identities(
+        _ identities: [[AnyHashable: Any]],
+        removingType type: Int,
+        when shouldRemove: Bool,
+        typeKey: String
+    ) -> [[AnyHashable: Any]] {
         guard shouldRemove,
               let index = identities.firstIndex(where: { ($0[typeKey] as? NSNumber)?.intValue == type })
         else {
@@ -38,5 +45,103 @@ import Foundation
     public static func dateFirstSet(fromMilliseconds milliseconds: NSNumber?) -> Date {
         guard let milliseconds else { return Date() }
         return Date(timeIntervalSince1970: milliseconds.doubleValue/1000.0)
+    }
+
+    /// Decides what setting `value` for `identityType` should do to the stored identity array.
+    ///
+    /// Two asymmetries in the original are preserved deliberately:
+    ///
+    /// - The "already set to this value" check inspects the **last** entry of the type, while the
+    ///   mutation acts on the **first**. With well-formed storage there is at most one entry per
+    ///   type and the two agree, but the original's behaviour on a duplicated type is kept.
+    /// - An empty-string value is *valid* for the equality check (it is not null) yet *removes* in
+    ///   the mutation, so setting "" over a stored "" reports unchanged rather than removing.
+    ///
+    /// The caller keeps every side effect: mutating the array, building
+    /// `MPUserIdentityChangePRIVATE`, persisting, logging and reporting the exec status.
+    @objc(planForIdentityType:value:currentIdentities:typeKey:idKey:dateFirstSetKey:now:)
+    public static func plan(
+        forIdentityType identityType: NSNumber,
+        value: String?,
+        currentIdentities: [[String: Any]],
+        typeKey: String,
+        idKey: String,
+        dateFirstSetKey: String,
+        now: Date
+    ) -> MPUserIdentityChangePlan {
+        let matchesType: ([String: Any]) -> Bool = { entry in
+            guard let type = entry[typeKey] as? NSNumber else { return false }
+            return type.isEqual(to: identityType)
+        }
+
+        // A stored id that is absent, `NSNull`, or not a string counts as "no valid old identity",
+        // the same as the original's `MPIsNull` guard.
+        if let existingValue = currentIdentities.last(where: matchesType)?[idKey] as? String,
+           let value,
+           existingValue == value {
+            return MPUserIdentityChangePlan(kind: .unchanged)
+        }
+
+        let index = currentIdentities.firstIndex(where: matchesType)
+
+        guard let value, !value.isEmpty else {
+            guard let index else { return MPUserIdentityChangePlan(kind: .nothingToRemove) }
+            return MPUserIdentityChangePlan(
+                kind: .remove,
+                index: index,
+                existingIdentity: currentIdentities[index]
+            )
+        }
+
+        guard let index else {
+            return MPUserIdentityChangePlan(kind: .add, dateFirstSet: now, isFirstTimeSet: true)
+        }
+
+        let existingIdentity = currentIdentities[index]
+        return MPUserIdentityChangePlan(
+            kind: .replace,
+            index: index,
+            existingIdentity: existingIdentity,
+            dateFirstSet: dateFirstSet(fromMilliseconds: existingIdentity[dateFirstSetKey] as? NSNumber),
+            isFirstTimeSet: false
+        )
+    }
+}
+
+/// What setting a user identity should do to the stored identity array.
+@objc public enum MPUserIdentityChangeKind: Int {
+    /// The stored value already equals the requested one: persist nothing, report a failed status.
+    case unchanged
+    /// A removal was requested but no entry of that type exists: persist nothing, report success.
+    case nothingToRemove
+    case remove
+    case add
+    case replace
+}
+
+@objc(MPUserIdentityChangePlan)
+public final class MPUserIdentityChangePlan: NSObject {
+    @objc public let kind: MPUserIdentityChangeKind
+    /// Index into the identities array for `remove`/`replace`, `NSNotFound` otherwise.
+    @objc public let index: Int
+    /// The entry being removed or replaced, so the caller can build the old identity from it.
+    @objc public let existingIdentity: [String: Any]?
+    /// What to stamp on the new identity: `now` for `add`, the stored first-set date for `replace`.
+    @objc public let dateFirstSet: Date?
+    @objc public let isFirstTimeSet: Bool
+
+    init(
+        kind: MPUserIdentityChangeKind,
+        index: Int = NSNotFound,
+        existingIdentity: [String: Any]? = nil,
+        dateFirstSet: Date? = nil,
+        isFirstTimeSet: Bool = false
+    ) {
+        self.kind = kind
+        self.index = index
+        self.existingIdentity = existingIdentity
+        self.dateFirstSet = dateFirstSet
+        self.isFirstTimeSet = isFirstTimeSet
+        super.init()
     }
 }

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPUserIdentityLogicTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPUserIdentityLogicTests.swift
@@ -64,3 +64,138 @@ final class MPUserIdentityLogicTests: XCTestCase {
         XCTAssertEqual(date.timeIntervalSince1970, Date().timeIntervalSince1970, accuracy: 2.0)
     }
 }
+
+extension MPUserIdentityLogicTests {
+    private static let typeKey = "n"
+    private static let idKey = "i"
+    private static let dfsKey = "dfs"
+    private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func entry(type: Int, value: Any?, firstSetMs: Double? = nil) -> [String: Any] {
+        var entry: [String: Any] = [Self.typeKey: NSNumber(value: type)]
+        if let value { entry[Self.idKey] = value }
+        if let firstSetMs { entry[Self.dfsKey] = NSNumber(value: firstSetMs) }
+        return entry
+    }
+
+    private func plan(
+        type: Int = 7,
+        value: String?,
+        identities: [[String: Any]]
+    ) -> MPUserIdentityChangePlan {
+        MPUserIdentityLogic.plan(
+            forIdentityType: NSNumber(value: type),
+            value: value,
+            currentIdentities: identities,
+            typeKey: Self.typeKey,
+            idKey: Self.idKey,
+            dateFirstSetKey: Self.dfsKey,
+            now: Self.now
+        )
+    }
+
+    // MARK: - unchanged
+
+    func testSettingTheSameValueIsUnchanged() {
+        XCTAssertEqual(plan(value: "abc", identities: [entry(type: 7, value: "abc")]).kind, .unchanged)
+    }
+
+    func testCasingDifferenceIsNotUnchanged() {
+        XCTAssertEqual(plan(value: "ABC", identities: [entry(type: 7, value: "abc")]).kind, .replace)
+    }
+
+    func testTheUnchangedCheckReadsTheLastEntryOfTheType() {
+        // Storage should hold at most one entry per type, but when it does not the original
+        // compared against the last one while mutating the first. Both halves are pinned here.
+        let identities = [entry(type: 7, value: "first"), entry(type: 7, value: "last")]
+
+        XCTAssertEqual(plan(value: "last", identities: identities).kind, .unchanged)
+
+        let replacement = plan(value: "first", identities: identities)
+        XCTAssertEqual(replacement.kind, .replace)
+        XCTAssertEqual(replacement.index, 0)
+    }
+
+    func testAnEmptyStringOverAStoredEmptyStringIsUnchangedRatherThanARemoval() {
+        // "" is not null, so it satisfies the equality check before the removal branch sees it.
+        XCTAssertEqual(plan(value: "", identities: [entry(type: 7, value: "")]).kind, .unchanged)
+    }
+
+    func testANullStoredValueIsNotTreatedAsAMatch() {
+        XCTAssertEqual(plan(value: "abc", identities: [entry(type: 7, value: NSNull())]).kind, .replace)
+        XCTAssertEqual(plan(value: "abc", identities: [entry(type: 7, value: nil)]).kind, .replace)
+    }
+
+    // MARK: - remove
+
+    func testNilValueRemovesTheExistingEntry() {
+        let result = plan(value: nil, identities: [entry(type: 1, value: "x"), entry(type: 7, value: "abc")])
+
+        XCTAssertEqual(result.kind, .remove)
+        XCTAssertEqual(result.index, 1)
+        XCTAssertEqual(result.existingIdentity?[Self.idKey] as? String, "abc")
+    }
+
+    func testEmptyStringRemovesTheExistingEntry() {
+        let result = plan(value: "", identities: [entry(type: 7, value: "abc")])
+        XCTAssertEqual(result.kind, .remove)
+        XCTAssertEqual(result.index, 0)
+    }
+
+    func testRemovalTargetsTheFirstMatchingEntry() {
+        let result = plan(value: nil, identities: [entry(type: 7, value: "first"), entry(type: 7, value: "last")])
+        XCTAssertEqual(result.kind, .remove)
+        XCTAssertEqual(result.index, 0)
+    }
+
+    func testRemovingSomethingThatIsNotStoredPersistsNothing() {
+        // Distinct from `.unchanged`: the caller still reports success here.
+        XCTAssertEqual(plan(value: nil, identities: []).kind, .nothingToRemove)
+        XCTAssertEqual(plan(value: "", identities: [entry(type: 1, value: "x")]).kind, .nothingToRemove)
+    }
+
+    // MARK: - add
+
+    func testANewTypeIsAddedAndStampedAsFirstTimeSet() {
+        let result = plan(value: "abc", identities: [entry(type: 1, value: "x")])
+
+        XCTAssertEqual(result.kind, .add)
+        XCTAssertEqual(result.index, NSNotFound)
+        XCTAssertNil(result.existingIdentity)
+        XCTAssertEqual(result.dateFirstSet, Self.now)
+        XCTAssertTrue(result.isFirstTimeSet)
+    }
+
+    // MARK: - replace
+
+    func testReplaceKeepsTheStoredFirstSetDate() {
+        let result = plan(value: "new", identities: [entry(type: 7, value: "old", firstSetMs: 1_500_000_000_000)])
+
+        XCTAssertEqual(result.kind, .replace)
+        XCTAssertEqual(result.index, 0)
+        XCTAssertEqual(result.existingIdentity?[Self.idKey] as? String, "old")
+        XCTAssertEqual(result.dateFirstSet, Date(timeIntervalSince1970: 1_500_000_000))
+        XCTAssertFalse(result.isFirstTimeSet)
+    }
+
+    func testReplaceWithoutAStoredFirstSetDateFallsBackToTheCurrentDate() throws {
+        let result = plan(value: "new", identities: [entry(type: 7, value: "old")])
+
+        XCTAssertEqual(result.kind, .replace)
+        // `dateFirstSetFromMilliseconds:` answers "now" when the stamp is absent.
+        let stamped = try XCTUnwrap(result.dateFirstSet)
+        XCTAssertEqual(stamped.timeIntervalSinceNow, 0, accuracy: 5)
+    }
+
+    // MARK: - malformed storage
+
+    func testEntriesWithoutANumericTypeAreIgnored() {
+        let identities: [[String: Any]] = [
+            [Self.typeKey: "not-a-number", Self.idKey: "abc"],
+            [Self.idKey: "abc"]
+        ]
+        let result = plan(value: "abc", identities: identities)
+
+        XCTAssertEqual(result.kind, .add)
+    }
+}

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -1535,75 +1535,48 @@ static BOOL skipNextUpload = NO;
     
     userIdentityChange.timestamp = timestamp;
     
-    NSNumber *identityTypeNumber = @(userIdentityChange.newUserIdentity.type);
-    
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF[%@] == %@", kMPUserIdentityTypeKey, identityTypeNumber];
-    NSDictionary *currentIdentities = [[[self userIdentitiesForUserId:[MPPersistenceController_PRIVATE mpId]] filteredArrayUsingPredicate:predicate] lastObject];
-    
-    BOOL oldIdentityIsValid = currentIdentities && !MPIsNull(currentIdentities[kMPUserIdentityIdKey]);
-    BOOL newIdentityIsValid = !MPIsNull(userIdentityChange.newUserIdentity.value);
-    
-    if (oldIdentityIsValid
-        && newIdentityIsValid
-        && [currentIdentities[kMPUserIdentityIdKey] isEqualToString:userIdentityChange.newUserIdentity.value]) {
+    NSMutableArray *userIdentities = [self userIdentitiesForUserId:[MPPersistenceController_PRIVATE mpId]];
+
+    MPUserIdentityChangePlan *plan = [MPUserIdentityLogic planForIdentityType:@(userIdentityChange.newUserIdentity.type)
+                                                                        value:userIdentityChange.newUserIdentity.value
+                                                            currentIdentities:userIdentities
+                                                                      typeKey:kMPUserIdentityTypeKey
+                                                                        idKey:kMPUserIdentityIdKey
+                                                              dateFirstSetKey:kMPDateUserIdentityWasFirstSet
+                                                                          now:[NSDate date]];
+
+    if (plan.kind == MPUserIdentityChangeKindUnchanged) {
         completionHandler(identityString, identityType, MPExecStatusFail);
         return;
     }
-    
-    BOOL (^objectTester)(id, NSUInteger, BOOL *) = ^(id obj, NSUInteger idx, BOOL *stop) {
-        NSNumber *currentIdentityType = obj[kMPUserIdentityTypeKey];
-        BOOL foundMatch = [currentIdentityType isEqualToNumber:identityTypeNumber];
-        
-        if (foundMatch) {
-            *stop = YES;
-        }
-        
-        return foundMatch;
-    };
-    
-    NSMutableDictionary<NSString *, id> *identityDictionary;
-    NSUInteger existingEntryIndex;
-    BOOL persistUserIdentities = NO;
-    
-    NSMutableArray *userIdentities = [self userIdentitiesForUserId:[MPPersistenceController_PRIVATE mpId]];
-    
-    if (userIdentityChange.newUserIdentity.value == nil || (NSNull *)userIdentityChange.newUserIdentity.value == [NSNull null] || [userIdentityChange.newUserIdentity.value isEqualToString:@""]) {
-        existingEntryIndex = [userIdentities indexOfObjectPassingTest:objectTester];
-        
-        if (existingEntryIndex != NSNotFound) {
-            identityDictionary = [userIdentities[existingEntryIndex] mutableCopy];
-            userIdentityChange.oldUserIdentity = [[MPUserIdentityInstancePRIVATE alloc] initWithUserIdentityDictionary:identityDictionary];
+
+    BOOL persistUserIdentities = plan.kind != MPUserIdentityChangeKindNothingToRemove;
+
+    switch (plan.kind) {
+        case MPUserIdentityChangeKindRemove:
+            userIdentityChange.oldUserIdentity = [[MPUserIdentityInstancePRIVATE alloc] initWithUserIdentityDictionary:plan.existingIdentity];
             userIdentityChange.newUserIdentity = nil;
-            
-            [userIdentities removeObjectAtIndex:existingEntryIndex];
-            persistUserIdentities = YES;
-        }
-    } else {
-        existingEntryIndex = [userIdentities indexOfObjectPassingTest:objectTester];
-        
-        if (existingEntryIndex == NSNotFound) {
-            userIdentityChange.newUserIdentity.dateFirstSet = [NSDate date];
-            userIdentityChange.newUserIdentity.isFirstTimeSet = YES;
-            
-            identityDictionary = [userIdentityChange.newUserIdentity dictionaryRepresentation];
-            
-            [userIdentities addObject:identityDictionary];
-        } else {
-            currentIdentities = userIdentities[existingEntryIndex];
-            userIdentityChange.oldUserIdentity = [[MPUserIdentityInstancePRIVATE alloc] initWithUserIdentityDictionary:currentIdentities];
-            
-            NSNumber *timeIntervalMilliseconds = currentIdentities[kMPDateUserIdentityWasFirstSet];
-            userIdentityChange.newUserIdentity.dateFirstSet = [MPUserIdentityLogic dateFirstSetFromMilliseconds:timeIntervalMilliseconds];
-            userIdentityChange.newUserIdentity.isFirstTimeSet = NO;
-            
-            identityDictionary = [userIdentityChange.newUserIdentity dictionaryRepresentation];
-            
-            [userIdentities replaceObjectAtIndex:existingEntryIndex withObject:identityDictionary];
-        }
-        
-        persistUserIdentities = YES;
+            [userIdentities removeObjectAtIndex:plan.index];
+            break;
+
+        case MPUserIdentityChangeKindAdd:
+            userIdentityChange.newUserIdentity.dateFirstSet = plan.dateFirstSet;
+            userIdentityChange.newUserIdentity.isFirstTimeSet = plan.isFirstTimeSet;
+            [userIdentities addObject:[userIdentityChange.newUserIdentity dictionaryRepresentation]];
+            break;
+
+        case MPUserIdentityChangeKindReplace:
+            userIdentityChange.oldUserIdentity = [[MPUserIdentityInstancePRIVATE alloc] initWithUserIdentityDictionary:plan.existingIdentity];
+            userIdentityChange.newUserIdentity.dateFirstSet = plan.dateFirstSet;
+            userIdentityChange.newUserIdentity.isFirstTimeSet = plan.isFirstTimeSet;
+            [userIdentities replaceObjectAtIndex:plan.index withObject:[userIdentityChange.newUserIdentity dictionaryRepresentation]];
+            break;
+
+        case MPUserIdentityChangeKindNothingToRemove:
+        case MPUserIdentityChangeKindUnchanged:
+            break;
     }
-    
+
     if (persistUserIdentities) {
         if (userIdentityChange.changed) {
             [self logUserIdentityChange:userIdentityChange];


### PR DESCRIPTION
Stacked on #956 (`refactor/swift-backend-decision-slices`).

`setUserIdentity:identityType:timestamp:completionHandler:` decided what to do to the stored identity array inline, across ~70 lines of index lookups, an `NSPredicate`, a block-based `objectTester` and four branches. That decision moves to `MPUserIdentityLogic.planForIdentityType:...`, which answers with an `MPUserIdentityChangePlan`: `unchanged`, `nothingToRemove`, `remove`, `add` or `replace`, plus the index, the entry being displaced and the first-set stamp.

## Why now — this reverses #923's deferral

#923 deliberately left this core in Objective-C, on the grounds that it orchestrates Objective-C objects. What changed is that `MPUserIdentityInstancePRIVATE` and `MPUserIdentityChangePRIVATE` are now fully Swift, so the helper reasons over plain `[[String: Any]]` entries instead of marshalling around SDK objects.

The `.m` still owns every side effect: mutating the array, building the change object, persisting to user defaults, logging, and reporting the exec status.

## Two asymmetries preserved deliberately

Both are in the original, both are now pinned by tests rather than left implicit:

- **The equality check reads the *last* entry of the type; the mutation acts on the *first*.** With well-formed storage there is at most one entry per type and the two agree, but the behaviour on a duplicated type is unchanged.
- **An empty string is *valid* for the equality check yet *removes* in the mutation.** So setting `""` over a stored `""` reports unchanged rather than removing.

`nothingToRemove` is a distinct outcome from `unchanged`: both persist nothing, but the first reports `MPExecStatusSuccess` and the second reports `MPExecStatusFail`, exactly as before.

## Two incidental improvements

- The stored identities are read **once** instead of three times. The original called `userIdentitiesForUserId:` for the predicate lookup, again for the index lookup, and the same user-defaults read returned the same array each time.
- An entry whose type key is not a number is skipped rather than being sent `isEqualToNumber:`, which would previously have raised.

## Validation

Identity is a high-consequence path, so the contract tests are the gate here, not a formality:

- Objective-C: **118/118** across `MPBackendControllerTests`, `MPIdentityTests`, `MPUserIdentityChangeTests` — run twice, clean both times. Includes `testSetIdentityToNil`, `testSetIdentityToNSNull`, `testDoNotSetDuplicateIdentity`, `testDoNotSetDuplicateIdentityCasing`, `testUserIdentityChanged`.
- Broader sweep: **208/208** across `MParticleTests`, `MPPersistenceControllerTests`, `MPKitContainerTests`, with one unrelated failure — `testActiveKitsRegistryThreadSafety`, a self-declared non-deterministic stress test that passes in isolation twice and touches no code in this PR.
- Swift suite: **857 passed, 0 failed**, including 21 new mirror tests.
- `Tools/abi-guard.sh check` → exit 0 · `trunk check` → clean · iOS build → 0 errors.

Delegated to CI: full Objective-C suite, tvOS, three-podspec `pod lib lint`, migration-progress report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)