### PR TITLE
ci: cache raw dependency sources to cut PR/build-kits runtime

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -31,8 +31,14 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
+      - name: Cache Ruby gems
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.gem
+          key: gems-xcodeproj-${{ runner.os }}
+
       - name: Update xcodeproj gem
-        run: sudo gem install xcodeproj
+        run: gem install xcodeproj --user-install
 
       - name: Prevent social URL warnings if twitter is unreachable
         run: find . -path '*.podspec' -exec perl -pi -e 's/.+\.social_media_url.+//' {} \;

--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -34,7 +34,12 @@ jobs:
       - name: Cache Ruby gems
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ~/.gem
+          # RubyGems only uses ~/.gem when that directory already exists; a
+          # fresh runner has neither, so --user-install falls back to the XDG
+          # path. Cache both so whichever one RubyGems actually picks is saved.
+          path: |
+            ~/.gem
+            ~/.local/share/gem
           key: gems-xcodeproj-${{ runner.os }}
 
       - name: Update xcodeproj gem

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           xcode-version: "26.2"
       - name: Compute weekly cache key
-        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> "$GITHUB_ENV"
+        run: echo "CACHE_WEEK=$(date +%G-W%V)" >> "$GITHUB_ENV"
       - name: Cache CocoaPods sources
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -88,7 +88,7 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Compute weekly cache key
-        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> "$GITHUB_ENV"
+        run: echo "CACHE_WEEK=$(date +%G-W%V)" >> "$GITHUB_ENV"
 
       - name: Cache SwiftPM package sources
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -35,6 +35,18 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26.2"
+      - name: Compute weekly cache key
+        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> $GITHUB_ENV
+      - name: Cache CocoaPods sources
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cocoapods
+            ~/Library/Caches/CocoaPods
+          key: cocoapods-${{ runner.os }}-${{ matrix.kit.name }}-${{ env.CACHE_WEEK }}-${{ hashFiles(format('{0}/*.podspec', matrix.kit.local_path)) }}
+          restore-keys: |
+            cocoapods-${{ runner.os }}-${{ matrix.kit.name }}-${{ env.CACHE_WEEK }}-
+            cocoapods-${{ runner.os }}-${{ matrix.kit.name }}-
       - name: Pod Lib Lint
         run: |
           echo "Linting: ${{ matrix.kit.podspec }}"
@@ -74,6 +86,22 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Compute weekly cache key
+        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> $GITHUB_ENV
+
+      - name: Cache SwiftPM package sources
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # ~/Library/Caches/org.swift.swiftpm holds SwiftPM's bare-clone source
+          # cache — shared by every xcodebuild invocation on the runner regardless
+          # of -derivedDataPath, so it also warms the example/test builds below.
+          # It never holds compiled objects, so nothing here can go stale: every
+          # step still runs a full xcodebuild compile against these sources.
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: spm-sources-${{ runner.os }}-${{ matrix.kit.name }}-${{ env.CACHE_WEEK }}
+          restore-keys: |
+            spm-sources-${{ runner.os }}-${{ matrix.kit.name }}-
 
       - name: Resolve SPM dependencies
         timeout-minutes: 20

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           xcode-version: "26.2"
       - name: Compute weekly cache key
-        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> $GITHUB_ENV
+        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> "$GITHUB_ENV"
       - name: Cache CocoaPods sources
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -88,7 +88,7 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Compute weekly cache key
-        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> $GITHUB_ENV
+        run: echo "CACHE_WEEK=$(date +%Y-W%V)" >> "$GITHUB_ENV"
 
       - name: Cache SwiftPM package sources
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -43,10 +43,14 @@ jobs:
           path: |
             ~/.cocoapods
             ~/Library/Caches/CocoaPods
-          key: cocoapods-${{ runner.os }}-${{ matrix.kit.name }}-${{ env.CACHE_WEEK }}-${{ hashFiles(format('{0}/*.podspec', matrix.kit.local_path)) }}
+          # "::" terminates the kit name unambiguously — restore-keys is a plain
+          # string-prefix match, and kit names share hyphens (e.g. "rokt" is a
+          # literal prefix of "rokt-sdk-plus-ios"), so a plain "-" boundary lets
+          # a small kit's cache miss restore a much bigger kit's cache instead.
+          key: cocoapods-${{ runner.os }}-${{ matrix.kit.name }}::${{ env.CACHE_WEEK }}-${{ hashFiles(format('{0}/*.podspec', matrix.kit.local_path)) }}
           restore-keys: |
