### PR TITLE
refactor: migrate peripheral persistence callers

### DIFF
--- a/UnitTests/ObjCTests/MPIdentityTests.m
+++ b/UnitTests/ObjCTests/MPIdentityTests.m
@@ -16,6 +16,8 @@
 #import "MPStateMachine.h"
 @import mParticle_Apple_SDK_Swift;
 
+@class MPPersistenceAdapter;
+
 typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     MPIdentityRequestIdentify = 0,
     MPIdentityRequestLogin = 1,
@@ -64,6 +66,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 @interface MParticle ()
 
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 
@@ -807,6 +810,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     id mockContainer = OCMClassMock([MPKitContainer_PRIVATE class]);
     [[[mockInstance stub] andReturn:mockContainer] kitContainer_PRIVATE];
     [[[mockInstance stub] andReturn:mockPersistenceController] persistenceController];
+    [[[mockInstance stub] andReturn:mockPersistenceController] persistenceAdapter];
     [[[mockInstance stub] andReturn:mockInstance] sharedInstance];
     
     id mockUser = OCMClassMock([MParticleUser class]);

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		53A79D4C29CE23F700E7489F /* MPDataPlanFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79B5729CDFB1F00E7489F /* MPDataPlanFilter.h */; };
 		53A79D4D29CE23F700E7489F /* MPPromotion+Dictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79B3F29CDFB1F00E7489F /* MPPromotion+Dictionary.h */; };
 		53A79D5529CE23F700E7489F /* MPPersistenceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79ABB29CDFB1E00E7489F /* MPPersistenceController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5A004052F8A000000000001 /* MPPersistenceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A004042F8A000000000001 /* MPPersistenceUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		53A79D5829CE23F700E7489F /* MPIdentityDTO.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79AA029CDFB1E00E7489F /* MPIdentityDTO.h */; };
 		53A79D5D29CE23F700E7489F /* MPNotificationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79B3429CDFB1F00E7489F /* MPNotificationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		53A79D6029CE23F700E7489F /* MPUploadBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53A79B2329CDFB1F00E7489F /* MPUploadBuilder.h */; };
@@ -337,6 +338,7 @@
 		53A79AB929CDFB1E00E7489F /* MPDatabaseMigrationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDatabaseMigrationController.m; sourceTree = "<group>"; };
 		53A79ABA29CDFB1E00E7489F /* MPDatabaseMigrationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPDatabaseMigrationController.h; sourceTree = "<group>"; };
 		53A79ABB29CDFB1E00E7489F /* MPPersistenceController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPPersistenceController.h; sourceTree = "<group>"; };
+		B5A004042F8A000000000001 /* MPPersistenceUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPPersistenceUtilities.h; sourceTree = "<group>"; };
 		B5A004022F5F900000000001 /* MPPersistenceUploadSettingsCodec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPPersistenceUploadSettingsCodec.m; sourceTree = "<group>"; };
 		B5A004032F5F900000000001 /* MPPersistenceUploadSettingsCodec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPPersistenceUploadSettingsCodec.h; sourceTree = "<group>"; };
 		53A79ABD29CDFB1E00E7489F /* MParticleUserNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MParticleUserNotification.h; sourceTree = "<group>"; };
@@ -1025,6 +1027,7 @@
 				53A79B3429CDFB1F00E7489F /* MPNotificationController.h */,
 				53A79AA329CDFB1E00E7489F /* MPBackendController.h */,
 				53A79ABB29CDFB1E00E7489F /* MPPersistenceController.h */,
+				B5A004042F8A000000000001 /* MPPersistenceUtilities.h */,
 				7E03877F2DB913D2003B7D5E /* MPRokt.h */,
 				7AF100062F89801000E74801 /* MPRoktKitDispatchTarget.h */,
 				35C3DE6E2F2919B40077C0FD /* MPCCPAConsent.h */,
@@ -1261,6 +1264,7 @@
 				53A79D4C29CE23F700E7489F /* MPDataPlanFilter.h in Headers */,
 				53A79D4D29CE23F700E7489F /* MPPromotion+Dictionary.h in Headers */,
 				53A79D5529CE23F700E7489F /* MPPersistenceController.h in Headers */,
+				B5A004052F8A000000000001 /* MPPersistenceUtilities.h in Headers */,
 				53A79D5829CE23F700E7489F /* MPIdentityDTO.h in Headers */,
 				D3CEDACB2CB027E1001B32DE /* MPConvertJS.h in Headers */,
 				D3724C192AE02AF60074CD67 /* mParticle_Apple_SDK.h in Headers */,

--- a/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.m
+++ b/mParticle-Apple-SDK/AppNotifications/MPAppNotificationHandler.m
@@ -6,6 +6,7 @@
 #import "MPKitExecStatus.h"
 #import <UIKit/UIKit.h>
 #import "mParticle.h"
+#import "../Persistence/MPPersistenceAdapter.h"
 
 #if TARGET_OS_IOS == 1
     #import "MPNotificationController.h"
@@ -19,7 +20,7 @@
 @interface MParticle ()
 
 @property (nonatomic, strong, readonly) MPBackendController_PRIVATE *backendController;
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;
 + (dispatch_queue_t)messageQueue;
