### PR TITLE
refactor: inject backend persistence protocols

### DIFF
--- a/UnitTests/ObjCTests/MPBackendControllerTests.m
+++ b/UnitTests/ObjCTests/MPBackendControllerTests.m
@@ -84,6 +84,8 @@
 - (void)processDidFinishLaunching:(NSNotification *)notification;
 - (void)beginBackgroundTask;
 - (void)endBackgroundTask;
+- (instancetype)initWithDelegate:(id<MPBackendControllerDelegate>)delegate
+                     persistence:(id<MPBackendPersistence>)persistence;
 - (void)beginBackgroundTimeCheckLoop;
 - (void)cancelBackgroundTimeCheckLoop;
 - (void)endSessionIfTimedOut;
@@ -2320,15 +2322,15 @@
     options.persistenceMaxAgeSeconds = @(maxAge); // 24 hours
     instance.options = options;
     
-    MPBackendController_PRIVATE *backendController = [[MPBackendController_PRIVATE alloc] init];
-    MPPersistenceController_PRIVATE *persistenceController = [[MPPersistenceController_PRIVATE alloc] init];
-    id mockPersistenceController = OCMPartialMock(persistenceController);
+    id mockPersistenceController = OCMProtocolMock(@protocol(MPBackendPersistence));
+    MPBackendController_PRIVATE *backendController =
+        [[MPBackendController_PRIVATE alloc] initWithDelegate:nil
+                                                 persistence:mockPersistenceController];
     
     NSTimeInterval currentTime = [[NSDate date] timeIntervalSince1970];
     [[mockPersistenceController expect] deleteRecordsOlderThan:(currentTime - maxAge)];
     
     instance.backendController = backendController;
-    instance.persistenceController = mockPersistenceController;
     
     [instance.backendController cleanUp:currentTime];
     

--- a/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceProtocols.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/Persistence/MPPersistenceProtocols.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+@objc public protocol MPPersistenceLifecycle {
+    @objc(isDatabaseOpen) func objectiveCDatabaseOpen() -> Bool
+    @objc(openDatabase) func objectiveCOpenDatabase() -> Bool
+    @objc(closeDatabase) func objectiveCCloseDatabase() -> Bool
+    @objc(purgeMemory) func objectiveCPurgeMemory()
+    @objc(deleteRecordsOlderThan:) func objectiveCDeleteRecords(olderThan timestamp: TimeInterval)
+}
+
+@objc public protocol MPSessionPersistence {
+    @objc(saveSession:) func objectiveCSaveSession(_ session: MPSessionPRIVATE)
+    @objc(updateSession:) func objectiveCUpdateSession(_ session: MPSessionPRIVATE)
+    @objc(fetchSessions) func objectiveCFetchSessions() -> NSMutableArray?
+    @objc(fetchPossibleSessionsFromCrash) func objectiveCFetchPossibleSessionsFromCrash() -> NSArray?
+    @objc(archiveSession:) func objectiveCArchiveSession(_ session: MPSessionPRIVATE) -> MPSessionPRIVATE?
+    @objc(fetchPreviousSession) func objectiveCFetchPreviousSession() -> MPSessionPRIVATE?
+    @objc(deletePreviousSession) func objectiveCDeletePreviousSession()
+    @objc(deleteSession:) func objectiveCDeleteSession(_ session: MPSessionPRIVATE)
+    @objc(deleteAllSessionsExcept:) func objectiveCDeleteAllSessions(except session: MPSessionPRIVATE?)
+    @objc(appAndDeviceInfoForSessionId:)
+    func objectiveCAppAndDeviceInfo(forSessionId sessionId: NSNumber) -> NSDictionary
+}
+
+@objc public protocol MPMessagePersistence {
+    @objc(saveMessage:) func objectiveCSaveMessage(_ message: MPMessagePRIVATE)
+    @objc(deleteMessages:) func objectiveCDeleteMessages(_ messages: [MPMessagePRIVATE])
+    @objc(deleteNetworkPerformanceMessages) func objectiveCDeleteNetworkPerformanceMessages()
+    @objc(fetchMessagesForUploading) func objectiveCFetchMessagesForUploading() -> NSMutableDictionary?
+    @objc(fetchSessionEndMessageInSession:)
+    func objectiveCFetchSessionEndMessage(in session: MPSessionPRIVATE) -> MPMessagePRIVATE?
+    @objc(fetchUploadedMessagesInSession:)
+    func objectiveCFetchUploadedMessages(in session: MPSessionPRIVATE) -> NSArray?
+    @objc(saveBreadcrumb:) func objectiveCSaveBreadcrumb(_ message: MPMessagePRIVATE)
+    @objc(fetchBreadcrumbs) func objectiveCFetchBreadcrumbs() -> NSArray?
+}
+
+@objc public protocol MPUploadPersistence {
+    @objc(saveUpload:optedOut:)
+    func objectiveCSaveUpload(_ upload: MPUploadPRIVATE, optedOut: Bool)
+    @objc(fetchUploads) func objectiveCFetchUploads() -> NSArray?
+    @objc(deleteUpload:) func objectiveCDeleteUpload(_ upload: MPUploadPRIVATE)
+    @objc(deleteUploadId:) func objectiveCDeleteUpload(id: Int64)
+    @objc(saveUploads:deleteMessages:optedOut:)
+    func objectiveCSaveUploads(
+        _ uploads: [MPUploadPRIVATE],
+        deleteMessages messages: [MPMessagePRIVATE],
+        optedOut: Bool
+    ) -> Bool
+}
+
+@objc public protocol MPBackendPersistence:
+    MPPersistenceLifecycle,
+    MPSessionPersistence,
+    MPMessagePersistence,
+    MPUploadPersistence {}
+
+extension MPPersistenceStorePRIVATE: MPBackendPersistence {}

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -55,6 +55,10 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
 
 @end
 
