### PR TITLE
refactor: inject upload and crash persistence

### DIFF
--- a/UnitTests/ObjCTests/MPBackendControllerTests.m
+++ b/UnitTests/ObjCTests/MPBackendControllerTests.m
@@ -1679,6 +1679,32 @@
     XCTAssertEqual(messages.count, 1, @"The Opt Out Message wasn't saved.");
 }
 
+- (void)testPrepareBatchesSuppressesMessagesQueuedBeforeOptOut {
+    [MPPersistenceController_PRIVATE setMpid:@2];
+    [MParticle sharedInstance].stateMachine.optOut = NO;
+
+    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970]
+                                                      userId:[MPPersistenceController_PRIVATE mpId]];
+    MPMessageBuilder *messageBuilder =
+        [[MPMessageBuilder alloc] initWithMessageType:MPMessageTypeEvent
+                                             session:session
+                                         messageInfo:@{@"MessageKey1": @"MessageValue1"}
+                                             context:self.messageBuilderContext];
+    MPMessage *message = [messageBuilder build];
+    [self.backendController saveMessage:message updateSession:NO];
+    XCTAssertGreaterThan(message.messageId, 0);
+
+    [MParticle sharedInstance].stateMachine.optOut = YES;
+    MPUploadSettings *uploadSettings =
+        [MPUploadSettings currentUploadSettingsWithStateMachine:[MParticle sharedInstance].stateMachine
+                                                 networkOptions:[MParticle sharedInstance].networkOptions];
+    [self.backendController prepareBatchesForUpload:uploadSettings];
+
+    XCTAssertEqual([persistence fetchUploads].count, 0);
+    XCTAssertEqual([persistence fetchMessagesForUploading].count, 0);
+}
+
 - (void)testBatchAndMessageLimitsMessagesPerBatch {
     MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController_PRIVATE mpId]];
     

--- a/UnitTests/ObjCTests/MPBackendControllerTests.m
+++ b/UnitTests/ObjCTests/MPBackendControllerTests.m
@@ -53,12 +53,19 @@
 
 @end
 
+@interface MPPersistenceController_PRIVATE (Tests)
+
+@property (nonatomic, strong, readonly) MPPersistenceStorePRIVATE *store;
+
+@end
+
 #pragma mark - MPBackendController+Tests category
 @interface MPBackendController_PRIVATE(Tests)
 
 @property (nonatomic, strong) MPNetworkCommunication_PRIVATE *networkCommunication;
 @property (nonatomic, strong) NSMutableDictionary *userAttributes;
 @property (nonatomic, strong) NSMutableArray *userIdentities;
+@property (nonatomic, strong) id<MPBackendPersistence> persistence;
 
 - (NSString *)caseInsensitiveKeyInDictionary:(NSDictionary *)dictionary withKey:(NSString *)key;
 - (void)cleanUp;
@@ -124,7 +131,10 @@
     
     [MParticle sharedInstance].kitContainer_PRIVATE = [[MPKitContainer_PRIVATE alloc] init];
     
-    [MParticle sharedInstance].backendController = [[MPBackendController_PRIVATE alloc] initWithDelegate:(id<MPBackendControllerDelegate>)[MParticle sharedInstance]];
+    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    [MParticle sharedInstance].backendController =
+        [[MPBackendController_PRIVATE alloc] initWithDelegate:(id<MPBackendControllerDelegate>)[MParticle sharedInstance]
+                                                 persistence:persistence.store];
     self.backendController = [MParticle sharedInstance].backendController;
     messageQueue = [MParticle messageQueue];
     