@@ -238,7 +239,7 @@
                     MPForwardRecord *forwardRecord = [[MPForwardRecord alloc] initWithMessageType:MPMessageTypePushNotification execStatus:execStatus];
                     
                     dispatch_async([MParticle messageQueue], ^{
-                        [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
+                        [[MParticle sharedInstance].persistenceAdapter saveForwardRecord:forwardRecord];
                     });
                     
                     MPILogDebug(@"Forwarded user notifications call to kit: %@", kitRegister.name);
@@ -275,7 +276,7 @@
                     MPForwardRecord *forwardRecord = [[MPForwardRecord alloc] initWithMessageType:MPMessageTypePushNotificationInteraction execStatus:execStatus];
                     
                     dispatch_async([MParticle messageQueue], ^{
-                        [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
+                        [[MParticle sharedInstance].persistenceAdapter saveForwardRecord:forwardRecord];
                     });
                     
                     MPILogDebug(@"Forwarded user notifications response call to kit: %@", kitRegister.name);

--- a/mParticle-Apple-SDK/Data Model/MPConsumerInfo.m
+++ b/mParticle-Apple-SDK/Data Model/MPConsumerInfo.m
@@ -2,6 +2,7 @@
 #import "MPIConstants.h"
 #import "MPILogger.h"
 #import "MPPersistenceController.h"
+#import "../Persistence/MPPersistenceAdapter.h"
 #import "mParticle.h"
 #import "MPUserDefaultsConnector.h"
 @import mParticle_Apple_SDK_Swift;
@@ -12,7 +13,7 @@ NSString *const kMPCKExpiration = @"e";
 
 @interface MParticle ()
 
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
 
@@ -214,10 +215,10 @@ NSString *const kMPCKExpiration = @"e";
         return;
     }
     
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    MPPersistenceAdapter *persistence = [MParticle sharedInstance].persistenceAdapter;
     
     NSMutableArray<MPCookie *> *cookies = [[NSMutableArray alloc] init];
-    NSArray<MPCookie *> *fetchedCookies = [persistence fetchCookiesForUserId:[MPPersistenceController_PRIVATE mpId]];
+    NSArray<MPCookie *> *fetchedCookies = [persistence fetchCookiesForUserId:[MPPersistenceUtilities mpId]];
     if (fetchedCookies) {
         [cookies addObjectsFromArray:fetchedCookies];
     }
@@ -257,7 +258,7 @@ NSString *const kMPCKExpiration = @"e";
 
 - (NSDictionary *)localCookiesDictionary {
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    NSDictionary *localCookies = [userDefaults mpObjectForKey:kMPRemoteConfigCookiesKey userId:[MPPersistenceController_PRIVATE mpId]];
+    NSDictionary *localCookies = [userDefaults mpObjectForKey:kMPRemoteConfigCookiesKey userId:[MPPersistenceUtilities mpId]];
     
     if (!localCookies) {
         return nil;

--- a/mParticle-Apple-SDK/Data Model/MPForwardRecord.m
+++ b/mParticle-Apple-SDK/Data Model/MPForwardRecord.m
@@ -84,7 +84,7 @@ NSString *const kMPFROptOutState = @"s";
         return nil;
     }
     
-    NSNumber *mpid = [MPPersistenceController_PRIVATE mpId];
+    NSNumber *mpid = [MPPersistenceUtilities mpId];
     NSMutableDictionary *dataDictionary = [[NSMutableDictionary alloc] init];
     dataDictionary[kMPFRModuleId] = execStatus.integrationId;
     dataDictionary[kMPTimestampKey] = MPCurrentEpochInMilliseconds;

--- a/mParticle-Apple-SDK/Identity/MPIdentityApi.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApi.m
@@ -14,6 +14,7 @@
 #import "../Kits/MPKitContainer+MParticlePrivate.h"
 #import "MPUserDefaultsConnector.h"
 #import "../MPRokt+MParticlePrivate.h"
+#import "../Persistence/MPPersistenceAdapter.h"
 @import mParticle_Apple_SDK_Swift;
 
 typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
@@ -25,7 +26,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 
 @interface MParticle ()
 
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;
 
@@ -148,8 +149,8 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
         }
         return;
     }
-    NSNumber *previousMPID = [MPPersistenceController_PRIVATE mpId];
-    [MPPersistenceController_PRIVATE setMpid:httpResponse.mpid];
+    NSNumber *previousMPID = [MPPersistenceUtilities mpId];
+    [MPPersistenceUtilities setMpid:httpResponse.mpid];
     MPIdentityApiResult *apiResult = [[MPIdentityApiResult alloc] init];
     MParticleUser *previousUser = self.currentUser;
     MParticleUser *user = [[MParticleUser alloc] init];
@@ -176,7 +177,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     }
     
     session.sessionUserIds = userIds.count > 0 ? [userIds componentsJoinedByString:@","] : @"";
-    [[MParticle sharedInstance].persistenceController updateSession:session];
+    [[MParticle sharedInstance].persistenceAdapter updateSession:session];
     
     if (request.identities) {
         NSMutableDictionary *userIDsCopy = [request.identities mutableCopy];
@@ -224,7 +225,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     [userDefaults setMPObject:@(httpResponse.isEphemeral) forKey:kMPIsEphemeralKey userId:httpResponse.mpid];
     [userDefaults synchronize];
     
-    [[MParticle sharedInstance].persistenceController moveContentFromMpidZeroToMpid:httpResponse.mpid];
+    [[MParticle sharedInstance].persistenceAdapter moveContentFromMpidZeroToMpid:httpResponse.mpid];
     
     if (newUser) {
         NSDictionary *userInfo = nil;
@@ -294,7 +295,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
             return _currentUser;
         }
 
-        NSNumber *mpid = [MPPersistenceController_PRIVATE mpId];
+        NSNumber *mpid = [MPPersistenceUtilities mpId];
         MParticleUser *user = [[MParticleUser alloc] init];
         user.userId = mpid;
         _currentUser = user;
@@ -474,7 +475,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
                                                    dataPlanVersion:[MParticle sharedInstance].dataPlanVersion
                                                     uploadSettings:[MPUploadSettings currentUploadSettingsWithStateMachine:[MParticle sharedInstance].stateMachine networkOptions:[MParticle sharedInstance].networkOptions]];
             
-            [MParticle.sharedInstance.persistenceController saveUpload:upload];
+            [MParticle.sharedInstance.persistenceAdapter saveUpload:upload];
             [MParticle.sharedInstance.backendController waitForKitsAndUploadWithCompletionHandler:nil];
         }];
         

