### PR TITLE
fix: restore cookie fields across an archive round trip

### DIFF
--- a/mParticle-Apple-SDK-Swift/Sources/DataModel/MPCookie.swift
+++ b/mParticle-Apple-SDK-Swift/Sources/DataModel/MPCookie.swift
@@ -96,32 +96,28 @@ public final class MPCookiePRIVATE: NSObject, NSSecureCoding {
         if let expiration { coder.encode(expiration, forKey: CodingKeys.expiration) }
     }
 
-    /// Ported verbatim from the deleted Objective-C wrapper, including a defect: `content`,
-    /// `domain` and `expiration` are encoded as strings but decoded with `NSDictionary` as the
-    /// expected class, so they never survive a round trip and a restored cookie carries only its
-    /// name.
+    /// `content`, `domain` and `expiration` are encoded as strings, so they are decoded as strings.
     ///
-    /// The production persistence path does not go through here — cookies are written as raw
-    /// sqlite columns, and the only production archives are `MPUploadSettings` and a
-    /// configuration dictionary. Cookies *are* archivable, though: `MPConsumerInfo` conforms to
+    /// The deleted Objective-C wrapper passed `NSDictionary` as the expected class for all three,
+    /// which never matches an `NSString`, so every restored cookie carried only its name.
+    ///
+    /// It went unnoticed because no production path archives a cookie — cookies are written as raw
+    /// sqlite columns, and the only production archives are `MPUploadSettings` and a configuration
+    /// dictionary. Cookies are archivable in principle: `MPConsumerInfo` conforms to
     /// `NSSecureCoding` and encodes its `cookies` array, and `MPConsumerInfoTests.testInstance`
