### PR TITLE
refactor: add Swift SQLite foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
             name: "mParticle_Apple_SDK_Swift",
             path: "mParticle-Apple-SDK-Swift/Sources",
             linkerSettings: [
-                .linkedFramework("SystemConfiguration")
+                .linkedFramework("SystemConfiguration"),
+                .linkedLibrary("sqlite3")
             ]
         ),
         // Objective-C SDK - source-based distribution (internal module: mParticle_Apple_SDK_ObjC)

--- a/mParticle-Apple-SDK-Swift.podspec
+++ b/mParticle-Apple-SDK-Swift.podspec
@@ -21,4 +21,5 @@ Pod::Spec.new do |s|
     
     s.source_files = 'mParticle-Apple-SDK-Swift/Sources/**/*.swift'
     s.frameworks = 'SystemConfiguration'
+    s.libraries = 'sqlite3'
 end

--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPSQLite.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPSQLite.swift
@@ -1,0 +1,260 @@
+import Foundation
+import SQLite3
+
+struct MPSQLiteError: Error, Equatable, CustomStringConvertible {
+    let code: Int32
+    let message: String
+    let sql: String?
+
+    var description: String {
+        if let sql {
+            return "SQLite error \(code): \(message) [\(sql)]"
+        }
+        return "SQLite error \(code): \(message)"
+    }
+}
+
+enum MPSQLiteStep: Equatable {
+    case row
+    case done
+}
+
+final class MPSQLiteConnection {
+    static let defaultOpenFlags = SQLITE_OPEN_CREATE
+        | SQLITE_OPEN_READWRITE
+        | SQLITE_OPEN_FULLMUTEX
+        | SQLITE_OPEN_FILEPROTECTION_NONE
+
+    private(set) var handle: OpaquePointer?
+    private let logger: MPLog?
+
+    init(path: String, flags: Int32 = defaultOpenFlags, logger: MPLog? = nil) throws {
+        self.logger = logger
+
+        var database: OpaquePointer?
+        let result = sqlite3_open_v2(path, &database, flags, nil)
+        guard result == SQLITE_OK, let database else {
+            let error = Self.error(code: result, database: database, sql: nil)
+            if let database {
+                sqlite3_close(database)
+            }
+            logger?.error(error.description)
+            throw error
+        }
+        handle = database
+    }
+
+    deinit {
+        close()
+    }
+
+    func close() {
+        guard let handle else {
+            return
+        }
+        sqlite3_close(handle)
+        self.handle = nil
+    }
+
+    func execute(_ sql: String) throws {
+        guard let handle else {
+            throw loggedError(code: SQLITE_MISUSE, sql: sql)
+        }
+
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(handle, sql, nil, nil, &errorMessage)
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map { String(cString: $0) }
+            sqlite3_free(errorMessage)
+            throw loggedError(code: result, sql: sql, message: message)
+        }
+    }
+
+    func prepare(_ sql: String) throws -> MPSQLiteStatement {
+        guard let handle else {
+            throw loggedError(code: SQLITE_MISUSE, sql: sql)
+        }
+
+        var statement: OpaquePointer?
+        let result = sqlite3_prepare_v2(handle, sql, -1, &statement, nil)
+        guard result == SQLITE_OK, let statement else {
+            throw loggedError(code: result, sql: sql)
+        }
+        return MPSQLiteStatement(connection: self, handle: statement, sql: sql)
+    }
+
+    func transaction<T>(_ body: () throws -> T) throws -> T {
+        try execute("BEGIN TRANSACTION")
+        do {
+            let value = try body()
+            try execute("COMMIT")
+            return value
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    func integrityCheck() throws -> Bool {
+        let statement = try prepare("PRAGMA integrity_check")
+        guard try statement.step() == .row else {
+            return false
+        }
+        return statement.string(at: 0) == "ok"
+    }
+
+    func releaseMemory() {
+        guard let handle else {
+            return
+        }
+        sqlite3_db_release_memory(handle)
+    }
+
+    fileprivate func loggedError(code: Int32, sql: String, message: String? = nil) -> MPSQLiteError {
+        let error = Self.error(code: code, database: handle, sql: sql, message: message)
+        logger?.error(error.description)
+        return error
+    }
+
+    private static func error(
+        code: Int32,
+        database: OpaquePointer?,
+        sql: String?,
+        message: String? = nil
+    ) -> MPSQLiteError {
+        let databaseMessage = database.map { String(cString: sqlite3_errmsg($0)) }
+        return MPSQLiteError(
+            code: code,
+            message: message ?? databaseMessage ?? "Unknown SQLite error",
+            sql: sql
+        )
+    }
+}
+
+final class MPSQLiteStatement {
+    private unowned let connection: MPSQLiteConnection
+    private var handle: OpaquePointer?
+    let sql: String
+
+    fileprivate init(connection: MPSQLiteConnection, handle: OpaquePointer, sql: String) {
+        self.connection = connection
+        self.handle = handle
+        self.sql = sql
+    }
+
+    deinit {
+        if let handle {
+            sqlite3_finalize(handle)
+        }
+    }
+
+    func reset() throws {
+        guard let handle else {
+            throw connection.loggedError(code: SQLITE_MISUSE, sql: sql)
+        }
+        let result = sqlite3_reset(handle)
+        guard result == SQLITE_OK else {
+            throw connection.loggedError(code: result, sql: sql)
+        }
+        sqlite3_clear_bindings(handle)
+    }
+
+    func bindNull(at index: Int32) throws {
+        try checkBind(sqlite3_bind_null(requiredHandle(), index))
+    }
+
+    func bind(_ value: Int32, at index: Int32) throws {
+        try checkBind(sqlite3_bind_int(requiredHandle(), index, value))
+    }
+
+    func bind(_ value: Int64, at index: Int32) throws {
+        try checkBind(sqlite3_bind_int64(requiredHandle(), index, value))
+    }
+
+    func bind(_ value: Double, at index: Int32) throws {
+        try checkBind(sqlite3_bind_double(requiredHandle(), index, value))
+    }
+
+    func bind(_ value: String?, at index: Int32) throws {
+        guard let value else {
+            try bindNull(at: index)
+            return
+        }
+        try checkBind(sqlite3_bind_text(requiredHandle(), index, value, -1, Self.transient))
+    }
+
+    func bind(_ value: Data?, at index: Int32) throws {
+        guard let value else {
+            try bindNull(at: index)
+            return
+        }
+        let result = value.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(requiredHandle(), index, bytes.baseAddress, Int32(bytes.count), Self.transient)
+        }
+        try checkBind(result)
+    }
+
+    func step() throws -> MPSQLiteStep {
+        let result = sqlite3_step(requiredHandle())
+        switch result {
+        case SQLITE_ROW:
+            return .row
+        case SQLITE_DONE:
+            return .done
+        default:
+            throw connection.loggedError(code: result, sql: sql)
+        }
+    }
+
+    func isNull(at index: Int32) -> Bool {
+        sqlite3_column_type(requiredHandle(), index) == SQLITE_NULL
+    }
+
+    func int(at index: Int32) -> Int32 {
+        sqlite3_column_int(requiredHandle(), index)
+    }
+
+    func int64(at index: Int32) -> Int64 {
+        sqlite3_column_int64(requiredHandle(), index)
+    }
+
+    func double(at index: Int32) -> Double {
+        sqlite3_column_double(requiredHandle(), index)
+    }
+
+    func string(at index: Int32) -> String? {
+        guard !isNull(at: index), let text = sqlite3_column_text(requiredHandle(), index) else {
+            return nil
+        }
+        return String(cString: text)
+    }
+
+    func data(at index: Int32) -> Data? {
+        guard !isNull(at: index), let bytes = sqlite3_column_blob(requiredHandle(), index) else {
+            return nil
+        }
+        return Data(bytes: bytes, count: Int(sqlite3_column_bytes(requiredHandle(), index)))
+    }
+
+    func jsonDictionary(at index: Int32) -> [String: Any]? {
+        guard let data = data(at: index) else {
+            return nil
+        }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private func requiredHandle() -> OpaquePointer {
+        guard let handle else {
+            preconditionFailure("Attempted to use a finalized SQLite statement")
+        }
+        return handle
+    }
+
+    private func checkBind(_ result: Int32) throws {
+        guard result == SQLITE_OK else {
+            throw connection.loggedError(code: result, sql: sql)
+        }
+    }
+
+    private static let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPSQLite.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPSQLite.swift
@@ -48,12 +48,16 @@ final class MPSQLiteConnection {
         close()
     }
 
-    func close() {
+    @discardableResult
+    func close() -> Bool {
         guard let handle else {
-            return
+            return true
         }
-        sqlite3_close(handle)
+        guard sqlite3_close(handle) == SQLITE_OK else {
+            return false
+        }
         self.handle = nil
+        return true
     }
 
     func execute(_ sql: String) throws {
@@ -132,7 +136,7 @@ final class MPSQLiteConnection {
 }
 
 final class MPSQLiteStatement {
-    private unowned let connection: MPSQLiteConnection
+    private let connection: MPSQLiteConnection
     private var handle: OpaquePointer?
     let sql: String
 
@@ -188,6 +192,10 @@ final class MPSQLiteStatement {
             try bindNull(at: index)
             return
         }
+        if value.isEmpty {
+            try checkBind(sqlite3_bind_zeroblob(requiredHandle(), index, 0))
+            return
+        }
         let result = value.withUnsafeBytes { bytes in
             sqlite3_bind_blob(requiredHandle(), index, bytes.baseAddress, Int32(bytes.count), Self.transient)
         }
@@ -230,10 +238,17 @@ final class MPSQLiteStatement {
     }
 
     func data(at index: Int32) -> Data? {
-        guard !isNull(at: index), let bytes = sqlite3_column_blob(requiredHandle(), index) else {
+        guard !isNull(at: index) else {
             return nil
         }
-        return Data(bytes: bytes, count: Int(sqlite3_column_bytes(requiredHandle(), index)))
+        let count = Int(sqlite3_column_bytes(requiredHandle(), index))
+        guard count > 0 else {
+            return Data()
+        }
+        guard let bytes = sqlite3_column_blob(requiredHandle(), index) else {
+            return nil
+        }
+        return Data(bytes: bytes, count: count)
     }
 
     func jsonDictionary(at index: Int32) -> [String: Any]? {

--- a/mParticle-Apple-SDK-Swift/Test/Persistence/MPSQLiteTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Persistence/MPSQLiteTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import mParticle_Apple_SDK_Swift
+
+final class MPSQLiteTests: XCTestCase {
+    func testBindsAndReadsSupportedValues() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+        try database.execute(
+            "CREATE TABLE values_table (int_value INTEGER, int64_value INTEGER, "
+                + "double_value REAL, text_value TEXT, blob_value BLOB, null_value TEXT)"
+        )
+
+        let dictionary = ["name": "mParticle", "count": 2] as [String: Any]
+        let data = try JSONSerialization.data(withJSONObject: dictionary)
+        let insert = try database.prepare(
+            "INSERT INTO values_table VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        try insert.bind(Int32(7), at: 1)
+        try insert.bind(Int64.max, at: 2)
+        try insert.bind(3.5, at: 3)
+        try insert.bind("text", at: 4)
+        try insert.bind(data, at: 5)
+        try insert.bindNull(at: 6)
+        XCTAssertEqual(try insert.step(), .done)
+
+        let select = try database.prepare("SELECT * FROM values_table")
+        XCTAssertEqual(try select.step(), .row)
+        XCTAssertEqual(select.int(at: 0), 7)
+        XCTAssertEqual(select.int64(at: 1), Int64.max)
+        XCTAssertEqual(select.double(at: 2), 3.5)
+        XCTAssertEqual(select.string(at: 3), "text")
+        XCTAssertEqual(select.data(at: 4), data)
+        XCTAssertEqual(select.jsonDictionary(at: 4)?["name"] as? String, "mParticle")
+        XCTAssertTrue(select.isNull(at: 5))
+        XCTAssertNil(select.string(at: 5))
+        XCTAssertNil(select.data(at: 5))
+    }
+
+    func testResetClearsBindingsForStatementReuse() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+        try database.execute("CREATE TABLE strings (value TEXT)")
+        let insert = try database.prepare("INSERT INTO strings VALUES (?)")
+
+        try insert.bind("first", at: 1)
+        XCTAssertEqual(try insert.step(), .done)
+        try insert.reset()
+        try insert.bind("second", at: 1)
+        XCTAssertEqual(try insert.step(), .done)
+
+        let count = try database.prepare("SELECT COUNT(*) FROM strings")
+        XCTAssertEqual(try count.step(), .row)
+        XCTAssertEqual(count.int(at: 0), 2)
+    }
+
+    func testTransactionCommitsSuccessfulWork() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+        try database.execute("CREATE TABLE records (value INTEGER)")
+
+        try database.transaction {
+            try database.execute("INSERT INTO records VALUES (1)")
+            try database.execute("INSERT INTO records VALUES (2)")
+        }
+
+        let count = try database.prepare("SELECT COUNT(*) FROM records")
+        XCTAssertEqual(try count.step(), .row)
+        XCTAssertEqual(count.int(at: 0), 2)
+    }
+
+    func testTransactionRollsBackFailedWork() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+        try database.execute("CREATE TABLE records (value INTEGER UNIQUE)")
+
+        XCTAssertThrowsError(try database.transaction {
+            try database.execute("INSERT INTO records VALUES (1)")
+            try database.execute("INSERT INTO records VALUES (1)")
+        })
+
+        let count = try database.prepare("SELECT COUNT(*) FROM records")
+        XCTAssertEqual(try count.step(), .row)
+        XCTAssertEqual(count.int(at: 0), 0)
+    }
+
+    func testIntegrityCheckAndMemoryRelease() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+
+        XCTAssertTrue(try database.integrityCheck())
+        database.releaseMemory()
+    }
+
+    func testErrorsIncludeSQLAndAreLogged() throws {
+        let logger = MPLog(logLevel: .error)
+        var messages: [String] = []
+        logger.customLogger = { messages.append($0) }
+        let database = try MPSQLiteConnection(path: ":memory:", logger: logger)
+
+        XCTAssertThrowsError(try database.execute("NOT VALID SQL")) { error in
+            let sqliteError = error as? MPSQLiteError
+            XCTAssertEqual(sqliteError?.sql, "NOT VALID SQL")
+            XCTAssertNotEqual(sqliteError?.code, 0)
+        }
+        XCTAssertTrue(messages.contains { $0.contains("NOT VALID SQL") })
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Persistence/MPSQLiteTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Persistence/MPSQLiteTests.swift
@@ -51,6 +51,35 @@ final class MPSQLiteTests: XCTestCase {
         XCTAssertEqual(count.int(at: 0), 2)
     }
 
+    func testEmptyBlobIsDistinctFromNull() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+        try database.execute("CREATE TABLE blobs (value BLOB)")
+        let insert = try database.prepare("INSERT INTO blobs VALUES (?), (?)")
+        try insert.bind(Data(), at: 1)
+        try insert.bind(nil as Data?, at: 2)
+        XCTAssertEqual(try insert.step(), .done)
+
+        let select = try database.prepare("SELECT value FROM blobs ORDER BY rowid")
+        XCTAssertEqual(try select.step(), .row)
+        XCTAssertFalse(select.isNull(at: 0))
+        XCTAssertEqual(select.data(at: 0), Data())
+        XCTAssertEqual(try select.step(), .row)
+        XCTAssertTrue(select.isNull(at: 0))
+        XCTAssertNil(select.data(at: 0))
+    }
+
+    func testCloseRetainsBusyConnectionUntilStatementsFinalize() throws {
+        let database = try MPSQLiteConnection(path: ":memory:")
+        var statement: MPSQLiteStatement? = try database.prepare("SELECT 1")
+
+        XCTAssertFalse(database.close())
+        XCTAssertNotNil(database.handle)
+
+        statement = nil
+        XCTAssertTrue(database.close())
+        XCTAssertNil(database.handle)
+    }
+
     func testTransactionCommitsSuccessfulWork() throws {
         let database = try MPSQLiteConnection(path: ":memory:")
         try database.execute("CREATE TABLE records (value INTEGER)")

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		534CD29F29CE2CE1008452B3 /* MPAppNotificationHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79CB529CE019F00E7489F /* MPAppNotificationHandlerTests.m */; };
 		534CD2A029CE2CE1008452B3 /* MParticleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C8E29CE019F00E7489F /* MParticleTests.m */; };
 		534CD2A229CE2CE1008452B3 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79CFB29CE046800E7489F /* libsqlite3.tbd */; };
+		B5A001012F5F900000000001 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79CFB29CE046800E7489F /* libsqlite3.tbd */; };
 		534CD2A429CE2CE1008452B3 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79C8829CE019F00E7489F /* OCMock.xcframework */; };
 		534CD2A629CE2CE1008452B3 /* sample_dataplan2.json in Resources */ = {isa = PBXBuildFile; fileRef = 53A79C9829CE019F00E7489F /* sample_dataplan2.json */; };
 		534CD2AC29CE2CF1008452B3 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79DC629CE23F700E7489F /* mParticle_Apple_SDK.framework */; };