--- a/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
@@ -46,7 +46,7 @@ static NSString *MPIdentityEnvironmentString(void) {
     if (self) {
         _knownIdentities = [[MPIdentityHTTPIdentities alloc] initWithIdentities:apiRequest.identities];
 
-        NSNumber *mpid = [MPPersistenceController_PRIVATE mpId];
+        NSNumber *mpid = [MPPersistenceUtilities mpId];
         if (mpid.longLongValue != 0) {
             _previousMPID = mpid.stringValue;
         }

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -142,7 +142,7 @@
     }
     
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    NSArray *storedIdentities = [userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:[MPPersistenceController_PRIVATE mpId]];
+    NSArray *storedIdentities = [userDefaults mpObjectForKey:kMPUserIdentityArrayKey userId:[MPPersistenceUtilities mpId]];
     NSArray *identities = [MPIdentityUserStoragePRIVATE applyingIdentity:identityString
                                                                     type:(NSInteger)identityType
                                                           toStoredArray:storedIdentities];
@@ -412,12 +412,12 @@
 - (void)setConsentState:(MPConsentState *)state {
     [[MParticle sharedInstance].rokt logRoktApiDiagnostic:@"SET_CONSENT_STATE"];
 
-    [MPPersistenceController_PRIVATE setConsentState:state forMpid:self.userId];
+    [MPPersistenceUtilities setConsentState:state forMpid:self.userId];
     
     [[MParticle sharedInstance].kitContainer_PRIVATE reconfigureKits];
     
     // Device-level consent supersedes user-level, so forward the effective consent to kits.
-    MPConsentState *effectiveConsentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:self.userId];
+    MPConsentState *effectiveConsentState = [MPPersistenceUtilities effectiveConsentStateForMpid:self.userId];
     dispatch_async(dispatch_get_main_queue(), ^{
         [[MParticle sharedInstance].kitContainer_PRIVATE forwardSDKCall:@selector(setConsentState:) consentState:effectiveConsentState kitHandler:^(id<MPKitProtocol>  _Nonnull kit, MPConsentState * _Nullable filteredConsentState, MPKitConfiguration * _Nonnull kitConfiguration) {
             MPKitExecStatus *status = [kit setConsentState:filteredConsentState];
@@ -430,7 +430,7 @@
 
 - (nullable MPConsentState *)consentState {
     [[MParticle sharedInstance].rokt logRoktApiDiagnostic:@"GET_CONSENT_STATE"];
-    return [MPPersistenceController_PRIVATE consentStateForMpid:self.userId];
+    return [MPPersistenceUtilities consentStateForMpid:self.userId];
 }
 
 

--- a/mParticle-Apple-SDK/Include/MPPersistenceController.h
+++ b/mParticle-Apple-SDK/Include/MPPersistenceController.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "MPPersistenceUtilities.h"
 
 @class MPMessage;
 @class MPSession;

--- a/mParticle-Apple-SDK/Include/MPPersistenceUtilities.h
+++ b/mParticle-Apple-SDK/Include/MPPersistenceUtilities.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+@class MPConsentState;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MPPersistenceUtilities : NSObject
+
++ (NSNumber *)mpId;
++ (void)setMpid:(NSNumber *)mpId;
++ (nullable MPConsentState *)consentStateForMpid:(NSNumber *)mpid;
++ (void)setConsentState:(nullable MPConsentState *)state forMpid:(NSNumber *)mpid;
++ (nullable MPConsentState *)deviceConsentState;
++ (void)setDeviceConsentState:(nullable MPConsentState *)state;
++ (nullable MPConsentState *)effectiveConsentStateForMpid:(nullable NSNumber *)mpid;
++ (NSInteger)maxBytesPerEvent:(nullable NSString *)messageType;
++ (NSInteger)maxBytesPerBatch:(nullable NSString *)messageType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mParticle-Apple-SDK/Kits/MPKitContainerExecutionAdapter.m
+++ b/mParticle-Apple-SDK/Kits/MPKitContainerExecutionAdapter.m
@@ -6,6 +6,7 @@
 #import "MPKitConfiguration.h"
 #import <UIKit/UIKit.h>
 #import "MPPersistenceController.h"
+#import "../Persistence/MPPersistenceAdapter.h"
 #import "MPILogger.h"
 #import "MPKitFilter.h"
 #import "MPEvent.h"
@@ -35,7 +36,7 @@
 NSString *const kitFileExtension = @"eks";
 
 @interface MParticle ()
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
 + (dispatch_queue_t)messageQueue;
@@ -712,7 +713,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
 }
 
 - (BOOL)isDisabledByBracketConfiguration:(NSDictionary *)bracketConfiguration {
-    int64_t mpId = [[MPPersistenceController_PRIVATE mpId] longLongValue];
+    int64_t mpId = [[MPPersistenceUtilities mpId] longLongValue];
     int16_t low = (int16_t)[bracketConfiguration[@"lo"] integerValue];
     int16_t high = (int16_t)[bracketConfiguration[@"hi"] integerValue];
     return [self.filterEngine isDisabledByBracketWithMpId:mpId
@@ -807,8 +808,7 @@ static const NSInteger sideloadedKitCodeStartValue = 1000000000;
         dispatch_semaphore_signal(bracketsSemaphore);
         return;
     }
-
-    long mpId = [[MPPersistenceController_PRIVATE mpId] longValue];
+    long mpId = [[MPPersistenceUtilities mpId] longValue];
     short low = (short)[configuration[@"lo"] integerValue];
     short high = (short)[configuration[@"hi"] integerValue];
 
@@ -1422,7 +1422,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
     MPBracket *bracket = [self bracketForKit:kitRegister.code];
     MParticleUser *currentUser = [MParticle sharedInstance].identity.currentUser;
     MPKitConfiguration *configuration = self.kitConfigurations[kitRegister.code];
-    MPConsentState *state = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:currentUser.userId];
+    MPConsentState *state = [MPPersistenceUtilities effectiveConsentStateForMpid:currentUser.userId];
 
     return [self.filterEngine isKitActiveWithActive:active
                                               mpId:bracket.mpId
@@ -1867,7 +1867,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
     
     if (forwardRecord != nil) {
         dispatch_async([MParticle messageQueue], ^{
-            [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
+            [[MParticle sharedInstance].persistenceAdapter saveForwardRecord:forwardRecord];
         });
     }
 }
@@ -1878,7 +1878,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
                                                                         kitFilter:kitFilter
                                                                     originalEvent:commerceEvent];
     dispatch_async([MParticle messageQueue], ^{
-        [[MParticle sharedInstance].persistenceController saveForwardRecord:forwardRecord];
+        [[MParticle sharedInstance].persistenceAdapter saveForwardRecord:forwardRecord];
     });
 }
 
@@ -2054,7 +2054,7 @@ completionHandler:(void (^)(NSArray<MPEvent *> *projectedEvents,
 }
 
 - (nullable NSDictionary<NSString *, NSString *> *)integrationAttributesForKit:(nonnull NSNumber *)integrationId {
-    NSArray<MPIntegrationAttributes *> *array = [[MParticle sharedInstance].persistenceController fetchIntegrationAttributes];
+    NSArray<MPIntegrationAttributes *> *array = [[MParticle sharedInstance].persistenceAdapter fetchIntegrationAttributes];
     __block NSDictionary<NSString *, NSString *> *dictionary = nil;
     [array enumerateObjectsUsingBlock:^(MPIntegrationAttributes * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         if (obj.integrationId.intValue == integrationId.intValue) {

--- a/mParticle-Apple-SDK/MPBackendController.m
+++ b/mParticle-Apple-SDK/MPBackendController.m
@@ -393,7 +393,7 @@ const NSTimeInterval kMPRemainingBackgroundTimeMinimumThreshold = 10.0;
         return;
     }
     
-    NSMutableDictionary *userAttributes = [self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]];
+    NSMutableDictionary *userAttributes = [self userAttributesForUserId:[MPPersistenceUtilities mpId]];
     NSString *localKey = [userAttributes caseInsensitiveKey:userAttributeChange.key];
 
     MPAttributeValidationResult validation = [MPBackendController_PRIVATE validateAndLogAttributeKey:localKey
@@ -671,7 +671,7 @@ static BOOL skipNextUpload = NO;
     tempSession = [[MParticleSession alloc] initWithUUID:[NSUUID UUID].UUIDString];
     
     MPSession *mpSession = [[MPSession alloc] initWithStartTime:[NSDate date].timeIntervalSince1970
-                                                        userId:[MPPersistenceController_PRIVATE mpId]];
+                                                        userId:[MPPersistenceUtilities mpId]];
     mpSession.uuid = tempSession.UUID;
     
     tempSession.startTime = MPMilliseconds(mpSession.startTime);
@@ -714,7 +714,7 @@ static BOOL skipNextUpload = NO;
         
         id<MPBackendPersistence> persistence = self.persistence;
         
-        NSNumber *mpId = [MPPersistenceController_PRIVATE mpId];
+        NSNumber *mpId = [MPPersistenceUtilities mpId];
         date = date ?: [NSDate date];
         if (tempSession) {
             _session = [[MPSession alloc] initWithStartTime:[date timeIntervalSince1970] userId:mpId uuid:tempSession.UUID];
@@ -947,13 +947,13 @@ static BOOL skipNextUpload = NO;
     NSAssert([value isKindOfClass:[NSNumber class]], @"'value' must be a number.");
     
     NSDate *timestamp = [NSDate date];
-    NSString *localKey = [[self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]] caseInsensitiveKey:key];
+    NSString *localKey = [[self userAttributesForUserId:[MPPersistenceUtilities mpId]] caseInsensitiveKey:key];
     if (!localKey) {
         [self setUserAttribute:key value:value timestamp:timestamp completionHandler:nil];
         return value;
     }
     
-    id currentValue = [self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]][localKey];
+    id currentValue = [self userAttributesForUserId:[MPPersistenceUtilities mpId]][localKey];
     if (currentValue && ![currentValue isKindOfClass:[NSNumber class]]) {
         return nil;
     } else if (MPIsNull(currentValue)) {
@@ -962,12 +962,12 @@ static BOOL skipNextUpload = NO;
     
     NSNumber *newValue = [MPUserAttributeLogic incrementedValueFrom:(NSNumber *)currentValue byValue:value];
 
-    NSMutableDictionary *userAttributes = [self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]];
+    NSMutableDictionary *userAttributes = [self userAttributesForUserId:[MPPersistenceUtilities mpId]];
     userAttributes[localKey] = newValue;
 
     NSDictionary *userAttributesCopy = [MPUserAttributeLogic attributesForStorage:userAttributes nullSentinel:kMPNullUserAttributeString];
     
-    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]] copy] key:key value:newValue];
+    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceUtilities mpId]] copy] key:key value:newValue];
     userAttributeChange.timestamp = timestamp;
     [self setUserAttributeChange:userAttributeChange completionHandler:nil];
  