-    /// and `testConsumerInfoEncoding` exercise exactly that. Neither asserts the cookie fields,
-    /// and `isEqual(toCookie:)` compares names only, which is why the loss goes unnoticed there
-    /// and in `testCookie`.
-    ///
-    /// Left as-is deliberately: repairing it would change what a decoded cookie contains, which is
-    /// a behaviour change rather than a migration. Tracked as a follow-up.
+    /// and `testConsumerInfoEncoding` do exercise that. Neither asserts the cookie fields, and
+    /// `isEqual(toCookie:)` compares names only, so the round-trip assertions passed over the loss.
     public convenience init?(coder: NSCoder) {
         let name = coder.decodeObject(of: NSString.self, forKey: CodingKeys.name) as String?
 
         let configuration = NSMutableDictionary()
-        if let content = coder.decodeObject(of: NSDictionary.self, forKey: CodingKeys.content) {
+        if let content = coder.decodeObject(of: NSString.self, forKey: CodingKeys.content) {
             configuration[Keys.content] = content
         }
-        if let domain = coder.decodeObject(of: NSDictionary.self, forKey: CodingKeys.domain) {
+        if let domain = coder.decodeObject(of: NSString.self, forKey: CodingKeys.domain) {
             configuration[Keys.domain] = domain
         }
-        if let expiration = coder.decodeObject(of: NSDictionary.self, forKey: CodingKeys.expiration) {
+        if let expiration = coder.decodeObject(of: NSString.self, forKey: CodingKeys.expiration) {
             configuration[Keys.expiration] = expiration
         }
 

--- a/mParticle-Apple-SDK-Swift/Test/Utils/MPDataModelTests.swift
+++ b/mParticle-Apple-SDK-Swift/Test/Utils/MPDataModelTests.swift
@@ -252,12 +252,9 @@ final class MPDataModelTests: XCTestCase {
         XCTAssertNil(cookie?.dictionaryRepresentation())
     }
 
-    /// Pins the ported defect rather than endorsing it: `content`, `domain` and `expiration` are
-    /// encoded as strings but decoded expecting `NSDictionary`, so only the name survives.
-    /// No production path archives a cookie, and equality is by name, so the loss is invisible
-    /// even to `MPConsumerInfoTests`, which does archive cookies through `MPConsumerInfo` but
-    /// asserts only `uniqueIdentifier`. Change this test the day the decode is repaired.
-    func testCookieArchiveRoundTripKeepsOnlyTheName() throws {
+    /// The wrapper decoded these three expecting `NSDictionary`, which never matches the `NSString`
+    /// that was encoded, so a restored cookie used to carry only its name.
+    func testCookieArchiveRoundTripPreservesEveryField() throws {
         let cookie = try XCTUnwrap(MPCookiePRIVATE(name: "uid",
                                                    configuration: ["c": "g=abc", "d": "example.com",
                                                                    "e": "2035-05-26T22:43:31.505262Z"]))
@@ -266,9 +263,24 @@ final class MPDataModelTests: XCTestCase {
         let restored = try XCTUnwrap(NSKeyedUnarchiver.unarchivedObject(ofClass: MPCookiePRIVATE.self, from: data))
 
         XCTAssertEqual(restored.name, "uid")
-        XCTAssertEqual(restored, cookie, "equality is by name, which is why the loss below is invisible")
+        XCTAssertEqual(restored.content, cookie.content)
+        XCTAssertEqual(restored.domain, cookie.domain)
+        XCTAssertEqual(restored.expiration, cookie.expiration)
+        XCTAssertFalse(restored.expired, "a restored future expiration must still read as unexpired")
+    }
+
+    /// A cookie that never had the optional fields still restores, and stays "expired" because an
+    /// absent expiration means expired.
+    func testCookieArchiveRoundTripWithOnlyANameStillRestores() throws {
+        let cookie = try XCTUnwrap(MPCookiePRIVATE(name: "uid", configuration: [:]))
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: cookie, requiringSecureCoding: false)
+        let restored = try XCTUnwrap(NSKeyedUnarchiver.unarchivedObject(ofClass: MPCookiePRIVATE.self, from: data))
+
+        XCTAssertEqual(restored.name, "uid")
         XCTAssertNil(restored.content)
         XCTAssertNil(restored.domain)
         XCTAssertNil(restored.expiration)
+        XCTAssertTrue(restored.expired)
     }
 }


### PR DESCRIPTION
> **Stacked on #978.** This PR's diff is only the third commit.

`MPCookie`'s `initWithCoder:` passed `NSDictionary` as the expected class for `content`, `domain` and `expiration` — all three of which are encoded as strings:

```objc
[coder encodeObject:self.content forKey:@"content"];                        // NSString in
...
value = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"content"]; // never matches
```

The class check never matched, so each decode returned nil and **every restored cookie carried only its name**.

## Why it was never caught

No production path archives a cookie — cookies are written as raw sqlite columns, and the only production archives in the SDK are `MPUploadSettings` and a configuration dictionary.

Cookies *are* archivable in principle: `MPConsumerInfo` conforms to `NSSecureCoding` and encodes its `cookies` array, and `MPConsumerInfoTests.testInstance` and `testConsumerInfoEncoding` exercise that path. Neither asserts the cookie fields, though, and `isEqual(toCookie:)` compares names only — so `testCookie`'s round-trip assertion passed straight over the loss:

```objc
XCTAssertEqualObjects(cookie, deserializedCookie, @"Should have been equal.");
```

## The fix

The three decodes now name `NSString`. Restoring the values is safe:

- They pass back through the same setters that escaped them on the way in, and `percentEscape()` escapes only `;` and space while leaving `%` untouched — so it is idempotent and the values do not double-escape.
- A restored cookie with a future `expiration` now reports `expired == false` instead of `true`, which is the point of storing it.

## Why this is separate from #978

#978 ported the coder verbatim precisely because repairing it changes what a decoded cookie contains — a behaviour change, not a migration. Keeping it here leaves #978 a pure `refactor:` and gives the fix its own changelog entry.

(Note the sibling defect in #977 was the opposite shape: there, unchecked `decodeObjectForKey:` under `supportsSecureCoding == YES` made the decode path *throw* rather than lose data, so fixing it could not regress any working behaviour and it stayed in that PR.)

## Tests

`testCookieArchiveRoundTripKeepsOnlyTheName`, added by #978 to pin the defect, becomes `testCookieArchiveRoundTripPreservesEveryField`. Added a name-only case for the cookie that never had the optional fields, which must still restore and still read as expired.

`testCookie`'s Objective-C assertions are unchanged and still pass.

## Verification

Rebased with #978 onto `workstation/swift-migration` after #975 and #977 landed, and re-run end to end:

- `bash Tools/abi-guard.sh check` → exit 0
- `trunk check` → clean (re-checked after committing)
- `run-analyzer`'s exact filter chain → **0 surviving warnings**
- Objective-C suite → green; Swift suite → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cookie data now correctly preserves content, domain, expiration, and expiration status when archived and restored.
  - Cookies containing only a name continue to restore correctly, with optional fields remaining empty and expiration status handled accurately.

- **Tests**
  - Expanded archive round-trip coverage to verify preservation of all cookie fields and name-only cookie behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->