@@ -1951,8 +1961,7 @@
                        plCrashReport:plCrashReport
                    completionHandler:^(NSString * _Nullable message, MPExecStatus execStatus) {}];
     
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
-    NSDictionary *messagesDictionary = [persistence fetchMessagesForUploading];
+    NSDictionary *messagesDictionary = [self.backendController.persistence fetchMessagesForUploading];
     NSMutableDictionary *sessionsDictionary = messagesDictionary[[MPPersistenceController_PRIVATE mpId]];
     NSMutableDictionary *dataPlanIdDictionary =  [sessionsDictionary objectForKey:@0]; // no crash session to recover so sessionId = 0
     NSMutableDictionary *dataPlanVersionDictionary =  [dataPlanIdDictionary objectForKey:@"0"];

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -471,7 +471,7 @@ static BOOL skipNextUpload = NO;
 }
 
 - (void)prepareBatchesForUpload:(MPUploadSettings *)uploadSettings {
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    id<MPBackendPersistence> persistence = self.persistence;
     
     //Fetch all stored messages (1)
     NSDictionary *mpidMessages = [persistence fetchMessagesForUploading];
@@ -517,7 +517,7 @@ static BOOL skipNextUpload = NO;
     [self prepareBatchesForUpload:[MPUploadSettings currentUploadSettingsWithStateMachine:[MParticle sharedInstance].stateMachine networkOptions:[MParticle sharedInstance].networkOptions]];
     
     const void (^completionHandlerCopy)(BOOL) = [completionHandler copy];
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    id<MPBackendPersistence> persistence = self.persistence;
     
     if (skipNextUpload) {
         skipNextUpload = NO;
@@ -1016,7 +1016,7 @@ static BOOL skipNextUpload = NO;
             messageInfo[kMPStackTrace] = [callStack componentsJoinedByString:@"\n"];
         }
         
-        NSArray<MPBreadcrumb *> *fetchedbreadcrumbs = [[MParticle sharedInstance].persistenceController fetchBreadcrumbs];
+        NSArray<MPBreadcrumb *> *fetchedbreadcrumbs = [self.persistence fetchBreadcrumbs];
         if (fetchedbreadcrumbs) {
             NSMutableArray *breadcrumbs = [[NSMutableArray alloc] initWithCapacity:fetchedbreadcrumbs.count];
             for (MPBreadcrumb *breadcrumb in fetchedbreadcrumbs) {
@@ -1073,7 +1073,7 @@ static BOOL skipNextUpload = NO;
         messageInfo[kMPPLCrashReport] = plCrashReportBase64;
     }
     
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    id<MPBackendPersistence> persistence = self.persistence;
     NSArray<MPBreadcrumb *> *fetchedbreadcrumbs = [persistence fetchBreadcrumbs];
     if (fetchedbreadcrumbs) {
         NSMutableArray *breadcrumbs = [[NSMutableArray alloc] initWithCapacity:fetchedbreadcrumbs.count];
@@ -1088,7 +1088,7 @@ static BOOL skipNextUpload = NO;
     }
 
     MPSession *crashSession = nil;
-    NSArray<MPSession *> *sessions = [[MParticle sharedInstance].persistenceController fetchPossibleSessionsFromCrash];
+    NSArray<MPSession *> *sessions = [persistence fetchPossibleSessionsFromCrash];
     for (MPSession *session in sessions) {
         if (![session isEqual:_session]) {
             crashSession = session;

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -503,7 +503,9 @@ static BOOL skipNextUpload = NO;
         //Atomically persist the batches (3) and delete the messages they were built from (4),
         //so messages are only removed once their upload is durably stored. A failure rolls
         //both back, leaving the messages to be retried instead of re-batched into a duplicate.
-        [persistence saveUploads:uploads deleteMessages:group.messages];
+        [persistence saveUploads:uploads
+                 deleteMessages:group.messages
+                       optedOut:[MParticle sharedInstance].stateMachine.optOut];
 
         self.deletedUserAttributes = nil;
     }

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -503,9 +503,9 @@ static BOOL skipNextUpload = NO;
         //Atomically persist the batches (3) and delete the messages they were built from (4),
         //so messages are only removed once their upload is durably stored. A failure rolls
         //both back, leaving the messages to be retried instead of re-batched into a duplicate.
-        [persistence saveUploads:uploads
-                 deleteMessages:group.messages
-                       optedOut:[MParticle sharedInstance].stateMachine.optOut];
+        (void)[persistence saveUploads:uploads
+                       deleteMessages:group.messages
+                             optedOut:[MParticle sharedInstance].stateMachine.optOut];
 
         self.deletedUserAttributes = nil;
     }


### PR DESCRIPTION
## Background
- Upload preparation, batch orchestration, and crash reporting still depend on global Objective-C persistence access.

## What Has Changed
- Migrated upload preparation, atomic batching, upload fetching, and deletion to injected persistence.
- Migrated crash-session recovery, error breadcrumbs, and crash-message storage.
- Restored historical grouping of messages without a session under session ID zero.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented messages queued before opting out from being uploaded afterward.
  * Ensured opted-out messages are no longer left pending for upload.
  * Improved reliability when preparing uploads and handling crash-related persistence operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->