@@ -1102,7 +1102,7 @@ static BOOL skipNextUpload = NO;
     MPMessage *crashMessage = [messageBuilder build];
     
     NSNumber *bytesToRetain = [MPBackendMessageInfo crashReportBytesToRetainForMessageLength:crashMessage.messageData.length
-                                                                                    maxBytes:[MPPersistenceController_PRIVATE maxBytesPerEvent:crashMessage.messageType]
+                                                                                    maxBytes:[MPPersistenceUtilities maxBytesPerEvent:crashMessage.messageType]
                                                                           base64ReportLength:plCrashReportBase64.length];
     if (bytesToRetain != nil) {
         [crashMessage truncateMessageDataProperty:kMPPLCrashReport toLength:bytesToRetain.integerValue];
@@ -1263,9 +1263,9 @@ static BOOL skipNextUpload = NO;
     MPILogDebug(@"Backend controller starting - firstRun: %@, startKitsAsync: %@",
                 firstRun ? @"YES" : @"NO", startKitsAsync ? @"YES" : @"NO");
     
-    MPConsentState *storedConsentState = [MPPersistenceController_PRIVATE consentStateForMpid:[MPPersistenceController_PRIVATE mpId]];
+    MPConsentState *storedConsentState = [MPPersistenceUtilities consentStateForMpid:[MPPersistenceUtilities mpId]];
     if (consentState != nil && storedConsentState == nil) {
-        [MPPersistenceController_PRIVATE setConsentState:consentState forMpid:[MPPersistenceController_PRIVATE mpId]];
+        [MPPersistenceUtilities setConsentState:consentState forMpid:[MPPersistenceUtilities mpId]];
     }
     
     if (![MParticle sharedInstance].stateMachine.optOut) {
@@ -1463,7 +1463,7 @@ static BOOL skipNextUpload = NO;
         return;
     }
     
-    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]] copy] key:keyCopy value:[NSNull null]];
+    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceUtilities mpId]] copy] key:keyCopy value:[NSNull null]];
     userAttributeChange.timestamp = timestamp;
     [self setUserAttributeChange:userAttributeChange completionHandler:completionHandler];
 }
@@ -1487,7 +1487,7 @@ static BOOL skipNextUpload = NO;
         return;
     }
     
-    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]] copy] key:keyCopy value:value];
+    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceUtilities mpId]] copy] key:keyCopy value:value];
     userAttributeChange.timestamp = timestamp;
     [self setUserAttributeChange:userAttributeChange completionHandler:completionHandler];
 }
@@ -1512,7 +1512,7 @@ static BOOL skipNextUpload = NO;
         return;
     }
     
-    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]] copy] key:keyCopy value:values];
+    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceUtilities mpId]] copy] key:keyCopy value:values];
     userAttributeChange.isArray = YES;
     
     
@@ -1531,7 +1531,7 @@ static BOOL skipNextUpload = NO;
         return;
     }
     
-    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceController_PRIVATE mpId]] copy] key:keyCopy value:nil];
+    MPUserAttributeChange *userAttributeChange = [[MPUserAttributeChange alloc] initWithUserAttributes:[[self userAttributesForUserId:[MPPersistenceUtilities mpId]] copy] key:keyCopy value:nil];
     userAttributeChange.timestamp = timestamp;
     [self setUserAttributeChange:userAttributeChange completionHandler:completionHandler];
 }
@@ -1548,11 +1548,11 @@ static BOOL skipNextUpload = NO;
                                                                                                      value:identityString];
     
     MPUserIdentityChangePRIVATE *userIdentityChange = [[MPUserIdentityChangePRIVATE alloc] initWithNewUserIdentity:newUserIdentity
-                                                                                                      userIdentities:[self identitiesForUserId:[MPPersistenceController_PRIVATE mpId]]];
+                                                                                                      userIdentities:[self identitiesForUserId:[MPPersistenceUtilities mpId]]];
     
     userIdentityChange.timestamp = timestamp;
     
-    NSMutableArray *userIdentities = [self userIdentitiesForUserId:[MPPersistenceController_PRIVATE mpId]];
+    NSMutableArray *userIdentities = [self userIdentitiesForUserId:[MPPersistenceUtilities mpId]];
 
     MPUserIdentityChangePlan *plan = [MPUserIdentityLogic planForIdentityType:@(userIdentityChange.newUserIdentity.type)
                                                                         value:userIdentityChange.newUserIdentity.value

--- a/mParticle-Apple-SDK/MPStateMachine.m
+++ b/mParticle-Apple-SDK/MPStateMachine.m
@@ -4,6 +4,7 @@
 #import "MPILogger.h"
 #import "MPConsumerInfo.h"
 #import "MPPersistenceController.h"
+#import "Persistence/MPPersistenceAdapter.h"
 #import "Kits/MPKitContainer+MParticlePrivate.h"
 #import <UIKit/UIKit.h>
 #import "MPDataPlanFilter.h"
@@ -16,7 +17,7 @@
 
 @interface MParticle ()
 + (dispatch_queue_t)messageQueue;
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
 @property (nonatomic, readwrite) MPDataPlanOptions *dataPlanOptions;
@@ -216,8 +217,8 @@
         return _consumerInfo;
     }
 
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
-    _consumerInfo = [persistence fetchConsumerInfoForUserId:[MPPersistenceController_PRIVATE mpId]];
+    MPPersistenceAdapter *persistence = [MParticle sharedInstance].persistenceAdapter;
+    _consumerInfo = [persistence fetchConsumerInfoForUserId:[MPPersistenceUtilities mpId]];
 
     if (!_consumerInfo) {
         _consumerInfo = [[MPConsumerInfo alloc] init];

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.m
@@ -15,6 +15,7 @@
 #import "MPNetworkCommunication.h"
 #import "MPUserDefaultsConnector.h"
 #import "../Kits/MPKitContainer+MParticlePrivate.h"
+#import "../Persistence/MPPersistenceAdapter.h"
 @import mParticle_Apple_SDK_Swift;
 
 NSString *const urlFormat = @"%@://%@/%@/%@%@"; // Scheme, URL Host, API Version, API key, path
@@ -55,7 +56,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 @interface MParticle ()
 
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong, readonly) MPBackendController_PRIVATE *backendController;
 @property (nonatomic, strong, readonly) MParticleWebViewPRIVATE *webView;
