### PR TITLE
refactor: Simplify Consent + Persistence Boundary

### DIFF
--- a/Tools/swift-migration-retained-objc.txt
+++ b/Tools/swift-migration-retained-objc.txt
@@ -77,6 +77,9 @@ mParticle-Apple-SDK/Utils/MPUploadSettings.m
 
 mParticle-Apple-SDK/Utils/MPUserDefaultsConnector.m
 
+mParticle-Apple-SDK/Persistence/MPPersistenceUploadSettingsCodec.m
+mParticle-Apple-SDK/Utils/UploadSettingsUtils.m
+
 # 360 C global definitions (`NSString *const`, `const NSTimeInterval`,
 # `const NSInteger`) declared extern in the internal MPIConstants.h and referenced by
 # bare identifier from 51 Objective-C files. Swift cannot emit C globals, so these

--- a/UnitTests/ObjCTests/MPDataModelTests.m
+++ b/UnitTests/ObjCTests/MPDataModelTests.m
@@ -2,6 +2,7 @@
 @import mParticle_Apple_SDK_Swift;
 #import "MPIConstants.h"
 #import "MPStateMachine.h"
+#import "MPPersistenceUploadSettingsCodec.h"
 #import "MPPersistenceUtilities.h"
 #import "MPBaseTestCase.h"
 #import "mParticle.h"
@@ -398,6 +399,47 @@
     
     MPBreadcrumb *persistedBreadcrumb = [self attemptSecureEncodingwithClass:[MPBreadcrumb class] Object:breadcrumb];
     XCTAssertEqualObjects(breadcrumb, persistedBreadcrumb, @"Breadcrumb should have been a match.");
+}
+
+- (void)testPersistenceUploadSettingsCodecRoundTrip {
+    MPUploadSettings *settings = [[MPUploadSettings alloc] initWithApiKey:@"api-key"
+                                                                  secret:@"secret"
+                                                              eventsHost:@"events.example.com"
+                                                       eventsTrackingHost:@"tracking.example.com"
+                                            overridesEventsSubdirectory:YES
+                                                               aliasHost:@"alias.example.com"
+                                                        aliasTrackingHost:@"alias-tracking.example.com"
+                                             overridesAliasSubdirectory:YES
+                                                              eventsOnly:YES];
+    MPPersistenceUploadSettingsCodec *codec = [[MPPersistenceUploadSettingsCodec alloc] init];
+
+    NSData *data = [codec archiveUploadSettings:settings];
+    MPUploadSettings *restored = (MPUploadSettings *)[codec unarchiveUploadSettings:data];
+
+    XCTAssertNotNil(data);
+    XCTAssertTrue([restored isKindOfClass:[MPUploadSettings class]]);
+    XCTAssertEqualObjects(restored.apiKey, settings.apiKey);
+    XCTAssertEqualObjects(restored.secret, settings.secret);
+    XCTAssertEqualObjects(restored.eventsHost, settings.eventsHost);
+    XCTAssertEqualObjects(restored.eventsTrackingHost, settings.eventsTrackingHost);
+    XCTAssertEqual(restored.overridesEventsSubdirectory, settings.overridesEventsSubdirectory);
+    XCTAssertEqualObjects(restored.aliasHost, settings.aliasHost);
+    XCTAssertEqualObjects(restored.aliasTrackingHost, settings.aliasTrackingHost);
+    XCTAssertEqual(restored.overridesAliasSubdirectory, settings.overridesAliasSubdirectory);
+    XCTAssertEqual(restored.eventsOnly, settings.eventsOnly);
+}
+
+- (void)testPersistenceUploadSettingsCodecRejectsUnsupportedInput {
+    MPPersistenceUploadSettingsCodec *codec = [[MPPersistenceUploadSettingsCodec alloc] init];
+
+    XCTAssertNil([codec archiveUploadSettings:@"not upload settings"]);
+}
+
+- (void)testPersistenceUploadSettingsCodecRejectsCorruptArchive {
+    MPPersistenceUploadSettingsCodec *codec = [[MPPersistenceUploadSettingsCodec alloc] init];
+    NSData *data = [@"not an archive" dataUsingEncoding:NSUTF8StringEncoding];
+
+    XCTAssertNil([codec unarchiveUploadSettings:data]);
 }
 
 @end

--- a/mParticle-Apple-SDK/Consent/MPConsentSerialization.m
+++ b/mParticle-Apple-SDK/Consent/MPConsentSerialization.m
@@ -1,26 +1,18 @@
 #import "MPConsentSerialization.h"
 #import "MPConsentState.h"
-#import "MPCCPAConsent.h"
-#import "MPGDPRConsent.h"
 #import "MPILogger.h"
 #import "mParticle.h"
 @import mParticle_Apple_SDK_Swift;
 
