### PR TITLE
refactor: port upload persistence to Swift

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceStore+Upload.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceStore+Upload.swift
@@ -1,0 +1,129 @@
+import Foundation
+import SQLite3
+
+@objc public protocol MPUploadSettingsCoding: AnyObject {
+    func archiveUploadSettings(_ settings: NSObject) -> Data?
+    func unarchiveUploadSettings(_ data: Data) -> NSObject?
+}
+
+protocol MPUploadPersistingStore {
+    func saveUpload(_ upload: MPUploadPRIVATE) throws -> Bool
+    func fetchUploads() throws -> [MPUploadPRIVATE]
+    func deleteUpload(_ upload: MPUploadPRIVATE) throws
+    func saveUploads(_ uploads: [MPUploadPRIVATE], deleting messages: [MPMessagePRIVATE]) throws -> Bool
+}
+
+extension MPPersistenceStorePRIVATE: MPUploadPersistingStore {
+    func saveUpload(_ upload: MPUploadPRIVATE) throws -> Bool {
+        if shouldSuppress(upload) {
+            return true
+        }
+        guard let uuid = upload.uuid,
+              let settingsData = encodeUploadSettings(upload.uploadSettings)
+        else {
+            return false
+        }
+
+        let statement = try requireConnection().prepare(
+            "INSERT INTO uploads "
+                + "(uuid, message_data, timestamp, session_id, upload_type, data_plan_id, "
+                + "data_plan_version, upload_settings) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        try statement.bind(uuid, at: 1)
+        try statement.bind(upload.uploadData, at: 2)
+        try statement.bind(upload.timestamp, at: 3)
+        try bindUploadSessionId(upload.sessionId, to: statement, at: 4)
+        try statement.bind(Int64(upload.uploadType), at: 5)
+        if let dataPlanId = upload.dataPlanId, dataPlanId != "0" {
+            try statement.bind(dataPlanId, at: 6)
+            if let version = upload.dataPlanVersion, version.intValue != 0 {
+                try statement.bind(version.int64Value, at: 7)
+            } else {
+                try statement.bindNull(at: 7)
+            }
+        } else {
+            try statement.bindNull(at: 6)
+            try statement.bindNull(at: 7)
+        }
+        try statement.bind(settingsData, at: 8)
+        guard try statement.step() == .done else {
+            return false
+        }
+        upload.uploadId = sqlite3_last_insert_rowid(try requireConnection().handle)
+        return true
+    }
+
+    func fetchUploads() throws -> [MPUploadPRIVATE] {
+        let statement = try requireConnection().prepare(
+            "SELECT _id, uuid, message_data, timestamp, session_id, upload_type, data_plan_id, "
+                + "data_plan_version, upload_settings FROM uploads ORDER BY timestamp, _id LIMIT 100"
+        )
+        var uploads: [MPUploadPRIVATE] = []
+        while try statement.step() == .row {
+            guard let uuid = statement.string(at: 1),
+                  let uploadData = statement.data(at: 2),
+                  let settingsData = statement.data(at: 8),
+                  let settings = decodeUploadSettings(settingsData)
+            else {
+                continue
+            }
+            uploads.append(MPUploadPRIVATE(
+                sessionId: statement.isNull(at: 4) ? nil : NSNumber(value: statement.int64(at: 4)),
+                uploadId: statement.int64(at: 0),
+                uuid: uuid,
+                uploadData: uploadData,
+                timestamp: statement.double(at: 3),
+                uploadType: UInt(statement.int64(at: 5)),
+                dataPlanId: statement.string(at: 6),
+                dataPlanVersion: statement.isNull(at: 7)
+                    ? nil
+                    : NSNumber(value: statement.int64(at: 7)),
+                uploadSettings: settings
+            ))
+        }
+        return uploads
+    }
+
+    func deleteUpload(_ upload: MPUploadPRIVATE) throws {
+        try deleteUpload(id: upload.uploadId)
+    }
+
+    func deleteUpload(id: Int64) throws {
+        let statement = try requireConnection().prepare("DELETE FROM uploads WHERE _id = ?")
+        try statement.bind(id, at: 1)
+        _ = try statement.step()
+    }
+
+    func saveUploads(_ uploads: [MPUploadPRIVATE], deleting messages: [MPMessagePRIVATE]) throws -> Bool {
+        let connection = try requireConnection()
+        do {
+            try connection.transaction {
+                for upload in uploads {
+                    guard try saveUpload(upload) else {
+                        throw MPPersistenceStoreError.uploadSettingsEncodingFailed
+                    }
+                }
+                try deleteMessages(messages)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func bindUploadSessionId(
+        _ number: NSNumber?,
+        to statement: MPSQLiteStatement,
+        at index: Int32
+    ) throws {
+        if let number {
+            try statement.bind(number.int64Value, at: index)
+        } else {
+            try statement.bindNull(at: index)
+        }
+    }
+}
+
+private enum MPPersistenceStoreError: Error {
+    case uploadSettingsEncodingFailed
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceStore.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceStore.swift
@@ -5,6 +5,8 @@ final class MPPersistenceStorePRIVATE {
     private let fileSystem: MPPersistenceFileSystemPRIVATE
     private let logger: MPLog
     private let mpidProvider: () -> NSNumber
+    private let uploadSettingsCodec: MPUploadSettingsCoding?
+    private let isOptedOut: () -> Bool
     private(set) var connection: MPSQLiteConnection?
     let databasePath: String
 
@@ -16,11 +18,15 @@ final class MPPersistenceStorePRIVATE {
         fileSystem: MPPersistenceFileSystemPRIVATE,
         logger: MPLog,
         openImmediately: Bool = true,
-        mpidProvider: @escaping () -> NSNumber = { MPUserDefaults.storedMpId() }
+        mpidProvider: @escaping () -> NSNumber = { MPUserDefaults.storedMpId() },
+        uploadSettingsCodec: MPUploadSettingsCoding? = nil,
+        isOptedOut: @escaping () -> Bool = { false }
     ) {
         self.fileSystem = fileSystem
         self.logger = logger
         self.mpidProvider = mpidProvider
+        self.uploadSettingsCodec = uploadSettingsCodec
+        self.isOptedOut = isOptedOut
 
         fileSystem.migrateLegacyDatabaseDirectoryIfNeeded()
         fileSystem.removeLegacySessionNumberFileIfNeeded()
@@ -104,6 +110,18 @@ final class MPPersistenceStorePRIVATE {
 
     func currentMpid() -> NSNumber {
         mpidProvider()
+    }
+
+    func encodeUploadSettings(_ settings: NSObject) -> Data? {
+        uploadSettingsCodec?.archiveUploadSettings(settings)
+    }
+
+    func decodeUploadSettings(_ data: Data) -> NSObject? {
+        uploadSettingsCodec?.unarchiveUploadSettings(data)
+    }
+
+    func shouldSuppress(_ upload: MPUploadPRIVATE) -> Bool {
+        isOptedOut() && !upload.containsOptOutMessage
     }
 
     func requireConnection() throws -> MPSQLiteConnection {

--- a/mParticle-Apple-SDK-Swift/Test/Persistence/MPPersistenceStoreTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Persistence/MPPersistenceStoreTests.swift
@@ -1,6 +1,19 @@
 import XCTest
 @testable import mParticle_Apple_SDK_Swift
 
+private final class TestUploadSettingsCodec: NSObject, MPUploadSettingsCoding {
+    let decodedSettings = NSObject()
+    var shouldEncode = true
+
+    func archiveUploadSettings(_: NSObject) -> Data? {
+        shouldEncode ? Data("settings".utf8) : nil
+    }
+
+    func unarchiveUploadSettings(_ data: Data) -> NSObject? {
+        data == Data("settings".utf8) ? decodedSettings : nil
+    }
+}
+
 final class MPPersistenceStoreTests: XCTestCase {
     private var rootDirectory: URL!
     private var logger: MPLog!
@@ -309,5 +322,112 @@ final class MPPersistenceStoreTests: XCTestCase {
         XCTAssertEqual(breadcrumbs.count, MPPersistenceSchemaPRIVATE.maxBreadcrumbs)
         XCTAssertEqual(breadcrumbs.first?.uuid, "breadcrumb-1")
         XCTAssertEqual(breadcrumbs.last?.uuid, "breadcrumb-50")
+    }
+
+    func testUploadRoundTripOrderingAndDelete() throws {
+        let codec = TestUploadSettingsCodec()
+        let store = MPPersistenceStorePRIVATE(
+            fileSystem: fileSystem,
+            logger: logger,
+            uploadSettingsCodec: codec
+        )
+        let later = upload(uuid: "later", timestamp: 20)
+        let earlier = upload(uuid: "earlier", timestamp: 10)
+
+        XCTAssertTrue(try store.saveUpload(later))
+        XCTAssertTrue(try store.saveUpload(earlier))
+
+        var fetched = try store.fetchUploads()
+        XCTAssertEqual(fetched.map(\.uuid), ["earlier", "later"])
+        XCTAssertTrue(fetched.allSatisfy { $0.uploadSettings === codec.decodedSettings })
+
+        try store.deleteUpload(earlier)
+        fetched = try store.fetchUploads()
+        XCTAssertEqual(fetched.map(\.uuid), ["later"])
+    }
+
+    func testOptOutSuppressesOrdinaryUploadsButKeepsOptOutMessage() throws {
+        let codec = TestUploadSettingsCodec()
+        let store = MPPersistenceStorePRIVATE(
+            fileSystem: fileSystem,
+            logger: logger,
+            uploadSettingsCodec: codec,
+            isOptedOut: { true }
+        )
+        let ordinary = upload(uuid: "ordinary", timestamp: 1)
+        let optOut = upload(uuid: "opt-out", timestamp: 2)
+        optOut.containsOptOutMessage = true
+
+        XCTAssertTrue(try store.saveUpload(ordinary))
+        XCTAssertEqual(ordinary.uploadId, 0)
+        XCTAssertTrue(try store.saveUpload(optOut))
+        XCTAssertEqual(try store.fetchUploads().map(\.uuid), ["opt-out"])
+    }
+
+    func testAtomicBatchRollsBackWhenUploadSettingsCannotEncode() throws {
+        let codec = TestUploadSettingsCodec()
+        let store = MPPersistenceStorePRIVATE(
+            fileSystem: fileSystem,
+            logger: logger,
+            uploadSettingsCodec: codec
+        )
+        let message = MPMessagePRIVATE(
+            sessionId: nil,
+            messageId: 0,
+            uuid: "message",
+            messageType: "e",
+            messageData: Data("{}".utf8),
+            timestamp: 1,
+            uploadStatus: 1,
+            userId: 42,
+            dataPlanId: nil,
+            dataPlanVersion: nil
+        )
+        try store.saveMessage(message)
+        codec.shouldEncode = false
+
+        XCTAssertFalse(try store.saveUploads([upload(uuid: "upload", timestamp: 1)], deleting: [message]))
+        XCTAssertFalse(try store.fetchMessagesForUploading().isEmpty)
+        XCTAssertTrue(try store.fetchUploads().isEmpty)
+    }
+
+    func testAtomicBatchPersistsUploadsAndDeletesMessages() throws {
+        let codec = TestUploadSettingsCodec()
+        let store = MPPersistenceStorePRIVATE(
+            fileSystem: fileSystem,
+            logger: logger,
+            uploadSettingsCodec: codec
+        )
+        let message = MPMessagePRIVATE(
+            sessionId: nil,
+            messageId: 0,
+            uuid: "message",
+            messageType: "e",
+            messageData: Data("{}".utf8),
+            timestamp: 1,
+            uploadStatus: 1,
+            userId: 42,
+            dataPlanId: nil,
+            dataPlanVersion: nil
+        )
+        try store.saveMessage(message)
+
+        XCTAssertTrue(try store.saveUploads([upload(uuid: "upload", timestamp: 1)], deleting: [message]))
+        XCTAssertTrue(try store.fetchMessagesForUploading().isEmpty)
+        XCTAssertEqual(try store.fetchUploads().map(\.uuid), ["upload"])
+    }
+
+    private func upload(uuid: String, timestamp: TimeInterval) -> MPUploadPRIVATE {
+        MPUploadPRIVATE(
+            sessionId: nil,
+            uploadId: 0,
+            uuid: uuid,
+            uploadData: Data(#"{"events":[]}"#.utf8),
+            timestamp: timestamp,
+            uploadType: 0,
+            dataPlanId: nil,
+            dataPlanVersion: nil,
+            uploadSettings: NSObject()
+        )
     }
 }

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		534CD2A029CE2CE1008452B3 /* MParticleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A79C8E29CE019F00E7489F /* MParticleTests.m */; };
 		534CD2A229CE2CE1008452B3 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79CFB29CE046800E7489F /* libsqlite3.tbd */; };
 		B5A001012F5F900000000001 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79CFB29CE046800E7489F /* libsqlite3.tbd */; };
+		B5A004012F5F900000000001 /* MPPersistenceUploadSettingsCodec.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A004022F5F900000000001 /* MPPersistenceUploadSettingsCodec.m */; };
 		534CD2A429CE2CE1008452B3 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79C8829CE019F00E7489F /* OCMock.xcframework */; };
 		534CD2A629CE2CE1008452B3 /* sample_dataplan2.json in Resources */ = {isa = PBXBuildFile; fileRef = 53A79C9829CE019F00E7489F /* sample_dataplan2.json */; };
 		534CD2AC29CE2CF1008452B3 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53A79DC629CE23F700E7489F /* mParticle_Apple_SDK.framework */; };
@@ -336,6 +337,8 @@
 		53A79AB929CDFB1E00E7489F /* MPDatabaseMigrationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDatabaseMigrationController.m; sourceTree = "<group>"; };
 		53A79ABA29CDFB1E00E7489F /* MPDatabaseMigrationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPDatabaseMigrationController.h; sourceTree = "<group>"; };
 		53A79ABB29CDFB1E00E7489F /* MPPersistenceController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPPersistenceController.h; sourceTree = "<group>"; };
+		B5A004022F5F900000000001 /* MPPersistenceUploadSettingsCodec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPPersistenceUploadSettingsCodec.m; sourceTree = "<group>"; };
+		B5A004032F5F900000000001 /* MPPersistenceUploadSettingsCodec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPPersistenceUploadSettingsCodec.h; sourceTree = "<group>"; };
 		53A79ABD29CDFB1E00E7489F /* MParticleUserNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MParticleUserNotification.h; sourceTree = "<group>"; };
 		53A79AC429CDFB1E00E7489F /* MPConsumerInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPConsumerInfo.m; sourceTree = "<group>"; };
 		53A79AC729CDFB1E00E7489F /* MParticleUserNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MParticleUserNotification.m; sourceTree = "<group>"; };
@@ -860,6 +863,8 @@
 				53A79AB829CDFB1E00E7489F /* MPPersistenceController.m */,
 				53A79AB929CDFB1E00E7489F /* MPDatabaseMigrationController.m */,
 				53A79ABA29CDFB1E00E7489F /* MPDatabaseMigrationController.h */,
+				B5A004032F5F900000000001 /* MPPersistenceUploadSettingsCodec.h */,
+				B5A004022F5F900000000001 /* MPPersistenceUploadSettingsCodec.m */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -1556,6 +1561,7 @@
 				53A79D7029CE23F700E7489F /* MPProduct.m in Sources */,
 				35329FF32E54CA78009AC4FD /* MParticleOptions+MParticlePrivate.m in Sources */,
 				53A79D7129CE23F700E7489F /* MPPersistenceController.m in Sources */,
+				B5A004012F5F900000000001 /* MPPersistenceUploadSettingsCodec.m in Sources */,
 				53A79D7329CE23F700E7489F /* FilteredMParticleUser.m in Sources */,
 				53A79D7429CE23F700E7489F /* MPBaseEvent.m in Sources */,
 				53A79D7529CE23F700E7489F /* MPAttributeProjection.m in Sources */,

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceUploadSettingsCodec.h
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceUploadSettingsCodec.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@import mParticle_Apple_SDK_Swift;
+
+@interface MPPersistenceUploadSettingsCodec : NSObject <MPUploadSettingsCoding>
+@end

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceUploadSettingsCodec.m
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceUploadSettingsCodec.m
@@ -1,0 +1,26 @@
+#import "MPPersistenceUploadSettingsCodec.h"
+#import "MPUploadSettings.h"
+
+@implementation MPPersistenceUploadSettingsCodec
+
+- (NSData *)archiveUploadSettings:(NSObject *)settings {
+    if (![settings isKindOfClass:[MPUploadSettings class]]) {
+        return nil;
+    }
+
+    NSError *error = nil;
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:settings
+                                        requiringSecureCoding:YES
+                                                        error:&error];
+    return error == nil ? data : nil;
+}
+
+- (NSObject *)unarchiveUploadSettings:(NSData *)data {
+    NSError *error = nil;
+    MPUploadSettings *settings = [NSKeyedUnarchiver unarchivedObjectOfClass:[MPUploadSettings class]
+                                                                   fromData:data
+                                                                      error:&error];
+    return error == nil ? settings : nil;
+}
+
+@end


### PR DESCRIPTION
## Background
- Upload creation and message deletion must remain atomic to prevent duplicate batches or lost events. Historical MPUploadSettings archives must also retain their Objective-C runtime identity.

## What Has Changed
- Ported upload save, fetch, ordering, deletion, and atomic batching to Swift.
- Added an Objective-C secure-coding boundary for MPUploadSettings.
- Preserved rollback, upload limits, ordering, opt-out behavior, and legacy archive compatibility.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