@@ -90,7 +91,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
 
 @implementation MPUploadPersistenceAdapter
 - (void)deleteUpload:(MPUpload *)upload {
-    [[MParticle sharedInstance].persistenceController deleteUpload:upload];
+    [[MParticle sharedInstance].persistenceAdapter deleteUpload:upload];
 }
 @end
 
@@ -260,7 +261,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
                                                                        defaultHost:self.defaultEventHost
                                                                      attAuthorized:NO];
     NSString *audienceURLFormat = [audienceFormat stringByAppendingString:@"?mpid=%@"];
-    NSString *urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, self.defaultEventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
+    NSString *urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, self.defaultEventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceUtilities mpId]];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
     MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPAudienceVersion
@@ -272,10 +273,10 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
     }
     if (style.usesOverrideFormat) {
         audienceURLFormat = [urlFormatOverride stringByAppendingString:@"?mpid=%@"];
-        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
+        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, kMPAudienceVersion, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceUtilities mpId]];
     } else {
         audienceURLFormat = [urlFormat stringByAppendingString:@"?mpid=%@"];
-        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, style.versionSegment, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceController_PRIVATE mpId]];
+        urlString = [NSString stringWithFormat:audienceURLFormat, kMPURLScheme, eventHost, style.versionSegment, stateMachine.apiKey, kMPAudienceURL, [MPPersistenceUtilities mpId]];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
@@ -371,7 +372,7 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
                                                                                  host:modifyNetworkOptions.identityHost
                                                                           defaultHost:self.defaultIdentityHost
                                                                         attAuthorized:[self attAuthorized]];
-    NSString *urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, self.defaultIdentityHost, kMPIdentityVersion, [MPPersistenceController_PRIVATE mpId],  pathComponent];
+    NSString *urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, self.defaultIdentityHost, kMPIdentityVersion, [MPPersistenceUtilities mpId],  pathComponent];
     NSURL *defaultURL = [NSURL URLWithString:urlString];
 
     MPEndpointPathStyle *style = [MPEndpointPathStyle styleWithDefaultVersion:kMPIdentityVersion
@@ -382,9 +383,9 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         MPILogWarning(@"MPNetworkOptions: customBaseURL with overridesIdentitySubdirectory is unsupported for CDN routing; overridesIdentitySubdirectory will be ignored.");
     }
     if (style.usesOverrideFormat) {
-        urlString = [NSString stringWithFormat:modifyURLFormatOverride, kMPURLScheme, identityHost, [MPPersistenceController_PRIVATE mpId], pathComponent];
+        urlString = [NSString stringWithFormat:modifyURLFormatOverride, kMPURLScheme, identityHost, [MPPersistenceUtilities mpId], pathComponent];
     } else {
-        urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, identityHost, style.versionSegment, [MPPersistenceController_PRIVATE mpId], pathComponent];
+        urlString = [NSString stringWithFormat:modifyURLFormat, kMPURLScheme, identityHost, style.versionSegment, [MPPersistenceUtilities mpId], pathComponent];
     }
 
     NSURL *modifiedURL = [NSURL URLWithString:urlString];
@@ -1210,13 +1211,13 @@ static NSObject<MPConnectorFactoryProtocol> *factory = nil;
         return;
     }
 
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    MPPersistenceAdapter *persistence = [MParticle sharedInstance].persistenceAdapter;
 
     // Consumer Information
     MPConsumerInfo *consumerInfo = [MParticle sharedInstance].stateMachine.consumerInfo;
     [consumerInfo updateWithConfiguration:configuration[kMPRemoteConfigConsumerInfoKey]];
     [persistence updateConsumerInfo:consumerInfo];
-    MPConsumerInfo *persistenceInfo = [persistence fetchConsumerInfoForUserId:[MPPersistenceController_PRIVATE mpId]];
+    MPConsumerInfo *persistenceInfo = [persistence fetchConsumerInfoForUserId:[MPPersistenceUtilities mpId]];
     if (persistenceInfo.cookies != nil) {
         [MParticle sharedInstance].stateMachine.consumerInfo.cookies = persistenceInfo.cookies;
     }

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceAdapter.h
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceAdapter.h
@@ -1,0 +1,40 @@
+#import <Foundation/Foundation.h>
+
+@class MPCookie;
+@class MPConsumerInfo;
+@class MPForwardRecord;
+@class MPIntegrationAttributes;
+@class MPMessage;
+@class MPSession;
+@class MPUpload;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Objective-C contract-type boundary around the Swift persistence store.
+/// This adapter is temporary for values whose public Objective-C runtime types
+/// cannot be constructed by the Swift target.
+@interface MPPersistenceAdapter : NSObject
+
+- (NSDictionary<NSString *, NSDictionary *> *)appAndDeviceInfoForSessionId:(NSNumber *)sessionId;
+- (nullable NSArray<MPForwardRecord *> *)fetchForwardRecords;
+- (void)saveForwardRecord:(MPForwardRecord *)forwardRecord;
+- (void)deleteForwardRecordsIds:(NSArray<NSNumber *> *)recordIds;
+- (nullable NSArray<MPIntegrationAttributes *> *)fetchIntegrationAttributes;
+- (nullable NSDictionary *)fetchIntegrationAttributesForId:(NSNumber *)integrationId;
+- (void)saveIntegrationAttributes:(MPIntegrationAttributes *)integrationAttributes;
+- (void)deleteIntegrationAttributesForIntegrationId:(NSNumber *)integrationId;
+- (void)deleteAllIntegrationAttributes;
+- (nullable MPConsumerInfo *)fetchConsumerInfoForUserId:(NSNumber *)userId;
+- (nullable NSArray<MPCookie *> *)fetchCookiesForUserId:(NSNumber *)userId;
+- (void)saveConsumerInfo:(MPConsumerInfo *)consumerInfo;
+- (void)updateConsumerInfo:(MPConsumerInfo *)consumerInfo;
+- (void)moveContentFromMpidZeroToMpid:(NSNumber *)mpid;
+- (void)updateSession:(MPSession *)session;
+- (void)saveUpload:(MPUpload *)upload;
+- (void)deleteUpload:(MPUpload *)upload;
+- (void)resetDatabase;
+- (void)resetDatabaseForWorkspaceSwitching;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceAdapter.h
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceAdapter.h
@@ -5,6 +5,7 @@
 @class MPForwardRecord;
 @class MPIntegrationAttributes;
 @class MPMessage;
