### PR TITLE
refactor: port peripheral persistence and migration

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPDatabaseMigrator.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPDatabaseMigrator.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+final class MPDatabaseMigratorPRIVATE {
+    private let databaseVersions: [NSNumber]
+    private let fileSystem: MPPersistenceFileSystemPRIVATE
+    private let logger: MPLog
+    private let uploadSettingsProvider: () -> NSObject?
+    private let uploadSettingsCodec: MPUploadSettingsCoding
+
+    init(
+        databaseVersions: [NSNumber],
+        fileSystem: MPPersistenceFileSystemPRIVATE,
+        logger: MPLog,
+        uploadSettingsProvider: @escaping () -> NSObject?,
+        uploadSettingsCodec: MPUploadSettingsCoding
+    ) {
+        self.databaseVersions = databaseVersions
+        self.fileSystem = fileSystem
+        self.logger = logger
+        self.uploadSettingsProvider = uploadSettingsProvider
+        self.uploadSettingsCodec = uploadSettingsCodec
+    }
+
+    func versionNeedingMigration() -> NSNumber? {
+        fileSystem.versionNeedingMigration(from: databaseVersions as NSArray)
+    }
+
+    func migrate(from oldVersion: NSNumber, deleteOldDatabase: Bool = true) throws {
+        guard let currentVersion = databaseVersions.last,
+              let oldPath = fileSystem.existingPath(
+                  forDatabaseName: MPPersistenceSchemaPRIVATE.databaseName(for: oldVersion)
+              )
+        else {
+            return
+        }
+        let currentPath = fileSystem.resolvedDatabasePath(
+            databaseName: MPPersistenceSchemaPRIVATE.databaseName(for: currentVersion)
+        )
+        let current = try MPSQLiteConnection(path: currentPath, logger: logger)
+        try createCurrentSchema(in: current, version: currentVersion)
+        let old = try MPSQLiteConnection(path: oldPath, logger: logger)
+        try deleteExpiredRecords(in: old)
+
+        try current.transaction {
+            try migrateSessions(from: old, to: current)
+            try migrateMessages(from: old, to: current)
+            try migrateUploads(from: old, to: current)
+            try migrateForwardRecords(from: old, to: current)
+            try migrateConsumerInfo(from: old, to: current)
+            try migrateCookies(from: old, to: current)
+            try migrateIntegrationAttributes(from: old, to: current)
+        }
+        old.close()
+        current.close()
+        if deleteOldDatabase {
+            fileSystem.removeDatabaseFileIfExists(atPath: oldPath)
+        }
+    }
+
+    private func createCurrentSchema(in database: MPSQLiteConnection, version: NSNumber) throws {
+        for sql in MPPersistenceSchemaPRIVATE.createTableStatements {
+            if let sql = sql as? String {
+                try database.execute(sql)
+            }
+        }
+        try database.execute(MPPersistenceSchemaPRIVATE.userVersionPragma(for: version))
+    }
+
+    private func deleteExpiredRecords(in database: MPSQLiteConnection) throws {
+        let cutoff = Date().timeIntervalSince1970 - MPPersistenceSchemaPRIVATE.sevenDays
+        try database.transaction {
+            for sql in MPDatabaseMigrationLogicPRIVATE.deleteRecordsOlderThanStatements {
+                guard let sql = sql as? String else {
+                    continue
+                }
+                let statement = try database.prepare(sql)
+                try statement.bind(cutoff, at: 1)
+                _ = try statement.step()
+            }
+        }
+    }
+
+    private func migrateSessions(from old: MPSQLiteConnection, to current: MPSQLiteConnection) throws {
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateSessionsSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateSessionsInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.string(at: 0), at: 1)
+            try insert.bind(select.double(at: 5), at: 2)
+            try insert.bind(select.double(at: 1), at: 3)
+            try insert.bind(select.double(at: 2), at: 4)
+            try insert.bind(select.data(at: 3), at: 5)
+            try insert.bind(Int64(0), at: 6)
+            try insert.bind(select.int(at: 6), at: 7)
+            try insert.bind(select.int(at: 7), at: 8)
+            try insert.bind(select.double(at: 8), at: 9)
+            try insert.bind(select.double(at: 9), at: 10)
+            try insert.bind(select.int64(at: 10), at: 11)
+            try insert.bind(select.string(at: 11), at: 12)
+            try insert.bind(select.data(at: 12), at: 13)
+            try insert.bind(select.data(at: 13), at: 14)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func migrateMessages(from old: MPSQLiteConnection, to current: MPSQLiteConnection) throws {
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateMessagesSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateMessagesInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.string(at: 0), at: 1)
+            try bindNullableInt64(from: select, column: 1, to: insert, index: 2)
+            try insert.bind(select.string(at: 2), at: 3)
+            try insert.bind(select.double(at: 3), at: 4)
+            try insert.bind(select.data(at: 4), at: 5)
+            try insert.bind(select.int(at: 5), at: 6)
+            try insert.bind(select.string(at: 6), at: 7)
+            try bindNullableInt64(from: select, column: 7, to: insert, index: 8)
+            try insert.bind(select.int64(at: 8), at: 9)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func migrateUploads(from old: MPSQLiteConnection, to current: MPSQLiteConnection) throws {
+        guard let settings = uploadSettingsProvider(),
+              let settingsData = uploadSettingsCodec.archiveUploadSettings(settings)
+        else {
+            return
+        }
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateUploadsSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateUploadsInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.string(at: 0), at: 1)
+            try insert.bind(select.data(at: 1), at: 2)
+            try insert.bind(select.double(at: 2), at: 3)
+            try bindNullableInt64(from: select, column: 3, to: insert, index: 4)
+            try insert.bind(select.int64(at: 4), at: 5)
+            try insert.bind(select.string(at: 5), at: 6)
+            try bindNullableInt64(from: select, column: 6, to: insert, index: 7)
+            try insert.bind(settingsData, at: 8)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func migrateForwardRecords(
+        from old: MPSQLiteConnection,
+        to current: MPSQLiteConnection
+    ) throws {
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateForwardingRecordsSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateForwardingRecordsInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.int64(at: 0), at: 1)
+            try insert.bind(select.data(at: 1), at: 2)
+            try insert.bind(select.int64(at: 2), at: 3)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func migrateConsumerInfo(from old: MPSQLiteConnection, to current: MPSQLiteConnection) throws {
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateConsumerInfoSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateConsumerInfoInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.int64(at: 0), at: 1)
+            try insert.bind(select.int64(at: 1), at: 2)
+            try insert.bind(select.string(at: 2), at: 3)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func migrateCookies(from old: MPSQLiteConnection, to current: MPSQLiteConnection) throws {
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateCookiesSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateCookiesInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.int64(at: 0), at: 1)
+            try insert.bind(select.int64(at: 1), at: 2)
+            try insert.bind(select.string(at: 2), at: 3)
+            try insert.bind(select.string(at: 3), at: 4)
+            try insert.bind(select.string(at: 4), at: 5)
+            try insert.bind(select.string(at: 5), at: 6)
+            try insert.bind(select.int64(at: 6), at: 7)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func migrateIntegrationAttributes(
+        from old: MPSQLiteConnection,
+        to current: MPSQLiteConnection
+    ) throws {
+        let select = try old.prepare(MPDatabaseMigrationLogicPRIVATE.migrateIntegrationAttributesSelectSQL)
+        let insert = try current.prepare(MPDatabaseMigrationLogicPRIVATE.migrateIntegrationAttributesInsertSQL)
+        while try select.step() == .row {
+            try insert.bind(select.int64(at: 0), at: 1)
+            try insert.bind(select.int(at: 1), at: 2)
+            try insert.bind(select.data(at: 2), at: 3)
+            _ = try insert.step()
+            try insert.reset()
+        }
+    }
+
+    private func bindNullableInt64(
+        from source: MPSQLiteStatement,
+        column: Int32,
+        to destination: MPSQLiteStatement,
+        index: Int32
+    ) throws {
+        if source.isNull(at: column) || source.int64(at: column) == 0 {
+            try destination.bindNull(at: index)
+        } else {
+            try destination.bind(source.int64(at: column), at: index)
+        }
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceStore+Peripheral.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceStore+Peripheral.swift
@@ -1,0 +1,250 @@
+import Foundation
+import SQLite3
+
+struct MPPersistedCookie: Equatable {
+    let id: Int64
+    let consumerInfoId: Int64
+    let content: String?
+    let domain: String?
+    let expiration: String?
+    let name: String
+    let mpid: Int64
+}
+
+struct MPPersistedConsumerInfo: Equatable {
+    let id: Int64
+    let mpid: Int64
+    let uniqueIdentifier: String?
+    let cookies: [MPPersistedCookie]
+}
+
+extension MPPersistenceStorePRIVATE {
+    func saveForwardRecord(_ record: MPForwardRecordPRIVATE) throws {
+        guard let data = record.dataRepresentation() else {
+            return
+        }
+        let statement = try requireConnection().prepare(
+            "INSERT INTO forwarding_records (forwarding_data, mpid) VALUES (?, ?)"
+        )
+        try statement.bind(data, at: 1)
+        try statement.bind(record.mpid.int64Value, at: 2)
+        _ = try statement.step()
+        record.forwardRecordId = UInt64(sqlite3_last_insert_rowid(try requireConnection().handle))
+    }
+
+    func fetchForwardRecords() throws -> [MPForwardRecordPRIVATE] {
+        let statement = try requireConnection().prepare(
+            "SELECT _id, forwarding_data, mpid FROM forwarding_records ORDER BY _id"
+        )
+        var records: [MPForwardRecordPRIVATE] = []
+        while try statement.step() == .row {
+            guard let data = statement.data(at: 1),
+                  let record = MPForwardRecordPRIVATE(
+                      recordId: statement.int64(at: 0),
+                      data: data,
+                      mpid: NSNumber(value: statement.int64(at: 2))
+                  )
+            else {
+                continue
+            }
+            records.append(record)
+        }
+        return records
+    }
+
+    func deleteForwardRecords(ids: [NSNumber]) throws {
+        guard !ids.isEmpty else {
+            return
+        }
+        let values = ids.map(\.int64Value).map(String.init).joined(separator: ",")
+        try requireConnection().execute(
+            "DELETE FROM forwarding_records WHERE _id IN (\(values))"
+        )
+    }
+
+    func saveIntegrationAttributes(_ attributes: MPIntegrationAttributesPRIVATE) throws {
+        try deleteIntegrationAttributes(for: attributes.integrationId)
+        guard JSONSerialization.isValidJSONObject(attributes.attributes),
+              let data = try? JSONSerialization.data(withJSONObject: attributes.attributes)
+        else {
+            return
+        }
+        let statement = try requireConnection().prepare(
+            "INSERT INTO integration_attributes (kit_code, attributes_data) VALUES (?, ?)"
+        )
+        try statement.bind(attributes.integrationId.int32Value, at: 1)
+        try statement.bind(data, at: 2)
+        _ = try statement.step()
+    }
+
+    func fetchIntegrationAttributes() throws -> [MPIntegrationAttributesPRIVATE] {
+        let statement = try requireConnection().prepare(
+            "SELECT kit_code, attributes_data FROM integration_attributes"
+        )
+        var attributes: [MPIntegrationAttributesPRIVATE] = []
+        while try statement.step() == .row {
+            guard let data = statement.data(at: 1),
+                  let value = MPIntegrationAttributesPRIVATE(
+                      integrationId: NSNumber(value: statement.int(at: 0)),
+                      attributesData: data
+                  )
+            else {
+                continue
+            }
+            attributes.append(value)
+        }
+        return attributes
+    }
+
+    func fetchIntegrationAttributes(for integrationId: NSNumber) throws -> NSDictionary? {
+        let statement = try requireConnection().prepare(
+            "SELECT attributes_data FROM integration_attributes WHERE kit_code = ?"
+        )
+        try statement.bind(integrationId.int32Value, at: 1)
+        guard try statement.step() == .row,
+              let data = statement.data(at: 0),
+              let value = MPIntegrationAttributesPRIVATE(
+                  integrationId: integrationId,
+                  attributesData: data
+              )
+        else {
+            return nil
+        }
+        return value.attributes
+    }
+
+    func deleteIntegrationAttributes(for integrationId: NSNumber) throws {
+        let statement = try requireConnection().prepare(
+            "DELETE FROM integration_attributes WHERE kit_code = ?"
+        )
+        try statement.bind(integrationId.int32Value, at: 1)
+        _ = try statement.step()
+    }
+
+    func deleteAllIntegrationAttributes() throws {
+        try requireConnection().execute("DELETE FROM integration_attributes")
+    }
+
+    func saveConsumerInfo(
+        mpid: NSNumber,
+        uniqueIdentifier: String?,
+        cookies: [MPPersistedCookie]
+    ) throws -> Int64 {
+        let connection = try requireConnection()
+        return try connection.transaction {
+            let statement = try connection.prepare(
+                "INSERT INTO consumer_info (mpid, unique_identifier) VALUES (?, ?)"
+            )
+            try statement.bind(mpid.int64Value, at: 1)
+            try statement.bind(uniqueIdentifier, at: 2)
+            _ = try statement.step()
+            let consumerInfoId = sqlite3_last_insert_rowid(connection.handle)
+            for cookie in cookies {
+                try saveCookie(cookie, consumerInfoId: consumerInfoId, mpid: mpid.int64Value)
+            }
+            return consumerInfoId
+        }
+    }
+
+    func fetchConsumerInfo(for mpid: NSNumber) throws -> MPPersistedConsumerInfo? {
+        let connection = try requireConnection()
+        let info = try connection.prepare(
+            "SELECT _id, mpid, unique_identifier FROM consumer_info WHERE mpid = ? ORDER BY _id LIMIT 1"
+        )
+        try info.bind(mpid.int64Value, at: 1)
+        guard try info.step() == .row else {
+            return nil
+        }
+        return MPPersistedConsumerInfo(
+            id: info.int64(at: 0),
+            mpid: info.int64(at: 1),
+            uniqueIdentifier: info.string(at: 2),
+            cookies: try fetchCookies(for: mpid)
+        )
+    }
+
+    func fetchCookies(for mpid: NSNumber) throws -> [MPPersistedCookie] {
+        let statement = try requireConnection().prepare(
+            "SELECT _id, consumer_info_id, content, domain, expiration, name, mpid "
+                + "FROM cookies WHERE mpid = ? ORDER BY _id"
+        )
+        try statement.bind(mpid.int64Value, at: 1)
+        var cookies: [MPPersistedCookie] = []
+        while try statement.step() == .row {
+            cookies.append(MPPersistedCookie(
+                id: statement.int64(at: 0),
+                consumerInfoId: statement.int64(at: 1),
+                content: statement.string(at: 2),
+                domain: statement.string(at: 3),
+                expiration: statement.string(at: 4),
+                name: statement.string(at: 5) ?? "",
+                mpid: statement.int64(at: 6)
+            ))
+        }
+        return cookies
+    }
+
+    func deleteConsumerInfo() throws {
+        let connection = try requireConnection()
+        try connection.transaction {
+            try connection.execute("DELETE FROM cookies")
+            try connection.execute("DELETE FROM consumer_info")
+        }
+    }
+
+    func moveDatabaseContentFromMpidZero(to mpid: NSNumber) throws {
+        let connection = try requireConnection()
+        try connection.transaction {
+            for table in MPPersistenceSchemaPRIVATE.mpidKeyedTableNames {
+                guard let table = table as? String else {
+                    continue
+                }
+                let statement = try connection.prepare(
+                    MPPersistenceSchemaPRIVATE.sqlUpdatingMpid(forTable: table)
+                )
+                try statement.bind(mpid.int64Value, at: 1)
+                _ = try statement.step()
+            }
+        }
+    }
+
+    private func saveCookie(
+        _ cookie: MPPersistedCookie,
+        consumerInfoId: Int64,
+        mpid: Int64
+    ) throws {
+        let statement = try requireConnection().prepare(
+            "INSERT INTO cookies "
+                + "(consumer_info_id, content, domain, expiration, name, mpid) "
+                + "VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        try statement.bind(consumerInfoId, at: 1)
+        try statement.bind(cookie.content, at: 2)
+        try statement.bind(cookie.domain, at: 3)
+        try statement.bind(cookie.expiration, at: 4)
+        try statement.bind(cookie.name, at: 5)
+        try statement.bind(mpid, at: 6)
+        _ = try statement.step()
+    }
+}
+
+final class MPPersistenceUserDefaultsMigrator {
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func moveContentFromMpidZero(to mpid: NSNumber) {
+        let dictionary = userDefaults.dictionaryRepresentation()
+        for (key, value) in dictionary where key.hasPrefix("mParticle::0") {
+            guard let newKey = MPPersistenceSchemaPRIVATE.remappedUserDefaultsKey(key, mpid: mpid) else {
+                continue
+            }
+            if dictionary[newKey] == nil {
+                userDefaults.set(value, forKey: newKey)
+            }
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceUserDefaultsStore.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceUserDefaultsStore.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+protocol MPPersistenceKeyValueStorage: AnyObject {
+    func mpObject(forKey key: String, userId: NSNumber) -> Any?
+    func setMPObject(_ value: Any?, forKey key: String, userId: NSNumber)
+    func removeMPObject(forKey key: String, userId: NSNumber)
+    func synchronize()
+}
+
+extension MPUserDefaults: MPPersistenceKeyValueStorage {}
+
+final class MPPersistenceConsentStringStore {
+    private enum Keys {
+        static let userConsent = "consent_state"
+        static let deviceConsent = "device_consent_state"
+    }
+
+    private let storage: MPPersistenceKeyValueStorage
+
+    init(storage: MPPersistenceKeyValueStorage) {
+        self.storage = storage
+    }
+
+    func consentString(forMpid mpid: NSNumber) -> String? {
+        storage.mpObject(forKey: Keys.userConsent, userId: mpid) as? String
+    }
+
+    func setConsentString(_ value: String?, forMpid mpid: NSNumber) {
+        set(value, key: Keys.userConsent, userId: mpid)
+    }
+
+    func deviceConsentString() -> String? {
+        storage.mpObject(forKey: Keys.deviceConsent, userId: 0) as? String
+    }
+
+    func setDeviceConsentString(_ value: String?) {
+        set(value, key: Keys.deviceConsent, userId: 0)
+    }
+
+    func effectiveConsentString(forMpid mpid: NSNumber?) -> String? {
+        if let device = deviceConsentString() {
+            return device
+        }
+        return mpid.flatMap(consentString(forMpid:))
+    }
+
+    private func set(_ value: String?, key: String, userId: NSNumber) {
+        if let value {
+            storage.setMPObject(value, forKey: key, userId: userId)
+        } else {
+            storage.removeMPObject(forKey: key, userId: userId)
+        }
+        storage.synchronize()
+    }
+}

--- a/mParticle-Apple-SDK-Swift/Test/Persistence/MPPersistenceStoreTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Persistence/MPPersistenceStoreTests.swift
@@ -14,6 +14,27 @@ private final class TestUploadSettingsCodec: NSObject, MPUploadSettingsCoding {
     }
 }
 
+private final class TestPersistenceKeyValueStorage: MPPersistenceKeyValueStorage {
+    var values: [String: Any] = [:]
+    private(set) var synchronizeCount = 0
+
+    func mpObject(forKey key: String, userId: NSNumber) -> Any? {
+        values["\(userId)::\(key)"]
+    }
+
+    func setMPObject(_ value: Any?, forKey key: String, userId: NSNumber) {
+        values["\(userId)::\(key)"] = value
+    }
+
+    func removeMPObject(forKey key: String, userId: NSNumber) {
+        values.removeValue(forKey: "\(userId)::\(key)")
+    }
+
+    func synchronize() {
+        synchronizeCount += 1
+    }
+}
+
 final class MPPersistenceStoreTests: XCTestCase {
     private var rootDirectory: URL!
     private var logger: MPLog!
@@ -415,6 +436,157 @@ final class MPPersistenceStoreTests: XCTestCase {
         XCTAssertTrue(try store.saveUploads([upload(uuid: "upload", timestamp: 1)], deleting: [message]))
         XCTAssertTrue(try store.fetchMessagesForUploading().isEmpty)
         XCTAssertEqual(try store.fetchUploads().map(\.uuid), ["upload"])
+    }
+
+    func testForwardRecordsAndIntegrationAttributesRoundTrip() throws {
+        let store = MPPersistenceStorePRIVATE(fileSystem: fileSystem, logger: logger)
+        let record = MPForwardRecordPRIVATE(
+            recordId: 0,
+            dataDictionary: ["timestamp": 1],
+            mpid: 42
+        )
+        try store.saveForwardRecord(record)
+        XCTAssertNotEqual(record.forwardRecordId, 0)
+        XCTAssertEqual(try store.fetchForwardRecords().first?.mpid, 42)
+
+        let attributes = try XCTUnwrap(MPIntegrationAttributesPRIVATE(
+            integrationId: 7,
+            attributes: ["key": "value"]
+        ))
+        try store.saveIntegrationAttributes(attributes)
+        XCTAssertEqual(
+            try store.fetchIntegrationAttributes(for: 7)?["key"] as? String,
+            "value"
+        )
+
+        try store.deleteForwardRecords(ids: [NSNumber(value: record.forwardRecordId)])
+        try store.deleteIntegrationAttributes(for: 7)
+        XCTAssertTrue(try store.fetchForwardRecords().isEmpty)
+        XCTAssertTrue(try store.fetchIntegrationAttributes().isEmpty)
+    }
+
+    func testConsumerInfoAndCookiesRoundTrip() throws {
+        let store = MPPersistenceStorePRIVATE(fileSystem: fileSystem, logger: logger)
+        let cookie = MPPersistedCookie(
+            id: 0,
+            consumerInfoId: 0,
+            content: "content",
+            domain: "example.com",
+            expiration: nil,
+            name: "cookie",
+            mpid: 42
+        )
+
+        let id = try store.saveConsumerInfo(
+            mpid: 42,
+            uniqueIdentifier: "identifier",
+            cookies: [cookie]
+        )
+        let fetched = try XCTUnwrap(store.fetchConsumerInfo(for: 42))
+        XCTAssertEqual(fetched.id, id)
+        XCTAssertEqual(fetched.uniqueIdentifier, "identifier")
+        XCTAssertEqual(fetched.cookies.first?.name, "cookie")
+
+        try store.deleteConsumerInfo()
+        XCTAssertNil(try store.fetchConsumerInfo(for: 42))
+        XCTAssertTrue(try store.fetchCookies(for: 42).isEmpty)
+    }
+
+    func testMovesDatabaseContentFromMpidZero() throws {
+        let store = MPPersistenceStorePRIVATE(fileSystem: fileSystem, logger: logger)
+        let connection = try XCTUnwrap(store.connection)
+        try connection.execute(
+            "INSERT INTO messages (message_type, uuid, timestamp, message_data, mpid) "
+                + "VALUES ('e', 'message', 1, X'01', 0)"
+        )
+
+        try store.moveDatabaseContentFromMpidZero(to: 42)
+
+        let mpid = try connection.prepare("SELECT mpid FROM messages")
+        XCTAssertEqual(try mpid.step(), .row)
+        XCTAssertEqual(mpid.int64(at: 0), 42)
+    }
+
+    func testConsentStringStoragePrefersDeviceConsent() {
+        let storage = TestPersistenceKeyValueStorage()
+        let consent = MPPersistenceConsentStringStore(storage: storage)
+
+        consent.setConsentString("user", forMpid: 42)
+        XCTAssertEqual(consent.effectiveConsentString(forMpid: 42), "user")
+        consent.setDeviceConsentString("device")
+        XCTAssertEqual(consent.effectiveConsentString(forMpid: 42), "device")
+        consent.setDeviceConsentString(nil)
+        XCTAssertEqual(consent.effectiveConsentString(forMpid: 42), "user")
+        XCTAssertEqual(storage.synchronizeCount, 3)
+    }
+
+    func testUserDefaultsMpidZeroMigrationDoesNotOverwriteDestination() throws {
+        let suiteName = "MPPersistenceStoreTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("source", forKey: "mParticle::0::source")
+        defaults.set("existing", forKey: "mParticle::42::existing")
+        defaults.set("ignored", forKey: "other::0::value")
+
+        MPPersistenceUserDefaultsMigrator(userDefaults: defaults)
+            .moveContentFromMpidZero(to: 42)
+
+        XCTAssertEqual(defaults.string(forKey: "mParticle::42::source"), "source")
+        XCTAssertEqual(defaults.string(forKey: "mParticle::42::existing"), "existing")
+        XCTAssertNil(defaults.object(forKey: "mParticle::0::source"))
+        XCTAssertEqual(defaults.string(forKey: "other::0::value"), "ignored")
+    }
+
+    func testMigratesVersion30RowsAndPurgesExpiredRecords() throws {
+        let oldName = MPPersistenceSchemaPRIVATE.databaseName(for: 30)
+        let oldPath = fileSystem.resolvedDatabasePath(databaseName: oldName)
+        let old = try MPSQLiteConnection(path: oldPath, logger: logger)
+        for sql in MPPersistenceSchemaPRIVATE.createTableStatements {
+            try old.execute(try XCTUnwrap(sql as? String))
+        }
+        try old.execute("DROP TABLE uploads")
+        try old.execute(
+            "CREATE TABLE uploads ("
+                + "_id INTEGER PRIMARY KEY AUTOINCREMENT, session_id INTEGER, uuid TEXT NOT NULL, "
+                + "message_data BLOB NOT NULL, timestamp REAL NOT NULL, upload_type INTEGER NOT NULL, "
+                + "data_plan_id TEXT, data_plan_version INTEGER)"
+        )
+        let freshTimestamp = Date().timeIntervalSince1970
+        let staleTimestamp = freshTimestamp - MPPersistenceSchemaPRIVATE.sevenDays - 1
+        try old.execute(
+            "INSERT INTO messages (message_type, uuid, timestamp, message_data, upload_status, mpid) "
+                + "VALUES ('e', 'fresh', \(freshTimestamp), X'7B7D', 1, 42), "
+                + "('e', 'stale', \(staleTimestamp), X'7B7D', 1, 42)"
+        )
+        try old.execute(
+            "INSERT INTO uploads (uuid, message_data, timestamp, upload_type) "
+                + "VALUES ('upload', X'7B7D', \(freshTimestamp), 0)"
+        )
+        try old.execute(MPPersistenceSchemaPRIVATE.userVersionPragma(for: 30))
+        old.close()
+
+        let codec = TestUploadSettingsCodec()
+        let migrator = MPDatabaseMigratorPRIVATE(
+            databaseVersions: [30, 31],
+            fileSystem: fileSystem,
+            logger: logger,
+            uploadSettingsProvider: { NSObject() },
+            uploadSettingsCodec: codec
+        )
+        XCTAssertEqual(migrator.versionNeedingMigration(), 30)
+
+        try migrator.migrate(from: 30)
+
+        let store = MPPersistenceStorePRIVATE(
+            fileSystem: fileSystem,
+            logger: logger,
+            mpidProvider: { 42 },
+            uploadSettingsCodec: codec
+        )
+        let messages = try store.fetchMessagesForUploading()
+        XCTAssertEqual(messages[42]?[-1]?["0"]?[0]?.map(\.uuid), ["fresh"])
+        XCTAssertEqual(try store.fetchUploads().map(\.uuid), ["upload"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldPath))
     }
 
     private func upload(uuid: String, timestamp: TimeInterval) -> MPUploadPRIVATE {


### PR DESCRIPTION
## Background
- Remaining peripheral tables and v30-to-v31 database migration must move before production persistence can cut over fully to Swift.

## What Has Changed
- Ported forward records, integration attributes, consumer information, cookies, MPID remapping, and consent storage.
- Added the Swift v30-to-v31 migration orchestrator.
- Preserved the seven-day migration purge and existing on-disk formats.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