-            cocoapods-${{ runner.os }}-${{ matrix.kit.name }}-${{ env.CACHE_WEEK }}-
-            cocoapods-${{ runner.os }}-${{ matrix.kit.name }}-
+            cocoapods-${{ runner.os }}-${{ matrix.kit.name }}::${{ env.CACHE_WEEK }}-
+            cocoapods-${{ runner.os }}-${{ matrix.kit.name }}::
       - name: Pod Lib Lint
         run: |
           echo "Linting: ${{ matrix.kit.podspec }}"
@@ -99,9 +103,13 @@ jobs:
           # It never holds compiled objects, so nothing here can go stale: every
           # step still runs a full xcodebuild compile against these sources.
           path: ~/Library/Caches/org.swift.swiftpm
-          key: spm-sources-${{ runner.os }}-${{ matrix.kit.name }}-${{ env.CACHE_WEEK }}
+          # "::" terminates the kit name unambiguously — restore-keys is a plain
+          # string-prefix match, and kit names share hyphens (e.g. "rokt" is a
+          # literal prefix of "rokt-sdk-plus-ios"), so a plain "-" boundary lets
+          # a small kit's cache miss restore a much bigger kit's cache instead.
+          key: spm-sources-${{ runner.os }}-${{ matrix.kit.name }}::${{ env.CACHE_WEEK }}
           restore-keys: |
-            spm-sources-${{ runner.os }}-${{ matrix.kit.name }}-
+            spm-sources-${{ runner.os }}-${{ matrix.kit.name }}::
 
       - name: Resolve SPM dependencies
         timeout-minutes: 20

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -32,8 +32,14 @@ jobs:
           distribution: "zulu"
           java-version: "17"
           cache: "gradle"
+      - name: Cache Ruby gems
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.gem
+          key: gems-cocoapods-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: gems-cocoapods-${{ runner.os }}
       - name: "Install Cocoapods"
-        run: sudo gem install cocoapods; sudo gem install cocoapods-generate
+        run: gem install cocoapods cocoapods-generate --user-install && echo "$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_PATH
       - name: Choose Xcode version
         run: xcode-select -p; sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer; xcode-select -p
       - name: Run Tests

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Cache Ruby gems
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ~/.gem
+          # RubyGems only uses ~/.gem when that directory already exists; a
+          # fresh runner has neither, so --user-install falls back to the XDG
+          # path. Cache both so whichever one RubyGems actually picks is saved.
+          path: |
+            ~/.gem
+            ~/.local/share/gem
           key: gems-cocoapods-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: gems-cocoapods-${{ runner.os }}
       - name: "Install Cocoapods"
-        run: gem install cocoapods cocoapods-generate --user-install && echo "$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_PATH
+        run: gem install cocoapods cocoapods-generate --user-install && echo "$(ruby -e 'puts Gem.user_dir')/bin" >> "$GITHUB_PATH"
       - name: Choose Xcode version
         run: xcode-select -p; sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer; xcode-select -p
       - name: Run Tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,15 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Cache WireMock JAR
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: wiremock-cache
+        with:
+          path: wiremock.jar
+          key: wiremock-${{ env.WIREMOCK_VERSION }}
+
       - name: Download WireMock standalone
+        if: steps.wiremock-cache.outputs.cache-hit != 'true'
         run: |
           curl -L -o wiremock.jar \
             "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${{ env.WIREMOCK_VERSION }}/wiremock-standalone-${{ env.WIREMOCK_VERSION }}.jar"


### PR DESCRIPTION
## Background

`build-kits` Build jobs still routinely take 10-18 min per kit today (verified against a recent `main` run, e.g. `Build google-analytics-firebase-ga4-11` 18m38s, `Build urbanairship-19` 18m10s, `Build rokt-sdk-plus-ios` 13m11s) — largely spent re-fetching multi-GB transitive SPM dependencies (e.g. stripe-ios, ~2.7GB) and re-downloading CocoaPods/gem/WireMock sources from scratch on every single run. None of this is cached today.