+@class MParticle;
 @class MPSession;
 @class MPUpload;
 
@@ -15,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// cannot be constructed by the Swift target.
 @interface MPPersistenceAdapter : NSObject
 
+- (instancetype)initWithMParticle:(MParticle *)mParticle;
 - (NSDictionary<NSString *, NSDictionary *> *)appAndDeviceInfoForSessionId:(NSNumber *)sessionId;
 - (nullable NSArray<MPForwardRecord *> *)fetchForwardRecords;
 - (void)saveForwardRecord:(MPForwardRecord *)forwardRecord;

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.m
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.m
@@ -24,10 +24,22 @@
 @interface MPPersistenceUploadSettingsProvider : NSObject <MPUploadSettingsProviding>
 @end
 
+@interface MPPersistenceAdapter ()
+@property (nonatomic, weak) MParticle *mParticle;
+@end
+
 @implementation MPPersistenceAdapter
 
+- (instancetype)initWithMParticle:(MParticle *)mParticle {
+    self = [super init];
+    if (self) {
+        _mParticle = mParticle;
+    }
+    return self;
+}
+
 - (MPPersistenceController_PRIVATE *)controller {
-    return [MParticle sharedInstance].persistenceController;
+    return self.mParticle.persistenceController;
 }
 
 - (NSDictionary<NSString *,NSDictionary *> *)appAndDeviceInfoForSessionId:(NSNumber *)sessionId {

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.m
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.m
@@ -1,4 +1,5 @@
 #import "MPPersistenceController.h"
+#import "MPPersistenceAdapter.h"
 
 #import "MPIConstants.h"
 #import "MPConsentSerialization.h"
@@ -16,10 +17,95 @@
 @interface MParticle ()
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong) MPNetworkOptions *networkOptions;
+@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
 - (MPLog *)getLogger;
 @end
 
 @interface MPPersistenceUploadSettingsProvider : NSObject <MPUploadSettingsProviding>
+@end
+
+@implementation MPPersistenceAdapter
+
+- (MPPersistenceController_PRIVATE *)controller {
+    return [MParticle sharedInstance].persistenceController;
+}
+
+- (NSDictionary<NSString *,NSDictionary *> *)appAndDeviceInfoForSessionId:(NSNumber *)sessionId {
+    return [self.controller appAndDeviceInfoForSessionId:sessionId];
+}
+
+- (NSArray<MPForwardRecord *> *)fetchForwardRecords {
+    return [self.controller fetchForwardRecords];
+}
+
+- (void)saveForwardRecord:(MPForwardRecord *)forwardRecord {
+    [self.controller saveForwardRecord:forwardRecord];
+}
+
+- (void)deleteForwardRecordsIds:(NSArray<NSNumber *> *)recordIds {
+    [self.controller deleteForwardRecordsIds:recordIds];
+}
+
+- (NSArray<MPIntegrationAttributes *> *)fetchIntegrationAttributes {
+    return [self.controller fetchIntegrationAttributes];
+}
+
+- (NSDictionary *)fetchIntegrationAttributesForId:(NSNumber *)integrationId {
+    return [self.controller fetchIntegrationAttributesForId:integrationId];
+}
+
+- (void)saveIntegrationAttributes:(MPIntegrationAttributes *)integrationAttributes {
+    [self.controller saveIntegrationAttributes:integrationAttributes];
+}
+
+- (void)deleteIntegrationAttributesForIntegrationId:(NSNumber *)integrationId {
+    [self.controller deleteIntegrationAttributesForIntegrationId:integrationId];
+}
+
+- (void)deleteAllIntegrationAttributes {
+    [self.controller deleteAllIntegrationAttributes];
+}
+
+- (MPConsumerInfo *)fetchConsumerInfoForUserId:(NSNumber *)userId {
+    return [self.controller fetchConsumerInfoForUserId:userId];
+}
+
+- (NSArray<MPCookie *> *)fetchCookiesForUserId:(NSNumber *)userId {
+    return [self.controller fetchCookiesForUserId:userId];
+}
+
+- (void)saveConsumerInfo:(MPConsumerInfo *)consumerInfo {
+    [self.controller saveConsumerInfo:consumerInfo];
+}
+
+- (void)updateConsumerInfo:(MPConsumerInfo *)consumerInfo {
+    [self.controller updateConsumerInfo:consumerInfo];
+}
+
+- (void)moveContentFromMpidZeroToMpid:(NSNumber *)mpid {
+    [self.controller moveContentFromMpidZeroToMpid:mpid];
+}
+
+- (void)updateSession:(MPSession *)session {
+    [self.controller updateSession:session];
+}
+
+- (void)saveUpload:(MPUpload *)upload {
+    [self.controller saveUpload:upload];
+}
+
+- (void)deleteUpload:(MPUpload *)upload {
+    [self.controller deleteUpload:upload];
+}
+
+- (void)resetDatabase {
+    [self.controller resetDatabase];
+}
+
+- (void)resetDatabaseForWorkspaceSwitching {
+    [self.controller resetDatabaseForWorkspaceSwitching];
+}
+
 @end
 
 @implementation MPPersistenceUploadSettingsProvider

--- a/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
+++ b/mParticle-Apple-SDK/Utils/MPUploadBuilder.m
@@ -9,11 +9,12 @@
 #import "mParticle.h"
 #import "MPILogger.h"
 #import "MPUserDefaultsConnector.h"
+#import "../Persistence/MPPersistenceAdapter.h"
 @import mParticle_Apple_SDK_Swift;
 
 @interface MParticle ()
 
-@property (nonatomic, strong, readonly) MPPersistenceController_PRIVATE *persistenceController;
+@property (nonatomic, strong, readonly) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong, readonly) MPStateMachine_PRIVATE *stateMachine;
 @property (nonatomic, strong, nonnull) MPBackendController_PRIVATE *backendController;
 @property (nonatomic, strong, nonnull) MParticleOptions *options;
@@ -109,7 +110,7 @@
                                                                             apiKey:stateMachine.apiKey];
     [_uploadDictionary addEntriesFromDictionary:headerFields];
     
-    NSDictionary *appAndDeviceInfoDict = [[MParticle sharedInstance].persistenceController appAndDeviceInfoForSessionId:_sessionId];
+    NSDictionary *appAndDeviceInfoDict = [[MParticle sharedInstance].persistenceAdapter appAndDeviceInfoForSessionId:_sessionId];
     
     NSDictionary *appInfoDict = appAndDeviceInfoDict[MPApplicationKeys.kMPApplicationInformationKey];
     if (appInfoDict) {
@@ -169,7 +170,7 @@
         _uploadDictionary[kMPDeviceApplicationStampKey] = deviceApplicationStamp;
     }
     