-@interface MPGDPRConsent ()
-@property (nonatomic, strong) MPConsentRecordPRIVATE *implementation;
-- (instancetype)initWithConsentRecord:(MPConsentRecordPRIVATE *)record;
-@end
-
-@interface MPCCPAConsent ()
-@property (nonatomic, strong) MPConsentRecordPRIVATE *implementation;
-- (instancetype)initWithConsentRecord:(MPConsentRecordPRIVATE *)record;
+@interface MPConsentState ()
+@property (nonatomic, strong) MPConsentStatePRIVATE *implementation;
 @end
 
 @implementation MPConsentSerialization
 
 + (nullable NSDictionary *)serverDictionaryFromConsentState:(MPConsentState *)state {
-    NSDictionary *gdprRecords = [self gdprRecordsFromConsentState:state];
-    MPConsentRecordPRIVATE *ccpaRecord = [self ccpaRecordFromConsentState:state];
+    NSDictionary *gdprRecords = state ? [state.implementation gdprConsentRecords] : @{};
+    MPConsentRecordPRIVATE *ccpaRecord = [state.implementation ccpaConsentRecord];
     return [MPConsentSerializationPRIVATE serverDictionaryFromGDPR:gdprRecords ccpa:ccpaRecord];
 }
 
@@ -29,8 +21,8 @@
         return nil;
     }
 
-    NSDictionary *gdprRecords = [self gdprRecordsFromConsentState:state];
-    MPConsentRecordPRIVATE *ccpaRecord = [self ccpaRecordFromConsentState:state];
+    NSDictionary *gdprRecords = [state.implementation gdprConsentRecords];
+    MPConsentRecordPRIVATE *ccpaRecord = [state.implementation ccpaConsentRecord];
     NSDictionary *dictionary = [MPConsentSerializationPRIVATE storageDictionaryFromGDPR:gdprRecords ccpa:ccpaRecord];
     if (!dictionary) {
         return nil;
@@ -60,12 +52,10 @@
 
     MPConsentState *state = [[MPConsentState alloc] init];
     for (NSString *purpose in gdprRecords) {
-        MPConsentRecordPRIVATE *record = gdprRecords[purpose];
-        MPGDPRConsent *gdprState = [[MPGDPRConsent alloc] initWithConsentRecord:record];
-        [state addGDPRConsentState:gdprState purpose:purpose];
+        (void)[state.implementation addGDPRConsentRecord:gdprRecords[purpose] purpose:purpose];
     }
     if (ccpaRecord) {
-        [state setCCPAConsentState:[[MPCCPAConsent alloc] initWithConsentRecord:ccpaRecord]];
+        [state.implementation setCCPAConsentRecord:ccpaRecord];
     }
     return state;
 }
@@ -76,22 +66,6 @@
 
 + (nullable NSDictionary *)dictionaryFromString:(NSString *)string {
     return [MPConsentSerializationPRIVATE dictionaryFrom:string];
-}
-
-+ (NSDictionary *)gdprRecordsFromConsentState:(MPConsentState *)state {
-    NSMutableDictionary *records = [NSMutableDictionary dictionary];
-    NSDictionary<NSString *, MPGDPRConsent *> *gdprState = [state gdprConsentState];
-    for (NSString *purpose in gdprState) {
-        MPConsentRecordPRIVATE *record = gdprState[purpose].implementation;
-        if (record) {
-            records[purpose] = record;
-        }
-    }
-    return records;
-}
-
-+ (MPConsentRecordPRIVATE *)ccpaRecordFromConsentState:(MPConsentState *)state {
-    return [state ccpaConsentState].implementation;
 }
 
 @end


### PR DESCRIPTION
## Background
- Consent serialization still performed redundant Objective-C wrapper conversions even though its serialization logic already resides in Swift.
- Two upload-settings utilities must remain Objective-C because they archive the runtime-pinned MPUploadSettings class across the Swift module boundary.

## What Has Changed
- Simplified consent serialization to marshal directly through MPConsentStatePRIVATE.
- Added archive round-trip and invalid-input tests for the persistence upload-settings codec.
- Classified MPPersistenceUploadSettingsCodec and UploadSettingsUtils as retained Objective-C boundary glue.
- Preserved public API, secure-archive identity, and stored-data formats.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent data serialization and deserialization for GDPR and CCPA records.
  * Added handling for unsupported or corrupt upload-settings archive data.

* **Tests**
  * Added coverage for upload-settings archive round trips and invalid archive scenarios.

* **Maintenance**
  * Preserved compatibility support for upload-settings persistence and secure archiving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->