+@interface MPPersistenceController_PRIVATE ()
+@property (nonatomic, strong, readonly) MPPersistenceStorePRIVATE *store;
+@end
+
 @interface MPBackendController_PRIVATE() {
     NSTimeInterval nextCleanUpTime;
     MParticleSession *tempSession;
@@ -68,6 +72,7 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
 @property UIBackgroundTaskIdentifier backendBackgroundTaskIdentifier;
 @property NSOperationQueue *backgroundCheckQueue;
 @property NSNumber *previousForegroundTime;
+@property (nonatomic, strong) id<MPBackendPersistence> persistence;
 
 @end
 
@@ -81,8 +86,15 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
 #endif
 
 - (instancetype)initWithDelegate:(id<MPBackendControllerDelegate>)delegate {
+    return [self initWithDelegate:delegate
+                     persistence:[MParticle sharedInstance].persistenceController.store];
+}
+
+- (instancetype)initWithDelegate:(id<MPBackendControllerDelegate>)delegate
+                     persistence:(id<MPBackendPersistence>)persistence {
     self = [super init];
     if (self) {
+        _persistence = persistence;
         _networkCommunication = [[MPNetworkCommunication_PRIVATE alloc] init];
 #if TARGET_OS_IOS == 1
         _notificationController = [[MPNotificationController_PRIVATE alloc] init];
@@ -1278,7 +1290,10 @@ static BOOL skipNextUpload = NO;
     
     dispatch_async([MParticle messageQueue], ^{
         MPILogDebug(@"Creating persistence controller");
-        [MParticle sharedInstance].persistenceController = [[MPPersistenceController_PRIVATE alloc] init];
+        MPPersistenceController_PRIVATE *persistenceController =
+            [[MPPersistenceController_PRIVATE alloc] init];
+        [MParticle sharedInstance].persistenceController = persistenceController;
+        self.persistence = persistenceController.store;
         
         // Check if we've switched workspaces on startup
         MPUploadSettings *lastUploadSettings = [UploadSettingsUtils lastUploadSettingsWithUserDefaults: MPUserDefaultsConnector.userDefaults];
@@ -1771,17 +1786,16 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)cleanUp:(NSTimeInterval)currentTime {
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
     MPCleanUpPlan *plan = [MPSessionTimingPolicy cleanUpPlanWithNow:currentTime
                                                    nextCleanUpTime:nextCleanUpTime
                                                      maxAgeSeconds:[MParticle sharedInstance].persistenceMaxAgeSeconds
                                                      defaultMaxAge:NINETY_DAYS
                                                           interval:TWENTY_FOUR_HOURS];
     if (plan) {
-        [persistence deleteRecordsOlderThan:plan.deleteRecordsOlderThan];
+        [self.persistence deleteRecordsOlderThan:plan.deleteRecordsOlderThan];
         nextCleanUpTime = plan.nextCleanUpTime;
     }
-    [persistence purgeMemory];
+    [self.persistence purgeMemory];
     MPIdentityCaching *identityCaching = [[MPIdentityCaching alloc] initWithUserDefaults:MPUserDefaultsConnector.userDefaults
                                                                                   logger:MParticle.sharedInstance.getLogger];
     [identityCaching clearExpiredCache];


### PR DESCRIPTION
## Background
- MPBackendController accesses persistence through global singleton state, making migration and focused testing difficult. Protocol injection is needed before migrating backend call paths.

## What Has Changed
- Added Objective-C-visible Swift persistence protocols.
- Injected persistence into MPBackendController.
- Migrated cleanup and retention operations to the injected Swift store.
- Updated backend tests to use protocol mocks.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