-    MPPersistenceController_PRIVATE *persistence = [MParticle sharedInstance].persistenceController;
+    MPPersistenceAdapter *persistence = [MParticle sharedInstance].persistenceAdapter;
     NSArray<MPForwardRecord *> *forwardRecords = [persistence fetchForwardRecords];
 
     if (forwardRecords) {
@@ -197,7 +198,7 @@
         _uploadDictionary[MPIntegrationAttributesKey] = [MPUploadBuilderFields mergedIntegrationAttributesDictionaryFrom:integrationAttributesDictionaries];
     }
     
-    MPConsentState *consentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:_uploadDictionary[kMPRemoteConfigMPIDKey]];
+    MPConsentState *consentState = [MPPersistenceUtilities effectiveConsentStateForMpid:_uploadDictionary[kMPRemoteConfigMPIDKey]];
     if (consentState) {
         NSDictionary *consentStateDictionary = [MPConsentSerialization serverDictionaryFromConsentState:consentState];
         if (consentStateDictionary) {

--- a/mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m
+++ b/mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m
@@ -71,7 +71,8 @@
 }
 
 + (MPConsentState *)effectiveConsentStateForMpid:(NSNumber *)mpid {
-    return self.deviceConsentState ?: (mpid ? [self consentStateForMpid:mpid] : nil);
+    return self.deviceConsentState
+        ?: (mpid != nil ? [self consentStateForMpid:mpid] : nil);
 }
 
 + (NSInteger)maxBytesPerEvent:(NSString *)messageType {

--- a/mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m
+++ b/mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m
@@ -1,6 +1,10 @@
 #import "MPUserDefaultsConnector.h"
 #import "mParticle.h"
 #import "../Kits/MPKitContainer+MParticlePrivate.h"
+#import "MPPersistenceUtilities.h"
+#import "MPIConstants.h"
+#import "MPConsentSerialization.h"
+#import "MPConsentState.h"
 
 @import mParticle_Apple_SDK_Swift;
 
@@ -13,6 +17,70 @@
 @end
 
 @interface MPUserDefaultsConnector()<MPUserDefaultsConnectorProtocol>
+
+@end
+
+@implementation MPPersistenceUtilities
+
++ (NSNumber *)mpId {
+    return MPUserDefaults.storedMpId;
+}
+
++ (void)setMpid:(NSNumber *)mpId {
+    MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
+    userDefaults[@"mpid"] = mpId;
+    [userDefaults synchronize];
+}
+
++ (MPConsentState *)consentStateForMpid:(NSNumber *)mpid {
+    NSString *string = [MPUserDefaultsConnector.userDefaults mpObjectForKey:kMPConsentStateKey userId:mpid];
+    return string ? [MPConsentSerialization consentStateFromString:string] : nil;
+}
+
++ (void)setConsentState:(MPConsentState *)state forMpid:(NSNumber *)mpid {
+    MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
+    if (!state) {
+        [userDefaults removeMPObjectForKey:kMPConsentStateKey userId:mpid];
+    } else {
+        NSString *string = [MPConsentSerialization stringFromConsentState:state];
+        if (!string) {
+            return;
+        }
+        [userDefaults setMPObject:string forKey:kMPConsentStateKey userId:mpid];
+    }
+    [userDefaults synchronize];
+}
+
++ (MPConsentState *)deviceConsentState {
+    NSString *string = [MPUserDefaultsConnector.userDefaults mpObjectForKey:kMPConsentDeviceStateKey userId:@0];
+    return string ? [MPConsentSerialization consentStateFromString:string] : nil;
+}
+
++ (void)setDeviceConsentState:(MPConsentState *)state {
+    MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
+    if (!state) {
+        [userDefaults removeMPObjectForKey:kMPConsentDeviceStateKey userId:@0];
+    } else {
+        NSString *string = [MPConsentSerialization stringFromConsentState:state];
+        if (!string) {
+            return;
+        }
+        [userDefaults setMPObject:string forKey:kMPConsentDeviceStateKey userId:@0];
+    }
+    [userDefaults synchronize];
+}
+
++ (MPConsentState *)effectiveConsentStateForMpid:(NSNumber *)mpid {
+    return self.deviceConsentState ?: (mpid ? [self consentStateForMpid:mpid] : nil);
+}
+
++ (NSInteger)maxBytesPerEvent:(NSString *)messageType {
+    return [MPPersistenceSchemaPRIVATE maxBytesPerEventForMessageType:messageType];
+}
+
++ (NSInteger)maxBytesPerBatch:(NSString *)messageType {
+    return [MPPersistenceSchemaPRIVATE maxBytesPerBatchForMessageType:messageType];
+}
 
 @end
 
@@ -124,7 +192,7 @@
 }
 
 - (nonnull NSNumber*)mpId {
-    return [MPPersistenceController_PRIVATE mpId];
+    return [MPPersistenceUtilities mpId];
 }
 
 - (nullable NSNumber*)configMaxAgeSeconds {

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -17,6 +17,7 @@
 #import "MPConvertJS.h"
 #import "MPUserDefaultsConnector.h"
 #import "MPRokt+MParticlePrivate.h"
+#import "Persistence/MPPersistenceAdapter.h"
 
 @import mParticle_Apple_SDK_Swift;
 
@@ -50,6 +51,7 @@ static NSString *const kMPStateKey = @"state";
 }
 
 @property (nonatomic, strong) id<MPPersistenceControllerProtocol> persistenceController;
+@property (nonatomic, strong) MPPersistenceAdapter *persistenceAdapter;
 @property (nonatomic, strong) MPDataPlanFilter *dataPlanFilter;
 @property (nonatomic, strong) id<MPStateMachineProtocol> stateMachine;
 @property (nonatomic, strong) MPKitContainer_PRIVATE *kitContainer_PRIVATE;
@@ -154,6 +156,7 @@ MPLog* logger;
     _stateMachine = [[MPStateMachine_PRIVATE alloc] init];
     _appEnvironmentProvider = [[AppEnvironmentProvider alloc] init];
     _notificationController = [[MPNotificationController_PRIVATE alloc] init];
+    _persistenceAdapter = [[MPPersistenceAdapter alloc] init];
     logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue: _stateMachine.logLevel]];
     _sceneDelegateHandler = [[SceneDelegateHandler alloc] initWithAppNotificationHandler:_appNotificationHandler];
     _sceneDelegateHandler.logger = logger;