Supersedes #753, which attempted the same goal but has gone stale (opened April, last rebased July) and directly conflicts with `build-kits.yml`'s "Resolve SPM dependencies" step, which #867 rewrote since to add a watchdog/retry loop around hung SPM fetches (a real reliability fix — SwiftPM fetches were observed hanging 24+ min). Merging #753 as-is would silently drop that fix. #753 also proposed caching full `DerivedData` (compiled build products), which is riskier than it looks — see "Why not DerivedData" below.

## What Has Changed

Caches only immutable, pre-compile inputs — never compiled build products:

- **build-kits.yml**
  - `pod-lint-kits`: weekly-keyed CocoaPods source cache (`~/.cocoapods`, `~/Library/Caches/CocoaPods`), keyed per-kit by podspec hash + weekly window (so upstream releases still get picked up)
  - `build-kits`: per-kit cache of `~/Library/Caches/org.swift.swiftpm` (SwiftPM's bare-clone source cache) — this path is shared by every `xcodebuild` invocation on the runner regardless of `-derivedDataPath`, so it also warms the SPM-Swift-Example/SPM-Objc-Example/SPM test builds later in the same job, not just the main build
  - Inserted before "Resolve SPM dependencies" — that step (and its watchdog/retry logic) is otherwise untouched
- **build-and-lint.yml**: Ruby gem cache for `xcodeproj` (switched to `--user-install` so the cache path is writable without `sudo`)
- **cross-platform-tests.yml**: Ruby gem cache for `cocoapods`/`cocoapods-generate`, keyed by `Podfile.lock` (same `--user-install` switch + `$GITHUB_PATH` export for the installed binaries)
- **integration-tests.yml**: WireMock JAR cache keyed by version, skips the download on a hit

## Why not DerivedData

#753's DerivedData cache key hashes kit + core SDK source files, but not Xcode/toolchain version — a toolchain bump wouldn't bust the cache, so a stale compiled object could get silently reused while CI stays green. Separately, ~20 kits × 1-3GB of DerivedData is 20-60GB, well past GitHub Actions' 10GB per-repo cache limit, so those caches would evict each other constantly and mostly just add restore/save overhead on top of a compile that still happens anyway.

Caching only sources avoids both: `xcodebuild` still fully recompiles from scratch every run (no correctness window), and these caches are small enough (source downloads, not build artifacts) to actually stay warm.

## Expected impact

- Kits with heavy SPM dependency graphs (Rokt SDK Plus via stripe-ios, in particular) should save a few minutes on the "Resolve SPM dependencies" step on a warm cache — this only speeds up the fetch/resolve phase, not the `xcodebuild build` compile phase, which is the majority of the time on the slowest kits (Firebase GA4, UrbanAirship). It also reduces exposure to the watchdog's retry path (each retry costs up to ~8 min) by making fewer/faster network fetches in the first place.
- Does **not** touch `release-publish.yml` — that's a structurally separate workflow (triggered only by a `VERSION` push, not `pull_request`) with its own inline kit-build job; it isn't edited here, so release behavior is unchanged.

## Testing

- `trunk check` — clean
- Diffed against the real merge-base with `main` to confirm the SPM watchdog/retry step is untouched by this change
- Verified `~/Library/Caches/org.swift.swiftpm/repositories` is the actual SwiftPM bare-clone cache location (not the compiled `DerivedData/Build` tree)
- CI on this PR will exercise the caches cold on first run; a second push (or a subsequent PR) should show the warm-cache timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved CI build and test efficiency by caching Ruby gems, CocoaPods data, Swift Package Manager sources, and the WireMock test artifact.
* **Reliability**
  * Improved setup consistency for Ruby and CocoaPods tools across fresh and cross-platform runners.
* **Automation**
  * Added cache-aware downloads and weekly cache refreshes for selected build and test dependencies.
  * Reduced unnecessary downloads when cached test artifacts are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->