@@ -560,6 +561,7 @@
 				Test/Persistence/MPIdentityCachingTests.swift,
 				Test/Persistence/MPPersistenceFileSystemTests.swift,
 				Test/Persistence/MPPersistenceSchemaTests.swift,
+				Test/Persistence/MPSQLiteTests.swift,
 				Test/Utils/AppEnvironmentProviderTests.swift,
 				Test/Utils/HasherTests.m,
 				Test/Utils/MPApplicationInfoProviderTests.swift,
@@ -645,6 +647,7 @@
 				Test/Persistence/MPIdentityCachingTests.swift,
 				Test/Persistence/MPPersistenceFileSystemTests.swift,
 				Test/Persistence/MPPersistenceSchemaTests.swift,
+				Test/Persistence/MPSQLiteTests.swift,
 				Test/Utils/AppEnvironmentProviderTests.swift,
 				Test/Utils/HasherTests.m,
 				Test/Utils/MPApplicationInfoProviderTests.swift,
@@ -706,6 +709,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5A001012F5F900000000001 /* libsqlite3.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Background
- Persistence is currently implemented through Objective-C SQLite APIs, blocking the broader Swift migration. A safe Swift SQLite foundation is needed before moving database ownership.

## What Has Changed
- Added SQLite linkage for Xcode, CocoaPods, and SwiftPM.
- Added checked Swift wrappers for connections, statements, binding, decoding, transactions, integrity checks, and error logging.
- Added focused SQLite helper tests without changing production persistence behavior.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