@@ -298,16 +301,16 @@ MPLog* logger;
 }
 
 - (MPConsentState *)deviceConsentState {
-    return [MPPersistenceController_PRIVATE deviceConsentState];
+    return [MPPersistenceUtilities deviceConsentState];
 }
 
 - (void)setDeviceConsentState:(MPConsentState *)deviceConsentState {
     [self.rokt logRoktApiDiagnostic:@"SET_DEVICE_CONSENT_STATE"];
-    [MPPersistenceController_PRIVATE setDeviceConsentState:deviceConsentState];
+    [MPPersistenceUtilities setDeviceConsentState:deviceConsentState];
 
     [self.kitContainer_PRIVATE reconfigureKits];
 
-    MPConsentState *effectiveConsentState = [MPPersistenceController_PRIVATE effectiveConsentStateForMpid:self.identity.currentUser.userId];
+    MPConsentState *effectiveConsentState = [MPPersistenceUtilities effectiveConsentStateForMpid:self.identity.currentUser.userId];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.kitContainer_PRIVATE forwardSDKCall:@selector(setConsentState:) consentState:effectiveConsentState kitHandler:^(id<MPKitProtocol>  _Nonnull kit, MPConsentState * _Nullable filteredConsentState, MPKitConfiguration * _Nonnull kitConfiguration) {
             MPKitExecStatus *status = [kit setConsentState:filteredConsentState];
@@ -446,7 +449,7 @@ MPLog* logger;
     }];
     
     if (firstRun) {
-        [userDefaults setMPObject:@NO forKey:kMParticleFirstRun userId:[MPPersistenceController_PRIVATE mpId]];
+        [userDefaults setMPObject:@NO forKey:kMParticleFirstRun userId:[MPPersistenceUtilities mpId]];
         [userDefaults synchronize];
     }
     
@@ -511,11 +514,11 @@ MPLog* logger;
     
     __weak MParticle *weakSelf = self;
     MPUserDefaults *userDefaults = MPUserDefaultsConnector.userDefaults;
-    BOOL firstRun = [userDefaults mpObjectForKey:kMParticleFirstRun userId:[MPPersistenceController_PRIVATE mpId]] == nil;
+    BOOL firstRun = [userDefaults mpObjectForKey:kMParticleFirstRun userId:[MPPersistenceUtilities mpId]] == nil;
     if (firstRun) {
         NSDate *firstSeen = [NSDate date];
         NSNumber *firstSeenMs = @([firstSeen timeIntervalSince1970] * 1000.0);
-        [userDefaults setMPObject:firstSeenMs forKey:kMPFirstSeenUser userId:[MPPersistenceController_PRIVATE mpId]];
+        [userDefaults setMPObject:firstSeenMs forKey:kMPFirstSeenUser userId:[MPPersistenceUtilities mpId]];
     }
     
     _automaticSessionTracking = self.options.automaticSessionTracking;
@@ -604,7 +607,7 @@ MPLog* logger;
         
         // Clean up persistence
         [MPUserDefaultsConnector.userDefaults resetDefaults];
-        [self.persistenceController resetDatabaseForWorkspaceSwitching];
+        [self.persistenceAdapter resetDatabaseForWorkspaceSwitching];
         
         // Clean up mParticle instance
         //
@@ -723,7 +726,7 @@ MPLog* logger;
         [self.kitContainer flushSerializedKits];
         [self.kitContainer removeAllSideloadedKits];
         [MPUserDefaultsConnector.userDefaults resetDefaults];
-        [self.persistenceController resetDatabase];
+        [self.persistenceAdapter resetDatabase];
         // See the matching comment in resetForSwitchingWorkspaces: - flushSerializedKits/
         // removeAllSideloadedKits only schedule each kit's stop() and teardown on the main
         // queue rather than completing it here, so waiting on notifyWhenKitTeardownComplete:
@@ -743,7 +746,7 @@ MPLog* logger;
     [self.rokt logRoktApiDiagnostic:@"RESET"];
     [executor executeOnMessageSync:^{
         [MPUserDefaultsConnector.userDefaults resetDefaults];
-        [[MParticle sharedInstance].persistenceController resetDatabase];
+        [[MParticle sharedInstance].persistenceAdapter resetDatabase];
         [MParticle setSharedInstance:nil];
     }];
 }
@@ -914,7 +917,7 @@ MPLog* logger;
                             if ([forwardRecords isKindOfClass:[NSArray class]]) {
                                 for (MPForwardRecord *forwardRecord in forwardRecords) {
                                     [executor executeOnMessage: ^{
-                                        [self.persistenceController saveForwardRecord:forwardRecord];
+                                        [self.persistenceAdapter saveForwardRecord:forwardRecord];
                                     }];
                                 }
                             }
@@ -1294,7 +1297,7 @@ MPLog* logger;
     
     if (integrationAttributes) {
         [executor executeOnMessage: ^{
-            [[MParticle sharedInstance].persistenceController saveIntegrationAttributes:integrationAttributes];
+        [[MParticle sharedInstance].persistenceAdapter saveIntegrationAttributes:integrationAttributes];
         }];
         
     } else {
@@ -1307,7 +1310,7 @@ MPLog* logger;
 - (nonnull MPKitExecStatus *)clearIntegrationAttributesForKit:(nonnull NSNumber *)integrationId {
     [self.rokt logRoktApiDiagnostic:@"CLEAR_INTEGRATION_ATTRIBUTES"];
     [executor executeOnMessage: ^{
-        [[MParticle sharedInstance].persistenceController deleteIntegrationAttributesForIntegrationId:integrationId];
+        [[MParticle sharedInstance].persistenceAdapter deleteIntegrationAttributesForIntegrationId:integrationId];
     }];
 
     return [[MPKitExecStatus alloc] initWithSDKCode:integrationId returnCode:MPKitReturnCodeSuccess forwardCount:0];
@@ -1315,7 +1318,7 @@ MPLog* logger;
 
 - (nullable NSDictionary *)integrationAttributesForKit:(nonnull NSNumber *)integrationId {
     [self.rokt logRoktApiDiagnostic:@"GET_INTEGRATION_ATTRIBUTES"];
-    return [[MParticle sharedInstance].persistenceController fetchIntegrationAttributesForId:integrationId];
+    return [[MParticle sharedInstance].persistenceAdapter fetchIntegrationAttributesForId:integrationId];
 }
 
 #pragma mark Kits

--- a/mParticle-Apple-SDK/mParticle.m
+++ b/mParticle-Apple-SDK/mParticle.m
@@ -156,7 +156,7 @@ MPLog* logger;
     _stateMachine = [[MPStateMachine_PRIVATE alloc] init];
     _appEnvironmentProvider = [[AppEnvironmentProvider alloc] init];
     _notificationController = [[MPNotificationController_PRIVATE alloc] init];
-    _persistenceAdapter = [[MPPersistenceAdapter alloc] init];
+    _persistenceAdapter = [[MPPersistenceAdapter alloc] initWithMParticle:self];
     logger = [[MPLog alloc] initWithLogLevel:[MPLog fromRawValue: _stateMachine.logLevel]];
     _sceneDelegateHandler = [[SceneDelegateHandler alloc] initWithAppNotificationHandler:_appNotificationHandler];
     _sceneDelegateHandler.logger = logger;


### PR DESCRIPTION
## Background
- Production callers outside the backend still depend on MPPersistenceController, preventing removal of the Objective-C facade.

## What Has Changed
- Migrated upload builder, identity, kits, notifications, state machine, network communication, and SDK-level callers.
- Added a narrow Objective-C adapter for contract types that cannot be constructed directly by the Swift target.
- Moved MPID, consent, and schema utility access out of the persistence facade.
- Updated affected tests and mocks.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
